### PR TITLE
Enum implementation of multi-chain functionality

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -5,6 +5,49 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
 
+/// Supported chain identifiers
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum ChainId {
+    /// Sepolia testnet (chain ID: 11155111)
+    #[default]
+    Sepolia = 11155111,
+    /// Gnosis mainnet (chain ID: 100)
+    Gnosis = 100,
+}
+
+impl ChainId {
+    /// Creates a ChainId from a numeric chain ID
+    pub fn from_u64(chain_id: u64) -> Option<Self> {
+        match chain_id {
+            11155111 => Some(ChainId::Sepolia),
+            100 => Some(ChainId::Gnosis),
+            _ => None,
+        }
+    }
+
+    /// Returns the numeric chain ID
+    pub fn as_u64(&self) -> u64 {
+        match self {
+            ChainId::Sepolia => 11155111,
+            ChainId::Gnosis => 100,
+        }
+    }
+
+    /// Returns the chain name
+    pub fn name(&self) -> &'static str {
+        match self {
+            ChainId::Sepolia => "sepolia",
+            ChainId::Gnosis => "gnosis",
+        }
+    }
+}
+
+impl std::fmt::Display for ChainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 /// Configuration for loading BLS private keys from JSON files
 #[derive(Debug, Serialize, Deserialize)]
 #[allow(non_snake_case)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,7 +5,7 @@ pub mod validator;
 
 // Re-export commonly used types
 pub use config::{
-    KeyConfig, OrchestratorConfig, get_operator_states, load_key_from_file,
+    ChainId, KeyConfig, OrchestratorConfig, get_operator_states, load_key_from_file,
     load_orchestrator_config,
 };
 pub use task_data::GasKillerTaskData;

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -5,10 +5,12 @@ use anyhow::Result;
 use commonware_codec::Read;
 use commonware_cryptography::sha256::Digest;
 use commonware_cryptography::{Hasher, Sha256};
+use std::collections::HashMap;
 use std::env;
 use tracing::debug;
 use url::Url;
 
+use crate::config::ChainId;
 use crate::task_data::GasKillerTaskData;
 use commonware_avs_router::validator::ValidatorTrait;
 use commonware_avs_router::wire;
@@ -32,8 +34,10 @@ pub struct AnalysisResult {
 /// Validator implementation for the gas killer use case with multi-chain support
 #[derive(Clone)]
 pub struct GasKillerValidator {
-    /// RPC URLs to try (in order)
-    rpc_urls: Vec<String>,
+    /// RPC URLs per chain for the gas analyzer
+    chain_rpc_urls: HashMap<ChainId, String>,
+    /// Default chain for backwards compatibility
+    default_chain: ChainId,
 }
 
 impl GasKillerValidator {
@@ -45,53 +49,114 @@ impl GasKillerValidator {
     ///
     /// Returns an error if Sepolia RPC is not set.
     pub fn new() -> Result<Self> {
-        let mut rpc_urls = Vec::new();
+        let mut chain_rpc_urls = HashMap::new();
 
-        // Load Sepolia RPC URL (required, checked first)
+        // Load Sepolia RPC URL (required)
         let sepolia_rpc = env::var("RPC_URL")
             .or_else(|_| env::var("HTTP_RPC"))
             .map_err(|_| anyhow::anyhow!("RPC_URL or HTTP_RPC environment variable is not set"))?;
-        rpc_urls.push(sepolia_rpc);
+        chain_rpc_urls.insert(ChainId::Sepolia, sepolia_rpc);
 
         // Load Gnosis RPC URL (optional)
         if let Ok(gnosis_rpc) = env::var("GNOSIS_RPC_URL").or_else(|_| env::var("GNOSIS_HTTP_RPC"))
         {
-            rpc_urls.push(gnosis_rpc);
+            chain_rpc_urls.insert(ChainId::Gnosis, gnosis_rpc);
         }
 
-        Ok(Self { rpc_urls })
+        Ok(Self {
+            chain_rpc_urls,
+            default_chain: ChainId::Sepolia,
+        })
     }
 
-    /// Creates a new GasKillerValidator with a specific RPC URL.
+    /// Creates a new GasKillerValidator with a specific RPC URL (for default chain).
     ///
     /// Useful for testing without modifying environment variables.
     pub fn with_rpc_url(rpc_url: impl Into<String>) -> Self {
+        let mut chain_rpc_urls = HashMap::new();
+        chain_rpc_urls.insert(ChainId::Sepolia, rpc_url.into());
         Self {
-            rpc_urls: vec![rpc_url.into()],
+            chain_rpc_urls,
+            default_chain: ChainId::Sepolia,
         }
     }
 
-    /// Returns the RPC URL for the first (default) chain
-    pub fn rpc_url(&self) -> &str {
-        self.rpc_urls.first().map(|s| s.as_str()).unwrap_or("")
+    /// Creates a new GasKillerValidator with RPC URLs for multiple chains.
+    pub fn with_chain_rpc_urls(chain_rpc_urls: HashMap<ChainId, String>) -> Self {
+        Self {
+            chain_rpc_urls,
+            default_chain: ChainId::Sepolia,
+        }
     }
 
-    /// Finds the RPC URL for the chain where the contract is deployed.
-    async fn find_rpc_for_contract(&self, address: alloy::primitives::Address) -> Result<&str> {
+    /// Returns the RPC URL for the default chain
+    pub fn rpc_url(&self) -> &str {
+        self.chain_rpc_urls
+            .get(&self.default_chain)
+            .map(|s| s.as_str())
+            .unwrap_or("")
+    }
+
+    /// Returns the RPC URL for a specific chain
+    pub fn rpc_url_for_chain(&self, chain_id: ChainId) -> Option<&str> {
+        self.chain_rpc_urls.get(&chain_id).map(|s| s.as_str())
+    }
+
+    /// Returns whether a chain is supported
+    pub fn supports_chain(&self, chain_id: ChainId) -> bool {
+        self.chain_rpc_urls.contains_key(&chain_id)
+    }
+
+    /// Returns all supported chains
+    pub fn supported_chains(&self) -> Vec<ChainId> {
+        self.chain_rpc_urls.keys().copied().collect()
+    }
+
+    /// Detects which chain has code deployed at the given address.
+    ///
+    /// Checks each supported chain to see if the address has contract code.
+    /// Returns the first chain where code is found, or an error if no chain has code.
+    pub async fn detect_chain_for_address(
+        &self,
+        address: alloy::primitives::Address,
+    ) -> Result<ChainId> {
         use alloy_provider::ProviderBuilder;
 
-        for rpc_url in &self.rpc_urls {
-            let url = match Url::parse(rpc_url) {
-                Ok(u) => u,
-                Err(_) => continue,
-            };
+        debug!(
+            address = %address,
+            "Detecting chain for address"
+        );
 
-            let provider = ProviderBuilder::new().connect_http(url);
+        // Check Sepolia first (primary chain)
+        for chain_id in [ChainId::Sepolia, ChainId::Gnosis] {
+            if let Some(rpc_url) = self.rpc_url_for_chain(chain_id) {
+                let url = match Url::parse(rpc_url) {
+                    Ok(u) => u,
+                    Err(_) => continue,
+                };
 
-            if let Ok(code) = provider.get_code_at(address).await
-                && !code.is_empty()
-            {
-                return Ok(rpc_url.as_str());
+                let provider = ProviderBuilder::new().connect_http(url);
+
+                match provider.get_code_at(address).await {
+                    Ok(code) => {
+                        if !code.is_empty() {
+                            debug!(
+                                chain = %chain_id,
+                                address = %address,
+                                code_len = code.len(),
+                                "Found contract code on chain"
+                            );
+                            return Ok(chain_id);
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            chain = %chain_id,
+                            error = %e,
+                            "Failed to check code on chain"
+                        );
+                    }
+                }
             }
         }
 
@@ -104,7 +169,7 @@ impl GasKillerValidator {
     /// Computes storage updates for a transaction using gas-analyzer-rs.
     ///
     /// Automatically detects which chain the contract is on, then computes storage updates.
-    /// Returns the storage updates and block height.
+    /// Returns the storage updates, block height, and detected chain ID.
     pub async fn compute_storage_updates_for_tx(
         &self,
         contract_address: alloy::primitives::Address,
@@ -112,8 +177,19 @@ impl GasKillerValidator {
         from_address: Option<alloy::primitives::Address>,
         value: Option<alloy::primitives::U256>,
         block_height: u64,
-    ) -> Result<(Vec<u8>, u64)> {
-        let rpc_url = self.find_rpc_for_contract(contract_address).await?;
+    ) -> Result<(Vec<u8>, u64, ChainId)> {
+        // Detect which chain has the contract
+        let chain_id = self.detect_chain_for_address(contract_address).await?;
+
+        debug!(
+            chain = %chain_id,
+            address = %contract_address,
+            "Detected chain for contract"
+        );
+
+        let rpc_url = self
+            .rpc_url_for_chain(chain_id)
+            .ok_or_else(|| anyhow::anyhow!("No RPC URL configured for chain: {}", chain_id))?;
 
         let result = Self::analyze_transaction(
             rpc_url,
@@ -124,7 +200,7 @@ impl GasKillerValidator {
             block_height,
         )
         .await?;
-        Ok((result.storage_updates, result.block_height))
+        Ok((result.storage_updates, result.block_height, chain_id))
     }
 
     /// Validates the message format and decodes the aggregation
@@ -275,7 +351,21 @@ impl GasKillerValidator {
             return Err(anyhow::anyhow!("block_height is required for validation"));
         }
 
-        let rpc_url = self.find_rpc_for_contract(task_data.target_address).await?;
+        // Detect which chain has the contract
+        let chain_id = self
+            .detect_chain_for_address(task_data.target_address)
+            .await?;
+
+        // Get the RPC URL for the detected chain
+        let rpc_url = self
+            .rpc_url_for_chain(chain_id)
+            .ok_or_else(|| anyhow::anyhow!("No RPC URL configured for chain: {}", chain_id))?;
+
+        debug!(
+            chain_id = %chain_id,
+            target_address = %task_data.target_address,
+            "Computing storage updates for detected chain"
+        );
 
         let result = Self::analyze_transaction(
             rpc_url,

--- a/example.env
+++ b/example.env
@@ -10,7 +10,7 @@
 RUST_LOG=info
 
 # =============================================================================
-# Network Configuration
+# Network Configuration (Sepolia - Primary Chain)
 # =============================================================================
 # For TESTNET mode (Sepolia)
 # HTTP_RPC=https://ethereum-sepolia-rpc.publicnode.com # Change to private rpc
@@ -22,6 +22,16 @@ HTTP_RPC=http://localhost:8545
 WS_RPC=ws://localhost:8545
 RPC_URL=http://ethereum:8545 # Docker internal network
 FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
+
+# =============================================================================
+# Network Configuration (Gnosis Chain - Optional)
+# =============================================================================
+# Uncomment to enable Gnosis chain support
+# For TESTNET mode (Gnosis)
+# GNOSIS_HTTP_RPC=https://rpc.gnosischain.com
+# GNOSIS_WS_RPC=wss://rpc.gnosischain.com/wss
+# GNOSIS_RPC_URL=https://rpc.gnosischain.com
+# GNOSIS_AVS_DEPLOYMENT_PATH="config/.nodes/gnosis_avs_deploy.json"
 
 # =============================================================================
 # Router Configuration
@@ -113,3 +123,12 @@ ARRAY_SUMMATION_MAX_VALUE=1000
 ARRAY_SUMMATION_SEED=42
 ARRAY_SUMMATION_FACTORY_ADDRESS=0xF7ded769418Ec1Db4DA3bd2d47ab72ce2296A032
 # ARRAY_SUMMATION_ADDRESS=0x8867cf9D1FfC33fE4761c19E621Ee29323E91E56 # Setting this will override deploying a new contract
+
+# =============================================================================
+# Multi-Chain Configuration
+# =============================================================================
+# The router supports multiple chains with automatic chain detection.
+# The system detects which chain has the target contract by checking for code at the address.
+# Supported chains:
+#   - Sepolia (chain_id: 11155111) - Primary chain, always required
+#   - Gnosis (chain_id: 100) - Optional, enabled when GNOSIS_HTTP_RPC is set

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -234,9 +234,12 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningGasKillerCreator
             "Creator received task"
         );
 
-        // Compute storage updates using the shared validator
-        debug!("Computing storage updates for task");
-        let (storage_updates, block_height) = self
+        // Compute storage updates - the validator automatically detects which chain has the contract
+        debug!(
+            "Computing storage updates for target {}",
+            task.body.target_address
+        );
+        let (storage_updates, block_height, detected_chain) = self
             .validator
             .compute_storage_updates_for_tx(
                 task.body.target_address,
@@ -260,7 +263,8 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningGasKillerCreator
             transition_index = task.body.transition_index,
             target_address = %task.body.target_address,
             target_function = %task.body.call_data.get(..4).map(hex::encode).unwrap_or_default(),
-            "Creator computed storage updates"
+            chain = %detected_chain,
+            "Creator computed storage updates on detected chain"
         );
 
         // Store enriched task with computed storage updates and block height for metadata access

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -1,5 +1,6 @@
 use gas_killer_common::WalletProvider;
 use gas_killer_common::bindings::gaskillersdk::{BN254, GasKillerSDK, IBLSSignatureCheckerTypes as GasKillerIBLSTypes};
+use gas_killer_common::ChainId;
 use commonware_avs_router::bindings::blssigcheckoperatorstateretriever::BLSSigCheckOperatorStateRetriever::getNonSignerStakesAndSignatureReturn;
 use commonware_avs_router::executor::bls::BlsSignatureVerificationHandler;
 use commonware_avs_router::executor::ExecutionResult;
@@ -8,34 +9,68 @@ use alloy_primitives::{Address, Bytes, FixedBytes, U256};
 use alloy_provider::Provider;
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
 /// Handler for executing verifyAndUpdate transactions with multi-chain support
 pub struct GasKillerHandler {
-    /// Wallet providers to try (in order)
-    providers: Vec<WalletProvider>,
+    /// Wallet providers keyed by chain ID
+    providers: HashMap<ChainId, WalletProvider>,
 }
 
 impl GasKillerHandler {
-    /// Creates a new handler with a single provider
+    /// Creates a new handler with a single provider (for backwards compatibility)
     pub fn new(provider: WalletProvider) -> Self {
-        Self {
-            providers: vec![provider],
-        }
-    }
-
-    /// Creates a new handler with providers for multiple chains
-    pub fn with_providers(providers: Vec<WalletProvider>) -> Self {
+        let mut providers = HashMap::new();
+        providers.insert(ChainId::Sepolia, provider);
         Self { providers }
     }
 
-    /// Finds the provider for the chain where the contract is deployed.
-    async fn find_provider_for_contract(&self, address: Address) -> Result<&WalletProvider> {
-        for provider in &self.providers {
-            if let Ok(code) = provider.get_code_at(address).await
-                && !code.is_empty()
-            {
-                return Ok(provider);
+    /// Creates a new handler with providers for multiple chains
+    pub fn with_providers(providers: HashMap<ChainId, WalletProvider>) -> Self {
+        Self { providers }
+    }
+
+    /// Adds a provider for a specific chain
+    pub fn add_provider(&mut self, chain_id: ChainId, provider: WalletProvider) {
+        self.providers.insert(chain_id, provider);
+    }
+
+    /// Gets the provider for a specific chain
+    fn get_provider(&self, chain_id: ChainId) -> Option<&WalletProvider> {
+        self.providers.get(&chain_id)
+    }
+
+    /// Detects which chain has code deployed at the given address
+    async fn detect_chain_for_address(&self, address: Address) -> Result<ChainId> {
+        debug!(
+            address = %address,
+            "Detecting chain for address in executor"
+        );
+
+        // Check Sepolia first (primary chain), then Gnosis
+        for chain_id in [ChainId::Sepolia, ChainId::Gnosis] {
+            if let Some(provider) = self.get_provider(chain_id) {
+                match provider.get_code_at(address).await {
+                    Ok(code) => {
+                        if !code.is_empty() {
+                            debug!(
+                                chain = %chain_id,
+                                address = %address,
+                                code_len = code.len(),
+                                "Found contract code on chain"
+                            );
+                            return Ok(chain_id);
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            chain = %chain_id,
+                            error = %e,
+                            "Failed to check code on chain"
+                        );
+                    }
+                }
             }
         }
 
@@ -90,14 +125,20 @@ impl BlsSignatureVerificationHandler for GasKillerHandler {
         let task_data = task_data
             .ok_or_else(|| anyhow::anyhow!("Task data is required for gas killer verification"))?;
 
-        // Find the provider for the chain where the contract is deployed
-        let provider = self
-            .find_provider_for_contract(task_data.target_address)
+        // Detect which chain the contract is on
+        let chain_id = self
+            .detect_chain_for_address(task_data.target_address)
             .await?;
+
+        // Get the chain-specific provider
+        let provider = self
+            .get_provider(chain_id)
+            .ok_or_else(|| anyhow::anyhow!("No provider configured for chain: {}", chain_id))?;
 
         info!(
             storage_updates_len = task_data.storage_updates.len(),
-            "Using storage updates from task data"
+            chain = %chain_id,
+            "Using storage updates from task data on detected chain"
         );
 
         // Extract task data parameters - use pre-computed storage_updates from task data
@@ -113,6 +154,7 @@ impl BlsSignatureVerificationHandler for GasKillerHandler {
             target_function = %target_function,
             storage_updates_len = storage_updates.len(),
             storage_updates_first_32 = %hex::encode(&task_data.storage_updates[..std::cmp::min(32, task_data.storage_updates.len())]),
+            detected_chain = %chain_id,
             "Executor getMessageHash inputs"
         );
 

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -11,7 +11,8 @@ use commonware_avs_router::bindings::blsapkregistry::BLSApkRegistry;
 use commonware_avs_router::bindings::blssigcheckoperatorstateretriever::BLSSigCheckOperatorStateRetriever;
 use commonware_avs_router::executor::bls::BlsEigenlayerExecutor;
 use commonware_avs_usecases::AvsDeployment;
-use gas_killer_common::{GasKillerValidator, WalletProvider};
+use gas_killer_common::{ChainId, GasKillerValidator, WalletProvider};
+use std::collections::HashMap;
 use std::{env, str::FromStr, sync::Arc};
 use tracing::info;
 
@@ -38,21 +39,26 @@ pub async fn create_listening_creator_with_server(
 }
 
 /// Creates a wallet provider for a specific chain
-async fn create_wallet_provider(
-    chain_name: &str,
-    rpc_url: &str,
+async fn create_wallet_provider_for_chain(
+    chain_id: ChainId,
     private_key: &str,
 ) -> Result<WalletProvider> {
+    let http_rpc = match chain_id {
+        ChainId::Sepolia => {
+            env::var("HTTP_RPC").map_err(|_| anyhow::anyhow!("HTTP_RPC must be set for Sepolia"))?
+        }
+        ChainId::Gnosis => env::var("GNOSIS_HTTP_RPC")
+            .map_err(|_| anyhow::anyhow!("GNOSIS_HTTP_RPC must be set for Gnosis"))?,
+    };
+
     let ecdsa_signer = PrivateKeySigner::from_str(private_key)
         .map_err(|e| anyhow::anyhow!("Failed to parse private key: {}", e))?;
 
     let provider = ProviderBuilder::new()
         .wallet(ecdsa_signer)
-        .connect(rpc_url)
+        .connect(&http_rpc)
         .await
-        .map_err(|e| {
-            anyhow::anyhow!("Failed to connect write provider for {}: {}", chain_name, e)
-        })?;
+        .map_err(|e| anyhow::anyhow!("Failed to connect write provider for {}: {}", chain_id, e))?;
 
     Ok(provider)
 }
@@ -82,22 +88,23 @@ pub async fn create_gas_killer_executor() -> Result<BlsEigenlayerExecutor<GasKil
         })?;
 
     // Create wallet providers for each supported chain
-    let mut providers: Vec<WalletProvider> = Vec::new();
+    let mut providers: HashMap<ChainId, WalletProvider> = HashMap::new();
 
-    // Sepolia provider (required, checked first)
-    let sepolia_provider = create_wallet_provider("sepolia", &http_rpc, &private_key).await?;
-    providers.push(sepolia_provider);
-    info!("Created Sepolia wallet provider");
+    // Sepolia provider (required)
+    let sepolia_provider = create_wallet_provider_for_chain(ChainId::Sepolia, &private_key).await?;
+    providers.insert(ChainId::Sepolia, sepolia_provider);
+    info!(chain = %ChainId::Sepolia, "Created wallet provider");
 
     // Gnosis provider (optional - only if GNOSIS_HTTP_RPC is set)
-    if let Ok(gnosis_rpc) = env::var("GNOSIS_HTTP_RPC") {
-        match create_wallet_provider("gnosis", &gnosis_rpc, &private_key).await {
+    if env::var("GNOSIS_HTTP_RPC").is_ok() {
+        match create_wallet_provider_for_chain(ChainId::Gnosis, &private_key).await {
             Ok(gnosis_provider) => {
-                providers.push(gnosis_provider);
-                info!("Created Gnosis wallet provider");
+                providers.insert(ChainId::Gnosis, gnosis_provider);
+                info!(chain = %ChainId::Gnosis, "Created wallet provider");
             }
             Err(e) => {
                 tracing::warn!(
+                    chain = %ChainId::Gnosis,
                     error = %e,
                     "Failed to create Gnosis wallet provider, Gnosis chain will be unavailable"
                 );


### PR DESCRIPTION
This recreates the enum-based multi-chain functionality changes (see: https://github.com/BreadchainCoop/gas-killer-router/pull/104) to work with this destination branch.

If we merge both of these PRs in, we can be relatively confident both branches "RonTuretzky/terraform-aws-deploy" and "DijarLlozana/terraform-aws-deploy" will have compatible implementations of multi-chain functionality and won't have conflicts when merged together in the future. If there are other branches that reveal themselves that have deviated in some way that would prevent back merging either of these branches, we can always merge either feature branch.