### PR TITLE
feat: Helm L2 parity for live Gnosis deployments

### DIFF
--- a/docker-compose.l2.yml
+++ b/docker-compose.l2.yml
@@ -1,35 +1,53 @@
-# Override for running gas-killer against a target L2 chain.
+# Override for running gas-killer against a local L2 Anvil fork (Gnosis).
 #
 # Usage:
 #   docker-compose -f docker-compose.yml -f docker-compose.l2.yml up
 #
 # Required additions to .env:
-#   L2_HTTP_RPC=https://rpc.gnosischain.com  # or your preferred L2 RPC
-#   PRIVATE_KEY=0x...                        # must have native gas token on L2 to pay for bridge deployment txns
-#   SET_CONTRACT_VALUES_MANUALLY=true        # set to true to skip YieldDistributor update
+#   L2_FORK_URL=https://rpc.gnosischain.com           # RPC to fork for local L2 Anvil
+#   YIELD_DISTRIBUTOR_ADDRESS=0x37A9CC16412CDA9b4f9B1ABdedd3e10BAD8A06da
+#   YIELD_DISTRIBUTOR_OWNER_ADDRESS=0x5DD2e7db868e33c03daB85d0C623048A7980634E
+#
+# Optional:
+#   BLS_SIG_CHECK_ADDRESS=0x056A41125bB62168B464ddDECd995e8494448913  # on L2 fork
+#   YIELD_CYCLE_LENGTH=1                                               # test-friendly
+#   YIELD_BLOCK_STALE_MEASURE=100000000                                # disable staleness
 #
 # Flow:
-#   eigenlayer  →  bridge  →  node-1/2/3 + router
-#
-# After the bridge completes, manually call setAvsAddress and setBlsSignatureChecker
-# on your YieldDistributor contract using the addresses from config/.nodes/l2-deploy.json.
-# Then trigger distribution via the router ingress at http://localhost:8080.
+#   eigenlayer  →  bridge (gnosis + eigenlayer)  →  yield-distribution  →  node-1/2/3 + router
 
 services:
+  # ─── L2 Anvil (Gnosis fork) ──────────────────────────────────────────────
+  gnosis:
+    platform: linux/amd64
+    image: ghcr.io/breadchaincoop/ethereum:dev
+    env_file:
+      - .env
+    ports:
+      - "8546:8545"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        anvil --fork-url ${L2_FORK_URL:-https://rpc.gnosischain.com} --host 0.0.0.0 --port 8545 --code-size-limit 65536 \
+          --timeout 120000 \
+          --retries 5 \
+          --compute-units-per-second 300
+
   # ─── Bridge ──────────────────────────────────────────────────────────────────
-  # Deploys RegistryCoordinatorMimic + BLSSignatureChecker to target L2 chain,
-  # bridging EigenLayer operator state from the local Anvil Sepolia fork.
+  # Deploys RegistryCoordinatorMimic + BLSSignatureChecker to the local L2 Anvil,
+  # bridging EigenLayer operator state from the local L1 Sepolia fork.
   bridge:
     platform: linux/amd64
     image: ghcr.io/breadchaincoop/target-contracts/bridge:latest
     depends_on:
       eigenlayer:
         condition: service_completed_successfully
+      gnosis:
+        condition: service_started
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY}
       - L1_HTTP_RPC=http://ethereum:8545
-      - L2_HTTP_RPC=${L2_HTTP_RPC}
-      - YIELD_DISTRIBUTOR_ADDRESS=${YIELD_DISTRIBUTOR_ADDRESS}
+      - L2_HTTP_RPC=http://gnosis:8545
     volumes:
       - ./config/.nodes:/app/.nodes
     entrypoint:
@@ -46,7 +64,7 @@ services:
         # L1_KEY: Anvil's pre-funded test account — nonce 0 on any fresh Sepolia fork,
         # so its CREATE addresses are guaranteed fresh (no CreateCollision).
         L1_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-        # L2_KEY: your key — must hold the native token on the L2 chain for L2 contract deployments.
+        # L2_KEY: Anvil's pre-funded account works on the local L2 fork too.
         L2_KEY="$$PRIVATE_KEY"
 
         REGISTRY_COORDINATOR_ADDRESS=$$(jq -r '.addresses.registryCoordinator // .addresses.RegistryCoordinator' /app/.nodes/avs_deploy.json)
@@ -156,23 +174,234 @@ services:
         echo "=== l2-deploy.json ===" | tee -a "$$LOG_FILE"
         cat /app/.nodes/l2-deploy.json | tee -a "$$LOG_FILE"
 
-        # ── Step 6: Update YieldDistributor with new contract addresses ────────────
-        if [ -n "$$SET_CONTRACT_VALUES_MANUALLY" ]; then
-          echo "[BRIDGE] SET_CONTRACT_VALUES_MANUALLY set, skipping YieldDistributor update. Manually set on YieldDistributor=$$YIELD_DISTRIBUTOR_ADDRESS: setAvsAddress($$MIMIC), setBlsSignatureChecker($$BLS_SIG_CHECKER)" | tee -a "$$LOG_FILE"
-        elif [ -n "$$YIELD_DISTRIBUTOR_ADDRESS" ]; then
-          echo "=== Step 6: Updating YieldDistributor at $$YIELD_DISTRIBUTOR_ADDRESS ===" | tee -a "$$LOG_FILE"
-          cast send --rpc-url "$$L2_HTTP_RPC" --private-key "$$L2_KEY" \
-            "$$YIELD_DISTRIBUTOR_ADDRESS" "setAvsAddress(address)" "$$MIMIC" 2>&1 | tee -a "$$LOG_FILE"
-          cast send --rpc-url "$$L2_HTTP_RPC" --private-key "$$L2_KEY" \
-            "$$YIELD_DISTRIBUTOR_ADDRESS" "setBlsSignatureChecker(address)" "$$BLS_SIG_CHECKER" 2>&1 | tee -a "$$LOG_FILE"
-          echo "[BRIDGE] YieldDistributor updated" | tee -a "$$LOG_FILE"
-        else
-          echo "[BRIDGE] YIELD_DISTRIBUTOR_ADDRESS not set, skipping YieldDistributor update" | tee -a "$$LOG_FILE"
-        fi
-
         touch /app/.nodes/.bridge_complete
         chmod 644 /app/.nodes/.bridge_complete
         echo "=== Bridge complete at $$(date) ===" | tee -a "$$LOG_FILE"
+    restart: "no"
+
+  # ─── Yield Distribution ──────────────────────────────────────────────────────
+  # Configures YieldDistributor on the local L2 Anvil fork with bridge-deployed
+  # addresses, casts a test vote, advances time, and verifies resolveYieldDistribution.
+  # Mirrors the Helm yield-distribution-job.yaml.
+  yield-distribution:
+    platform: linux/amd64
+    image: ghcr.io/breadchaincoop/target-contracts/bridge:latest
+    depends_on:
+      bridge:
+        condition: service_completed_successfully
+    environment:
+      - L2_HTTP_RPC=http://gnosis:8545
+      - YIELD_DISTRIBUTOR_ADDRESS=${YIELD_DISTRIBUTOR_ADDRESS:-0x37A9CC16412CDA9b4f9B1ABdedd3e10BAD8A06da}
+      - YIELD_DISTRIBUTOR_OWNER_ADDRESS=${YIELD_DISTRIBUTOR_OWNER_ADDRESS:-0x5DD2e7db868e33c03daB85d0C623048A7980634E}
+      - BLS_SIG_CHECK_ADDRESS=${BLS_SIG_CHECK_ADDRESS:-0x056A41125bB62168B464ddDECd995e8494448913}
+      - YIELD_CYCLE_LENGTH=${YIELD_CYCLE_LENGTH:-1}
+      - YIELD_BLOCK_STALE_MEASURE=${YIELD_BLOCK_STALE_MEASURE:-100000000}
+    volumes:
+      - ./config/.nodes:/app/.nodes
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -ex
+        LOG_FILE="/app/.nodes/yield-distribution.log"
+
+        {
+          echo "=== Yield Distribution Starting at $$(date) ==="
+
+          # ── Parse bridge output ────────────────────────────────────────────────
+          BLS_CHECKER=$$(jq -r '.blsSignatureChecker' /app/.nodes/l2-deploy.json)
+          REG_COORD=$$(jq -r '.registryCoordinatorMimic' /app/.nodes/l2-deploy.json)
+
+          echo "BLSSignatureChecker (from bridge): $$BLS_CHECKER"
+          echo "RegistryCoordinatorMimic (from bridge): $$REG_COORD"
+
+          if [ -z "$$BLS_CHECKER" ] || [ "$$BLS_CHECKER" = "null" ] || [ -z "$$REG_COORD" ] || [ "$$REG_COORD" = "null" ]; then
+            echo "ERROR: Failed to parse addresses from l2-deploy.json"
+            exit 1
+          fi
+
+          # ── Create l2_avs_deploy.json for the router ───────────────────────────
+          BLS_APK_REGISTRY=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$REG_COORD" "blsApkRegistry()(address)")
+          echo "BLSApkRegistry: $$BLS_APK_REGISTRY"
+
+          cat > /app/.nodes/l2_avs_deploy.json <<DEPLOYEOF
+          {
+            "addresses": {
+              "registryCoordinator": "$$REG_COORD",
+              "blsapkRegistry": "$$BLS_APK_REGISTRY",
+              "blsSigCheck": "$$BLS_SIG_CHECK_ADDRESS",
+              "counter": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        DEPLOYEOF
+          echo "=== Created l2_avs_deploy.json ==="
+          cat /app/.nodes/l2_avs_deploy.json
+
+          # ── Step 1: Sanity-check contract owner ────────────────────────────────
+          echo ""
+          echo "=== Step 1: Getting contract owner ==="
+          OWNER_ONCHAIN=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "owner()(address)")
+          echo "Owner (onchain): $$OWNER_ONCHAIN"
+
+          # ── Step 2: Configure YieldDistributor ─────────────────────────────────
+          echo ""
+          echo "=== Step 2: Configuring YieldDistributor ==="
+
+          CURRENT_BLS=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "blsSignatureChecker()(address)" 2>/dev/null || echo "0x0000000000000000000000000000000000000000")
+          CURRENT_AVS=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "avsAddress()(address)" 2>/dev/null || echo "0x0000000000000000000000000000000000000000")
+          echo "Current blsSignatureChecker: $$CURRENT_BLS"
+          echo "Current avsAddress: $$CURRENT_AVS"
+          echo "New blsSignatureChecker (from bridge): $$BLS_CHECKER"
+          echo "New avsAddress (from bridge): $$REG_COORD"
+
+          echo "Impersonating owner to apply config..."
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_impersonateAccount "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS"
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_setBalance "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" "0x56BC75E2D63100000"
+
+          cast send --rpc-url "$$L2_HTTP_RPC" --from "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" --unlocked \
+            "$$YIELD_DISTRIBUTOR_ADDRESS" "setAvsAddress(address)" "$$REG_COORD"
+          cast send --rpc-url "$$L2_HTTP_RPC" --from "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" --unlocked \
+            "$$YIELD_DISTRIBUTOR_ADDRESS" "setBlsSignatureChecker(address)" "$$BLS_CHECKER"
+          cast send --rpc-url "$$L2_HTTP_RPC" --from "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" --unlocked \
+            "$$YIELD_DISTRIBUTOR_ADDRESS" "setBlockStaleMeasure(uint256)" "$$YIELD_BLOCK_STALE_MEASURE"
+          cast send --rpc-url "$$L2_HTTP_RPC" --from "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" --unlocked \
+            "$$YIELD_DISTRIBUTOR_ADDRESS" "setCycleLength(uint256)" "$$YIELD_CYCLE_LENGTH"
+
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_stopImpersonatingAccount "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS"
+
+          # ── Step 3: Cast a vote so currentVotes > 0 ────────────────────────────
+          echo ""
+          echo "=== Step 3: Casting vote from owner ==="
+
+          VOTING_DIST_RAW=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "getCurrentVotingDistribution()(address[],uint256[])" 2>/dev/null || echo "")
+          if [ -z "$$VOTING_DIST_RAW" ]; then
+            echo "ERROR: Failed to read current voting distribution"
+            exit 1
+          fi
+
+          PROJECTS_HEX=$$(echo "$$VOTING_DIST_RAW" | head -n1)
+          PROJECT_COUNT=$$(echo "$$PROJECTS_HEX" | grep -o "0x" | wc -l | tr -d '[:space:]')
+          if [ "$$PROJECT_COUNT" -le 0 ]; then
+            echo "ERROR: No projects found for voting (projectCount=$$PROJECT_COUNT)"
+            exit 1
+          fi
+          echo "Detected $$PROJECT_COUNT projects for voting"
+
+          POINTS_CSV=""
+          for i in $$(seq 1 "$$PROJECT_COUNT"); do
+            if [ -z "$$POINTS_CSV" ]; then
+              POINTS_CSV="1"
+            else
+              POINTS_CSV="$$POINTS_CSV,1"
+            fi
+          done
+          POINTS_ARG="[$$POINTS_CSV]"
+          echo "Voting points vector: $$POINTS_ARG"
+
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_impersonateAccount "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS"
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_setBalance "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" "0x56BC75E2D63100000"
+
+          if ! cast send --rpc-url "$$L2_HTTP_RPC" --from "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" --unlocked \
+            "$$YIELD_DISTRIBUTOR_ADDRESS" "castVote(uint256[])" "$$POINTS_ARG"; then
+            echo "ERROR: castVote from owner failed"
+            cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_stopImpersonatingAccount "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS" || true
+            exit 1
+          fi
+
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_stopImpersonatingAccount "$$YIELD_DISTRIBUTOR_OWNER_ADDRESS"
+
+          CURRENT_VOTES=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "currentVotes()(uint256)" 2>/dev/null | tr -d '[:space:]' | grep -oE '^[0-9]+' || echo "0")
+          echo "currentVotes after test vote: $$CURRENT_VOTES"
+          if [ "$$CURRENT_VOTES" -le 0 ]; then
+            echo "ERROR: currentVotes is still zero after casting vote"
+            exit 1
+          fi
+
+          # ── Step 4: Advance time and mine blocks ───────────────────────────────
+          echo ""
+          echo "=== Step 4: Advancing time ==="
+
+          CURRENT_TIMESTAMP=$$(cast block --rpc-url "$$L2_HTTP_RPC" latest -f timestamp 2>&1 | grep -oE '^[0-9]+' | head -1 || echo "1770000000")
+          CURRENT_BLOCK=$$(cast block-number --rpc-url "$$L2_HTTP_RPC" | tr -d '[:space:]')
+          echo "Current timestamp: $$CURRENT_TIMESTAMP"
+          echo "Current block: $$CURRENT_BLOCK"
+
+          TIME_ADVANCE=$$((8 * 24 * 60 * 60))
+          NEW_TIMESTAMP=$$((CURRENT_TIMESTAMP + TIME_ADVANCE))
+          echo "Advancing time by $$TIME_ADVANCE seconds to timestamp $$NEW_TIMESTAMP"
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_setNextBlockTimestamp $$(printf '0x%x' "$$NEW_TIMESTAMP")
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_mine 0x1
+          cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_mine 0x2
+
+          NEW_BLOCK=$$(cast block-number --rpc-url "$$L2_HTTP_RPC" | tr -d '[:space:]')
+          echo "New block number: $$NEW_BLOCK"
+
+          # ── Step 5: Contract state after setup ─────────────────────────────────
+          echo ""
+          echo "=== Step 5: Contract state after setup ==="
+          echo "blsSignatureChecker:"
+          cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "blsSignatureChecker()(address)" 2>/dev/null || echo "N/A"
+          echo "avsAddress:"
+          cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "avsAddress()(address)" 2>/dev/null || echo "N/A"
+          echo "stateTransitionCount:"
+          cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "stateTransitionCount()(uint256)" 2>/dev/null || echo "N/A"
+          echo "lastClaimedBlockNumber:"
+          cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "lastClaimedBlockNumber()(uint256)" 2>/dev/null || echo "N/A"
+
+          # ── Step 6: Verify results ─────────────────────────────────────────────
+          echo ""
+          echo "=== Step 6: Verifying test results ==="
+
+          PASSED=true
+
+          FINAL_BLS=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "blsSignatureChecker()(address)" 2>/dev/null || echo "unknown")
+          echo "blsSignatureChecker: $$FINAL_BLS"
+          echo "Expected (from bridge): $$BLS_CHECKER"
+          if [ "$$FINAL_BLS" != "$$BLS_CHECKER" ]; then
+            echo "FAIL: blsSignatureChecker not set correctly"
+            PASSED=false
+          else
+            echo "OK: blsSignatureChecker matches bridge deployment"
+          fi
+
+          FINAL_AVS=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "avsAddress()(address)" 2>/dev/null || echo "unknown")
+          echo "avsAddress: $$FINAL_AVS"
+          echo "Expected (from bridge): $$REG_COORD"
+          if [ "$$FINAL_AVS" != "$$REG_COORD" ]; then
+            echo "FAIL: avsAddress not set correctly"
+            PASSED=false
+          else
+            echo "OK: avsAddress matches bridge deployment"
+          fi
+
+          echo ""
+          echo "Checking resolveYieldDistribution..."
+          RESOLVER_RAW=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$YIELD_DISTRIBUTOR_ADDRESS" "resolveYieldDistribution()(bool,bytes)" 2>&1) || RESOLVER_RAW="call failed"
+          echo "Resolver result: $$RESOLVER_RAW"
+          if echo "$$RESOLVER_RAW" | grep -q "true"; then
+            echo "OK: resolveYieldDistribution returns true"
+          else
+            echo "FAIL: resolveYieldDistribution did not return true"
+            PASSED=false
+          fi
+
+          echo ""
+          if [ "$$PASSED" = "true" ]; then
+            echo "=========================================="
+            echo "=== YIELD DISTRIBUTION TEST PASSED ==="
+            echo "=========================================="
+            touch /app/.nodes/.yield_distribution_complete
+            exit 0
+          else
+            echo "=========================================="
+            echo "=== YIELD DISTRIBUTION TEST FAILED ==="
+            echo "=========================================="
+            exit 1
+          fi
+        } 2>&1 | tee -a "$$LOG_FILE"
+
+        EXIT_CODE=$${PIPESTATUS[0]}
+        exit $$EXIT_CODE
     restart: "no"
 
   # ─── Nodes (L2 overrides) ─────────────────────────────────────────────────
@@ -181,24 +410,24 @@ services:
   # L2_HTTP_RPC enables GasKillerValidator to simulate tasks on the L2 chain.
   node-1:
     depends_on:
-      bridge:
+      yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=${L2_HTTP_RPC}
+      - L2_HTTP_RPC=http://gnosis:8545
 
   node-2:
     depends_on:
-      bridge:
+      yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=${L2_HTTP_RPC}
+      - L2_HTTP_RPC=http://gnosis:8545
 
   node-3:
     depends_on:
-      bridge:
+      yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=${L2_HTTP_RPC}
+      - L2_HTTP_RPC=http://gnosis:8545
 
   # ─── Router (L2 overrides) ────────────────────────────────────────────────
   # HTTP_RPC stays on Sepolia Anvil so operator state (BLS keys, pubkeyHashToOperator)
@@ -206,7 +435,7 @@ services:
   # wallet provider for submitting verifyAndUpdate transactions on the L2 chain.
   router:
     depends_on:
-      bridge:
+      yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=${L2_HTTP_RPC}
+      - L2_HTTP_RPC=http://gnosis:8545

--- a/docker-compose.l2.yml
+++ b/docker-compose.l2.yml
@@ -1,4 +1,4 @@
-# Override for running gas-killer against a local L2 Anvil fork (Gnosis).
+# Override for running gas-killer against a local L2 Anvil fork.
 #
 # Usage:
 #   docker-compose -f docker-compose.yml -f docker-compose.l2.yml up
@@ -9,29 +9,37 @@
 #   YIELD_DISTRIBUTOR_OWNER_ADDRESS=0x5DD2e7db868e33c03daB85d0C623048A7980634E
 #
 # Optional:
-#   BLS_SIG_CHECK_ADDRESS=0x056A41125bB62168B464ddDECd995e8494448913  # on L2 fork
+#   L2_PORT=8546                                                       # host port for L2 Anvil
 #   YIELD_CYCLE_LENGTH=1                                               # test-friendly
 #   YIELD_BLOCK_STALE_MEASURE=100000000                                # disable staleness
+#   YIELD_TIME_ADVANCE=691200                                          # seconds to advance (default 8 days)
 #
 # Flow:
-#   eigenlayer  →  bridge (gnosis + eigenlayer)  →  yield-distribution  →  node-1/2/3 + router
+#   eigenlayer  →  bridge (l2 + eigenlayer)  →  yield-distribution  →  node-1/2/3 + router
 
 services:
-  # ─── L2 Anvil (Gnosis fork) ──────────────────────────────────────────────
-  gnosis:
+  # ─── L2 Anvil fork ─────────────────────────────────────────────────────────
+  l2:
     platform: linux/amd64
     image: ghcr.io/breadchaincoop/ethereum:dev
     env_file:
       - .env
     ports:
-      - "8546:8545"
+      - "${L2_PORT:-8546}:8545"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        anvil --fork-url ${L2_FORK_URL:-https://rpc.gnosischain.com} --host 0.0.0.0 --port 8545 --code-size-limit 65536 \
-          --timeout 120000 \
-          --retries 5 \
-          --compute-units-per-second 300
+        anvil --fork-url ${L2_FORK_URL:-https://rpc.gnosischain.com} --host 0.0.0.0 --port 8545 \
+          --code-size-limit ${ANVIL_CODE_SIZE_LIMIT:-65536} \
+          --timeout ${ANVIL_TIMEOUT:-120000} \
+          --retries ${ANVIL_RETRIES:-5} \
+          --compute-units-per-second ${ANVIL_COMPUTE_UNITS:-300}
+    healthcheck:
+      test: ["CMD-SHELL", "cast chain-id --rpc-url http://localhost:8545 || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
 
   # ─── Bridge ──────────────────────────────────────────────────────────────────
   # Deploys RegistryCoordinatorMimic + BLSSignatureChecker to the local L2 Anvil,
@@ -42,12 +50,12 @@ services:
     depends_on:
       eigenlayer:
         condition: service_completed_successfully
-      gnosis:
-        condition: service_started
+      l2:
+        condition: service_healthy
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY}
       - L1_HTTP_RPC=http://ethereum:8545
-      - L2_HTTP_RPC=http://gnosis:8545
+      - L2_HTTP_RPC=http://l2:8545
     volumes:
       - ./config/.nodes:/app/.nodes
     entrypoint:
@@ -190,12 +198,12 @@ services:
       bridge:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=http://gnosis:8545
+      - L2_HTTP_RPC=http://l2:8545
       - YIELD_DISTRIBUTOR_ADDRESS=${YIELD_DISTRIBUTOR_ADDRESS:-0x37A9CC16412CDA9b4f9B1ABdedd3e10BAD8A06da}
       - YIELD_DISTRIBUTOR_OWNER_ADDRESS=${YIELD_DISTRIBUTOR_OWNER_ADDRESS:-0x5DD2e7db868e33c03daB85d0C623048A7980634E}
-      - BLS_SIG_CHECK_ADDRESS=${BLS_SIG_CHECK_ADDRESS:-0x056A41125bB62168B464ddDECd995e8494448913}
       - YIELD_CYCLE_LENGTH=${YIELD_CYCLE_LENGTH:-1}
       - YIELD_BLOCK_STALE_MEASURE=${YIELD_BLOCK_STALE_MEASURE:-100000000}
+      - YIELD_TIME_ADVANCE=${YIELD_TIME_ADVANCE:-691200}
     volumes:
       - ./config/.nodes:/app/.nodes
     entrypoint:
@@ -224,16 +232,9 @@ services:
           BLS_APK_REGISTRY=$$(cast call --rpc-url "$$L2_HTTP_RPC" "$$REG_COORD" "blsApkRegistry()(address)")
           echo "BLSApkRegistry: $$BLS_APK_REGISTRY"
 
-          cat > /app/.nodes/l2_avs_deploy.json <<DEPLOYEOF
-          {
-            "addresses": {
-              "registryCoordinator": "$$REG_COORD",
-              "blsapkRegistry": "$$BLS_APK_REGISTRY",
-              "blsSigCheck": "$$BLS_SIG_CHECK_ADDRESS",
-              "counter": "0x0000000000000000000000000000000000000000"
-            }
-          }
-        DEPLOYEOF
+          printf '{"addresses":{"registryCoordinator":"%s","blsapkRegistry":"%s","blsSigCheck":"%s"}}' \
+            "$$REG_COORD" "$$BLS_APK_REGISTRY" "$$BLS_CHECKER" \
+            | jq '.' > /app/.nodes/l2_avs_deploy.json
           echo "=== Created l2_avs_deploy.json ==="
           cat /app/.nodes/l2_avs_deploy.json
 
@@ -326,7 +327,7 @@ services:
           echo "Current timestamp: $$CURRENT_TIMESTAMP"
           echo "Current block: $$CURRENT_BLOCK"
 
-          TIME_ADVANCE=$$((8 * 24 * 60 * 60))
+          TIME_ADVANCE=$${YIELD_TIME_ADVANCE:-691200}
           NEW_TIMESTAMP=$$((CURRENT_TIMESTAMP + TIME_ADVANCE))
           echo "Advancing time by $$TIME_ADVANCE seconds to timestamp $$NEW_TIMESTAMP"
           cast rpc --rpc-url "$$L2_HTTP_RPC" anvil_setNextBlockTimestamp $$(printf '0x%x' "$$NEW_TIMESTAMP")
@@ -413,21 +414,21 @@ services:
       yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=http://gnosis:8545
+      - L2_HTTP_RPC=http://l2:8545
 
   node-2:
     depends_on:
       yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=http://gnosis:8545
+      - L2_HTTP_RPC=http://l2:8545
 
   node-3:
     depends_on:
       yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=http://gnosis:8545
+      - L2_HTTP_RPC=http://l2:8545
 
   # ─── Router (L2 overrides) ────────────────────────────────────────────────
   # HTTP_RPC stays on Sepolia Anvil so operator state (BLS keys, pubkeyHashToOperator)
@@ -438,4 +439,4 @@ services:
       yield-distribution:
         condition: service_completed_successfully
     environment:
-      - L2_HTTP_RPC=http://gnosis:8545
+      - L2_HTTP_RPC=http://l2:8545

--- a/example.env
+++ b/example.env
@@ -105,9 +105,9 @@ INGRESS_TIMEOUT_MS=180000
 # =============================================================================
 YIELD_DISTRIBUTOR_ADDRESS=0x37A9CC16412CDA9b4f9B1ABdedd3e10BAD8A06da
 YIELD_DISTRIBUTOR_OWNER_ADDRESS=0x5DD2e7db868e33c03daB85d0C623048A7980634E
-BLS_SIG_CHECK_ADDRESS=0x056A41125bB62168B464ddDECd995e8494448913
 YIELD_CYCLE_LENGTH=1
 YIELD_BLOCK_STALE_MEASURE=100000000
+# YIELD_TIME_ADVANCE=691200  # seconds to advance time (default: 8 days)
 
 # =============================================================================
 # Gas Killer Trigger Inputs (optional for E2E test)

--- a/example.env
+++ b/example.env
@@ -22,10 +22,12 @@ WS_RPC=ws://localhost:8545
 FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 
 # =============================================================================
-# Network Configuration (L2 - Optional)
+# Network Configuration (L2 - Required for docker-compose.l2.yml)
 # =============================================================================
-# Uncomment to enable L2 chain support
-# For TESTNET mode (L2)
+# L2 Anvil fork source — the local gnosis service forks from this URL
+L2_FORK_URL=https://rpc.gnosischain.com
+
+# For TESTNET mode (L2) — uncomment to bypass local Anvil and hit a real chain
 # L2_HTTP_RPC=https://rpc.gnosischain.com
 # L2_WS_RPC=wss://rpc.gnosischain.com/wss
 
@@ -97,6 +99,15 @@ SIGNER_ENDPOINT=http://signer:50051
 INGRESS=true
 INGRESS_ADDRESS=0.0.0.0:8080
 INGRESS_TIMEOUT_MS=180000
+
+# =============================================================================
+# Yield Distribution (Required for docker-compose.l2.yml yield-distribution service)
+# =============================================================================
+YIELD_DISTRIBUTOR_ADDRESS=0x37A9CC16412CDA9b4f9B1ABdedd3e10BAD8A06da
+YIELD_DISTRIBUTOR_OWNER_ADDRESS=0x5DD2e7db868e33c03daB85d0C623048A7980634E
+BLS_SIG_CHECK_ADDRESS=0x056A41125bB62168B464ddDECd995e8494448913
+YIELD_CYCLE_LENGTH=1
+YIELD_BLOCK_STALE_MEASURE=100000000
 
 # =============================================================================
 # Gas Killer Trigger Inputs (optional for E2E test)

--- a/helm/gas-killer/templates/bridge-job.yaml
+++ b/helm/gas-killer/templates/bridge-job.yaml
@@ -162,6 +162,41 @@ spec:
               chmod 644 /app/.nodes/l2-deploy.json
               echo "l2-deploy.json copied to shared volume" | tee -a "$LOG_FILE"
 
+              # ── Create l2_avs_deploy.json for the router ──────────────────────────
+              echo "=== Creating l2_avs_deploy.json ===" | tee -a "$LOG_FILE"
+              L2_DEPLOY="/app/contracts/artifacts/l2-deploy.json"
+              MIMIC_ADDR=$(jq -r '.registryCoordinatorMimic' "$L2_DEPLOY")
+              BLS_CHECKER_ADDR=$(jq -r '.blsSignatureChecker' "$L2_DEPLOY")
+
+              BLS_APK_REGISTRY=$(cast call --rpc-url "$L2_HTTP_RPC" "$MIMIC_ADDR" "blsApkRegistry()(address)" 2>/dev/null || echo "0x0000000000000000000000000000000000000000")
+              echo "[BRIDGE] BLSApkRegistry: $BLS_APK_REGISTRY" | tee -a "$LOG_FILE"
+
+              cat > /app/.nodes/l2_avs_deploy.json <<DEPLOYEOF
+              {
+                "addresses": {
+                  "registryCoordinator": "$MIMIC_ADDR",
+                  "blsapkRegistry": "$BLS_APK_REGISTRY",
+                  "blsSigCheck": "$BLS_CHECKER_ADDR",
+                  "counter": "0x0000000000000000000000000000000000000000"
+                }
+              }
+          DEPLOYEOF
+              chmod 644 /app/.nodes/l2_avs_deploy.json
+              echo "l2_avs_deploy.json created" | tee -a "$LOG_FILE"
+              cat /app/.nodes/l2_avs_deploy.json | tee -a "$LOG_FILE"
+
+              # ── Optional: Update YieldDistributor with bridge-deployed addresses ──
+              if [ -n "$YIELD_DISTRIBUTOR_ADDRESS" ]; then
+                echo "=== Updating YieldDistributor at $YIELD_DISTRIBUTOR_ADDRESS ===" | tee -a "$LOG_FILE"
+                cast send --rpc-url "$L2_HTTP_RPC" --private-key "$PRIVATE_KEY" \
+                  "$YIELD_DISTRIBUTOR_ADDRESS" "setAvsAddress(address)" "$MIMIC_ADDR" 2>&1 | tee -a "$LOG_FILE"
+                cast send --rpc-url "$L2_HTTP_RPC" --private-key "$PRIVATE_KEY" \
+                  "$YIELD_DISTRIBUTOR_ADDRESS" "setBlsSignatureChecker(address)" "$BLS_CHECKER_ADDR" 2>&1 | tee -a "$LOG_FILE"
+                echo "[BRIDGE] YieldDistributor updated" | tee -a "$LOG_FILE"
+              else
+                echo "[BRIDGE] YIELD_DISTRIBUTOR_ADDRESS not set, skipping YieldDistributor update" | tee -a "$LOG_FILE"
+              fi
+
               # Write completion marker
               touch /app/.nodes/.bridge_complete
               chmod 644 /app/.nodes/.bridge_complete
@@ -200,6 +235,10 @@ spec:
                   name: {{ include "gas-killer.secret.fullname" . }}
                   key: L2_HTTP_RPC
             {{- end }}
+            {{- end }}
+            {{- if .Values.yieldDistribution.contractAddress }}
+            - name: YIELD_DISTRIBUTOR_ADDRESS
+              value: {{ .Values.yieldDistribution.contractAddress | quote }}
             {{- end }}
           volumeMounts:
             - name: shared-data

--- a/helm/gas-killer/templates/bridge-job.yaml
+++ b/helm/gas-killer/templates/bridge-job.yaml
@@ -171,16 +171,9 @@ spec:
               BLS_APK_REGISTRY=$(cast call --rpc-url "$L2_HTTP_RPC" "$MIMIC_ADDR" "blsApkRegistry()(address)" 2>/dev/null || echo "0x0000000000000000000000000000000000000000")
               echo "[BRIDGE] BLSApkRegistry: $BLS_APK_REGISTRY" | tee -a "$LOG_FILE"
 
-              cat > /app/.nodes/l2_avs_deploy.json <<DEPLOYEOF
-              {
-                "addresses": {
-                  "registryCoordinator": "$MIMIC_ADDR",
-                  "blsapkRegistry": "$BLS_APK_REGISTRY",
-                  "blsSigCheck": "$BLS_CHECKER_ADDR",
-                  "counter": "0x0000000000000000000000000000000000000000"
-                }
-              }
-          DEPLOYEOF
+              printf '{"addresses":{"registryCoordinator":"%s","blsapkRegistry":"%s","blsSigCheck":"%s","counter":"0x0000000000000000000000000000000000000000"}}' \
+                "$MIMIC_ADDR" "$BLS_APK_REGISTRY" "$BLS_CHECKER_ADDR" \
+                | jq '.' > /app/.nodes/l2_avs_deploy.json
               chmod 644 /app/.nodes/l2_avs_deploy.json
               echo "l2_avs_deploy.json created" | tee -a "$LOG_FILE"
               cat /app/.nodes/l2_avs_deploy.json | tee -a "$LOG_FILE"

--- a/helm/gas-killer/templates/bridge-job.yaml
+++ b/helm/gas-killer/templates/bridge-job.yaml
@@ -168,10 +168,14 @@ spec:
               MIMIC_ADDR=$(jq -r '.registryCoordinatorMimic' "$L2_DEPLOY")
               BLS_CHECKER_ADDR=$(jq -r '.blsSignatureChecker' "$L2_DEPLOY")
 
-              BLS_APK_REGISTRY=$(cast call --rpc-url "$L2_HTTP_RPC" "$MIMIC_ADDR" "blsApkRegistry()(address)" 2>/dev/null || echo "0x0000000000000000000000000000000000000000")
+              BLS_APK_REGISTRY=$(cast call --rpc-url "$L2_HTTP_RPC" "$MIMIC_ADDR" "blsApkRegistry()(address)")
+              if [ -z "$BLS_APK_REGISTRY" ] || [ "$BLS_APK_REGISTRY" = "0x0000000000000000000000000000000000000000" ]; then
+                echo "ERROR: blsApkRegistry() returned empty/zero — L2 RPC may not be ready or contract missing" | tee -a "$LOG_FILE"
+                exit 1
+              fi
               echo "[BRIDGE] BLSApkRegistry: $BLS_APK_REGISTRY" | tee -a "$LOG_FILE"
 
-              printf '{"addresses":{"registryCoordinator":"%s","blsapkRegistry":"%s","blsSigCheck":"%s","counter":"0x0000000000000000000000000000000000000000"}}' \
+              printf '{"addresses":{"registryCoordinator":"%s","blsapkRegistry":"%s","blsSigCheck":"%s"}}' \
                 "$MIMIC_ADDR" "$BLS_APK_REGISTRY" "$BLS_CHECKER_ADDR" \
                 | jq '.' > /app/.nodes/l2_avs_deploy.json
               chmod 644 /app/.nodes/l2_avs_deploy.json
@@ -180,11 +184,18 @@ spec:
 
               # ── Optional: Update YieldDistributor with bridge-deployed addresses ──
               if [ -n "$YIELD_DISTRIBUTOR_ADDRESS" ]; then
+                YD_KEY="${YIELD_DISTRIBUTOR_OWNER_KEY:-$PRIVATE_KEY}"
                 echo "=== Updating YieldDistributor at $YIELD_DISTRIBUTOR_ADDRESS ===" | tee -a "$LOG_FILE"
-                cast send --rpc-url "$L2_HTTP_RPC" --private-key "$PRIVATE_KEY" \
-                  "$YIELD_DISTRIBUTOR_ADDRESS" "setAvsAddress(address)" "$MIMIC_ADDR" 2>&1 | tee -a "$LOG_FILE"
-                cast send --rpc-url "$L2_HTTP_RPC" --private-key "$PRIVATE_KEY" \
-                  "$YIELD_DISTRIBUTOR_ADDRESS" "setBlsSignatureChecker(address)" "$BLS_CHECKER_ADDR" 2>&1 | tee -a "$LOG_FILE"
+                if ! cast send --rpc-url "$L2_HTTP_RPC" --private-key "$YD_KEY" \
+                  "$YIELD_DISTRIBUTOR_ADDRESS" "setAvsAddress(address)" "$MIMIC_ADDR" 2>&1 | tee -a "$LOG_FILE"; then
+                  echo "ERROR: setAvsAddress failed — is the key the contract owner?" | tee -a "$LOG_FILE"
+                  exit 1
+                fi
+                if ! cast send --rpc-url "$L2_HTTP_RPC" --private-key "$YD_KEY" \
+                  "$YIELD_DISTRIBUTOR_ADDRESS" "setBlsSignatureChecker(address)" "$BLS_CHECKER_ADDR" 2>&1 | tee -a "$LOG_FILE"; then
+                  echo "ERROR: setBlsSignatureChecker failed — is the key the contract owner?" | tee -a "$LOG_FILE"
+                  exit 1
+                fi
                 echo "[BRIDGE] YieldDistributor updated" | tee -a "$LOG_FILE"
               else
                 echo "[BRIDGE] YIELD_DISTRIBUTOR_ADDRESS not set, skipping YieldDistributor update" | tee -a "$LOG_FILE"
@@ -232,6 +243,13 @@ spec:
             {{- if .Values.yieldDistribution.contractAddress }}
             - name: YIELD_DISTRIBUTOR_ADDRESS
               value: {{ .Values.yieldDistribution.contractAddress | quote }}
+            {{- end }}
+            {{- if .Values.secrets.yieldDistributorOwnerKey }}
+            - name: YIELD_DISTRIBUTOR_OWNER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gas-killer.secret.fullname" . }}
+                  key: YIELD_DISTRIBUTOR_OWNER_KEY
             {{- end }}
           volumeMounts:
             - name: shared-data

--- a/helm/gas-killer/templates/node-deployment.yaml
+++ b/helm/gas-killer/templates/node-deployment.yaml
@@ -145,6 +145,13 @@ spec:
             {{- if and (eq $root.Values.global.environment "LOCAL") $root.Values.l2.enabled }}
             - name: L2_HTTP_RPC
               value: "http://{{ include "gas-killer.l2.fullname" $root }}:{{ $root.Values.l2.service.port }}"
+            {{- else if and (eq $root.Values.global.environment "TESTNET") $root.Values.l2.httpRpc }}
+            # TESTNET mode: Use external L2 RPC for cross-chain validation
+            - name: L2_HTTP_RPC
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gas-killer.secret.fullname" $root }}
+                  key: L2_HTTP_RPC
             {{- end }}
             - name: RUST_BACKTRACE
               value: "1"

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -188,6 +188,13 @@ spec:
             # LOCAL mode: L2 RPC for cross-chain execution (yield distribution) via Anvil fork
             - name: L2_HTTP_RPC
               value: "http://{{ include "gas-killer.l2.fullname" . }}:{{ .Values.l2.service.port }}"
+            {{- else if and (eq .Values.global.environment "TESTNET") .Values.l2.httpRpc }}
+            # TESTNET mode: Use external L2 RPC for cross-chain execution
+            - name: L2_HTTP_RPC
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gas-killer.secret.fullname" . }}
+                  key: L2_HTTP_RPC
             {{- end }}
             - name: AVS_DEPLOYMENT_PATH
               value: "/app/.nodes/avs_deploy.json"

--- a/helm/gas-killer/templates/secret.yaml
+++ b/helm/gas-killer/templates/secret.yaml
@@ -31,4 +31,9 @@ stringData:
   L2_HTTP_RPC: {{ .Values.l2.httpRpc | quote }}
   L2_WS_RPC: {{ .Values.l2.httpRpc | replace "https://" "wss://" | replace "http://" "ws://" | quote }}
   {{- end }}
+  {{- if .Values.secrets.yieldDistributorOwnerKey }}
+  # Private key of the YieldDistributor owner (for TESTNET mode bridge configuration)
+  # If not provided, PRIVATE_KEY is used as fallback
+  YIELD_DISTRIBUTOR_OWNER_KEY: {{ .Values.secrets.yieldDistributorOwnerKey | quote }}
+  {{- end }}
 {{- end }}

--- a/helm/gas-killer/templates/yield-distribution-job.yaml
+++ b/helm/gas-killer/templates/yield-distribution-job.yaml
@@ -93,17 +93,9 @@ spec:
               echo "BLSSigCheckOperatorStateRetriever (from L2 fork): $BLS_SIG_CHECK"
 
               # Create l2_avs_deploy.json with L2 AVS addresses for future use
-              # Format matches AvsDeployment { addresses: { registryCoordinator, blsapkRegistry, blsSigCheck, counter } }
-              cat > /app/.nodes/l2_avs_deploy.json <<DEPLOYEOF
-              {
-                "addresses": {
-                  "registryCoordinator": "$REG_COORD",
-                  "blsapkRegistry": "$BLS_APK_REGISTRY",
-                  "blsSigCheck": "$BLS_SIG_CHECK",
-                  "counter": "0x0000000000000000000000000000000000000000"
-                }
-              }
-              DEPLOYEOF
+              printf '{"addresses":{"registryCoordinator":"%s","blsapkRegistry":"%s","blsSigCheck":"%s"}}' \
+                "$REG_COORD" "$BLS_APK_REGISTRY" "$BLS_SIG_CHECK" \
+                | jq '.' > /app/.nodes/l2_avs_deploy.json
 
               echo "=== Created l2_avs_deploy.json ==="
               cat /app/.nodes/l2_avs_deploy.json

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -175,11 +175,13 @@ orchestrator:
   # WARNING: The image contains a default private key. For production, always provide your own!
   routerPrivateKey: ""
 
-# L2 (Anvil fork) configuration - only used in LOCAL mode
-# Defaults to disabled; enable explicitly via --set l2.enabled=true (e.g. in CI)
+# L2 configuration
+# LOCAL mode:  set l2.enabled=true to spin up a local Anvil fork (requires secrets.l2ForkUrl)
+# TESTNET mode: set l2.httpRpc to connect nodes/router/bridge to a live L2 chain (e.g. Gnosis mainnet)
 l2:
   enabled: false
   # Direct RPC URL for L2 in TESTNET mode (contains API key - sensitive!)
+  # When set, nodes and router receive L2_HTTP_RPC for cross-chain validation/execution
   # Override with: --set l2.httpRpc=<your-l2-rpc-url>
   # Example: --set l2.httpRpc=https://rpc.gnosischain.com
   httpRpc: ""
@@ -215,16 +217,20 @@ bridge:
       memory: "1Gi"
       cpu: "500m"
 
-# Yield Distribution test configuration - only used in LOCAL mode with l2.enabled
-# Defaults to disabled; enable explicitly via --set yieldDistribution.enabled=true (e.g. in CI)
+# Yield Distribution configuration
+# LOCAL mode: enable to run yield distribution test job (requires l2.enabled, uses Anvil impersonation)
+# TESTNET mode: set contractAddress to have the bridge configure a live YieldDistributor
+#               (PRIVATE_KEY must be the contract owner)
 yieldDistribution:
   enabled: false
   # YieldDistributor contract address on L2
+  # In TESTNET mode, the bridge will call setAvsAddress/setBlsSignatureChecker on this contract
   contractAddress: "0x37A9CC16412CDA9b4f9B1ABdedd3e10BAD8A06da"
-  # Owner of the YieldDistributor on the fork (used for anvil impersonation)
+  # Owner of the YieldDistributor on the fork (used for anvil impersonation in LOCAL mode only)
   ownerAddress: "0x5DD2e7db868e33c03daB85d0C623048A7980634E"
-  # BLSSigCheckOperatorStateRetriever address on the L2 fork
-  # In LOCAL mode this is the address present on the forked L2 chain
+  # BLSSigCheckOperatorStateRetriever address on the L2 fork (LOCAL mode only)
+  # Pre-existing contract on the forked Gnosis chain; not needed in TESTNET mode
+  # (the bridge deploys its own BLSSignatureChecker)
   blsSigCheckAddress: "0x056A41125bB62168B464ddDECd995e8494448913"
   # Test-friendly overrides applied via contract setters
   cycleLength: 1

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -45,6 +45,11 @@ secrets:
   # Example: --set secrets.l2ForkUrl=https://rpc.gnosischain.com
   l2ForkUrl: ""
 
+  # Private key of the YieldDistributor contract owner (TESTNET mode only)
+  # Used by the bridge to call setAvsAddress/setBlsSignatureChecker on the live contract
+  # If not provided, PRIVATE_KEY is used as fallback (will fail if it's not the owner)
+  yieldDistributorOwnerKey: ""
+
 # L1 (Anvil) configuration - only used in LOCAL mode
 l1:
   enabled: true


### PR DESCRIPTION
## Summary
- Pass `L2_HTTP_RPC` to nodes and router in TESTNET mode so they can validate and execute cross-chain tasks on a live Gnosis chain
- Add `l2_avs_deploy.json` creation to the bridge job (queries `blsApkRegistry` from deployed contracts, no user input needed)
- Add optional YieldDistributor configuration in the bridge job when `yieldDistribution.contractAddress` is set (calls `setAvsAddress`/`setBlsSignatureChecker` using bridge-deployed addresses)
- Update `docker-compose.l2.yml` with full local Anvil fork support: adds `gnosis` service, `yield-distribution` service (voting, time advancement, verification), and wires all services to the local L2

## Test plan
- [ ] Deploy with `global.environment=TESTNET` and `l2.httpRpc` set — verify nodes and router receive `L2_HTTP_RPC`
- [ ] Verify bridge creates `l2_avs_deploy.json` with correct addresses from `l2-deploy.json`
- [ ] Test optional YieldDistributor update by setting `yieldDistribution.contractAddress`
- [ ] Run `docker-compose -f docker-compose.yml -f docker-compose.l2.yml up` and verify full local flow