### PR TITLE
Default to 0 ms time which means no timeout

### DIFF
--- a/helm/gas-killer/testnet-overrides.yaml
+++ b/helm/gas-killer/testnet-overrides.yaml
@@ -28,3 +28,7 @@ monitoring:
     ingress:
       enabled: true
       host: grafana-testnet.gaskiller.xyz
+
+router:
+  ingress:
+    timeoutMs: "0"

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -215,9 +215,9 @@ router:
   aggregationFrequency: "90"
   ingress:
     enabled: true
-    # IMPORTANT: Must be quoted string to prevent YAML from converting to scientific notation (3e+06)
-    # which Rust's u64 parser cannot handle
-    timeoutMs: "3000000"  # 50 minutes
+    # IMPORTANT: Must be quoted string to prevent YAML from converting to scientific notation.
+    # "0" means no timeout — router waits indefinitely for an incoming task.
+    timeoutMs: "0"
   service:
     type: ClusterIP
     port: 3000

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -136,7 +136,7 @@ impl Default for GasKillerConfig {
         let timeout_ms: u64 = env::var("INGRESS_TIMEOUT_MS")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(30_000);
+            .unwrap_or(0);
 
         Self {
             polling_interval_ms: 100,
@@ -208,22 +208,28 @@ impl<Q: TaskQueue + Send + Sync + 'static> ListeningGasKillerCreator<Q> {
 
     async fn wait_for_task(&self) -> Result<GasKillerTaskRequest> {
         use tokio::time::{Duration, sleep};
-        let mut attempts = 0;
-        let max_attempts = self.config.timeout_ms / self.config.polling_interval_ms;
+        // timeout_ms == 0 means wait indefinitely
+        let max_attempts = if self.config.timeout_ms == 0 {
+            None
+        } else {
+            Some(self.config.timeout_ms / self.config.polling_interval_ms)
+        };
+        let mut attempts = 0u64;
         loop {
             if let Some(task) = self.queue.pop() {
                 return Ok(task);
             }
             attempts += 1;
-            if attempts >= max_attempts {
-                break;
+            if let Some(max) = max_attempts {
+                if attempts >= max {
+                    return Err(anyhow::anyhow!(
+                        "Timeout waiting for task after {}ms",
+                        self.config.timeout_ms
+                    ));
+                }
             }
             sleep(Duration::from_millis(self.config.polling_interval_ms)).await;
         }
-        Err(anyhow::anyhow!(
-            "Timeout waiting for task after {}ms",
-            self.config.timeout_ms
-        ))
     }
 }
 

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -220,13 +220,13 @@ impl<Q: TaskQueue + Send + Sync + 'static> ListeningGasKillerCreator<Q> {
                 return Ok(task);
             }
             attempts += 1;
-            if let Some(max) = max_attempts {
-                if attempts >= max {
-                    return Err(anyhow::anyhow!(
-                        "Timeout waiting for task after {}ms",
-                        self.config.timeout_ms
-                    ));
-                }
+            if let Some(max) = max_attempts
+                && attempts >= max
+            {
+                return Err(anyhow::anyhow!(
+                    "Timeout waiting for task after {}ms",
+                    self.config.timeout_ms
+                ));
             }
             sleep(Duration::from_millis(self.config.polling_interval_ms)).await;
         }


### PR DESCRIPTION
Router was restarting every 50 minutes because we had a default value set for the timeout. This sets the default to 0 which means no timeout.