### PR TITLE
fix: preserve test exit code when piping through tee

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
       - name: Run test
-        run: bash ./scripts/run_e2e_test.sh 2>&1 | tee e2e-test-output.log
+        run: bash ./scripts/run_e2e_test.sh 2>&1 | tee e2e-test-output.log; exit ${PIPESTATUS[0]}
 
       - name: Show router logs
         if: always()


### PR DESCRIPTION
The e2e test workflow was losing the exit code from the test script because tee swallows pipe exit codes. This fix uses PIPESTATUS to capture and propagate the actual test result, ensuring the workflow step fails when tests fail.