### PR TITLE
Update to newest version of `commonware-restaking` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#6f6ca99f89fecffff9b51e52bbcae57718547d04"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#7d90d01a0065d1660068cbc5fc01ba0e9fd2a4fd"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#6f6ca99f89fecffff9b51e52bbcae57718547d04"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#7d90d01a0065d1660068cbc5fc01ba0e9fd2a4fd"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2191,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#6f6ca99f89fecffff9b51e52bbcae57718547d04"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#7d90d01a0065d1660068cbc5fc01ba0e9fd2a4fd"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2209,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#6f6ca99f89fecffff9b51e52bbcae57718547d04"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#7d90d01a0065d1660068cbc5fc01ba0e9fd2a4fd"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#6f6ca99f89fecffff9b51e52bbcae57718547d04"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#7d90d01a0065d1660068cbc5fc01ba0e9fd2a4fd"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5023,7 +5023,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6036,7 +6036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6056,7 +6056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",


### PR DESCRIPTION
Update to new version of library with orchestrator fixes https://github.com/BreadchainCoop/commonware-restaking/commit/7d90d01a0065d1660068cbc5fc01ba0e9fd2a4fd#diff-0f3d4db4cccd1b10f40c2fe276111bea687b8c47d25d5517a5f4632861a9e92e