### PR TITLE
Delete unneeded `.gitmodules` file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "commonware-avs-node"]
-	path = commonware-avs-node
-	url = https://github.com/BreadchainCoop/commonware-avs-node.git


### PR DESCRIPTION
Remove `.gitmodules` artifact from when we used submodules for this repo.