### PR TITLE
Recreate `avs_deploy.json` on cluster recreation

### DIFF
--- a/helm/gas-killer/templates/setup-job.yaml
+++ b/helm/gas-killer/templates/setup-job.yaml
@@ -23,8 +23,13 @@ spec:
         app.kubernetes.io/component: setup
     spec:
       restartPolicy: OnFailure
-      {{- if eq .Values.global.environment "LOCAL" }}
+      {{- if and (eq .Values.global.environment "TESTNET") .Values.secretManager.enabled }}
+      serviceAccountName: {{ default (include "gas-killer.serviceaccount.fullname" .) .Values.secretManager.serviceAccountName }}
+      {{- end }}
+      {{- $needsInitContainers := or (eq .Values.global.environment "LOCAL") (and (eq .Values.global.environment "TESTNET") .Values.secretManager.enabled) }}
+      {{- if $needsInitContainers }}
       initContainers:
+        {{- if eq .Values.global.environment "LOCAL" }}
         # Wait for L1 to be ready (LOCAL mode only)
         - name: wait-for-l1
           image: busybox:1.36
@@ -45,6 +50,79 @@ spec:
                 ELAPSED=$((ELAPSED + 5))
               done
               echo "L1 is ready!"
+        {{- end }}
+        {{- if and (eq .Values.global.environment "TESTNET") .Values.secretManager.enabled }}
+        # Restore avs_deploy.json and BLS keys from Secret Manager if the PVC is empty
+        # (e.g. after cluster recreation). If secrets don't exist yet this is a fresh
+        # install — exit 0 and let eigenlayer-setup run normally.
+        - name: fetch-avs-deploy
+          image: {{ .Values.secretManager.cloudSdkImage | quote }}
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
+
+              PROJECT="{{ required "secretManager.projectId is required when secretManager.enabled=true" .Values.secretManager.projectId }}"
+              PREFIX="{{ .Values.secretManager.keyPrefix }}"
+              DEPLOY_SECRET="${PREFIX}-avs-deploy"
+
+              echo "Checking Secret Manager for existing deployment state (secret: ${DEPLOY_SECRET})..."
+
+              # No avs_deploy secret yet → fresh install, let eigenlayer-setup run normally.
+              if ! gcloud secrets describe "${DEPLOY_SECRET}" --project="${PROJECT}" &>/dev/null; then
+                echo "Secret ${DEPLOY_SECRET} not found. Proceeding with fresh setup."
+                exit 0
+              fi
+
+              # PVC already has a completed setup (normal helm upgrade) → nothing to restore.
+              if [ -f /root/.nodes/.setup_complete ]; then
+                echo "PVC already has .setup_complete marker. Skipping restore."
+                exit 0
+              fi
+
+              echo "Secret found and PVC is empty. Restoring state from Secret Manager..."
+              mkdir -p /root/.nodes/operator_keys
+
+              # Restore avs_deploy.json
+              gcloud secrets versions access latest \
+                --secret="${DEPLOY_SECRET}" \
+                --project="${PROJECT}" \
+                > /root/.nodes/avs_deploy.json
+              echo "Restored avs_deploy.json"
+
+              # Restore each operator's BLS key — fails fast if any secret is missing.
+              {{- $nodeCount := int .Values.global.nodeCount }}
+              {{- range $i := until $nodeCount }}
+              {{- $nodeIndex := add $i 1 }}
+              gcloud secrets versions access latest \
+                --secret="${PREFIX}-node-{{ $nodeIndex }}-bls-key" \
+                --project="${PROJECT}" \
+                > /root/.nodes/operator_keys/testacc{{ $nodeIndex }}.private.bls.key.json
+              echo "Restored testacc{{ $nodeIndex }} BLS key"
+              {{- end }}
+
+              # Fix permissions so non-root containers can read the files
+              chmod -R 755 /root/.nodes
+              chmod 644 /root/.nodes/avs_deploy.json
+              chmod 644 /root/.nodes/operator_keys/*.json
+
+              # Signal eigenlayer-setup to skip re-running
+              touch /root/.nodes/.setup_complete
+              chmod 644 /root/.nodes/.setup_complete
+
+              echo "State restored from Secret Manager. Setup will be skipped."
+          volumeMounts:
+            - name: shared-data
+              mountPath: /root/.nodes
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+        {{- end }}
       {{- end }}
 
       containers:

--- a/helm/gas-killer/templates/setup-job.yaml
+++ b/helm/gas-killer/templates/setup-job.yaml
@@ -70,9 +70,14 @@ spec:
               echo "Checking Secret Manager for existing deployment state (secret: ${DEPLOY_SECRET})..."
 
               # No avs_deploy secret yet → fresh install, let eigenlayer-setup run normally.
-              if ! gcloud secrets describe "${DEPLOY_SECRET}" --project="${PROJECT}" &>/dev/null; then
-                echo "Secret ${DEPLOY_SECRET} not found. Proceeding with fresh setup."
-                exit 0
+              # Capture stderr so we can distinguish NOT_FOUND from auth/permission failures.
+              if ! describe_error="$(gcloud secrets describe "${DEPLOY_SECRET}" --project="${PROJECT}" 2>&1 >/dev/null)"; then
+                if printf '%s\n' "${describe_error}" | grep -Eqi '(^|[[:space:][:punct:]])NOT_FOUND([[:space:][:punct:]]|$)|not found'; then
+                  echo "Secret ${DEPLOY_SECRET} not found. Proceeding with fresh setup."
+                  exit 0
+                fi
+                echo "Failed to check Secret Manager for ${DEPLOY_SECRET}: ${describe_error}" >&2
+                exit 1
               fi
 
               # PVC already has a completed setup (normal helm upgrade) → nothing to restore.
@@ -81,7 +86,14 @@ spec:
                 exit 0
               fi
 
-              echo "Secret found and PVC is empty. Restoring state from Secret Manager..."
+              # If setup files already exist without the completion marker, do not overwrite them.
+              # This guards against a partial prior run (e.g. crash after avs_deploy.json was
+              # written but before .setup_complete was created).
+              if [ -f /root/.nodes/avs_deploy.json ] || find /root/.nodes/operator_keys -maxdepth 1 -type f -name '*.json' 2>/dev/null | grep -q .; then
+                echo "Detected existing setup files in PVC without .setup_complete marker. Refusing to restore over partial state." >&2
+                exit 1
+              fi
+              echo "Secret found and no existing restore target files were detected. Restoring state from Secret Manager..."
               mkdir -p /root/.nodes/operator_keys
 
               # Restore avs_deploy.json


### PR DESCRIPTION
If a cluster is recreated, the secrets will exist in GKE, but not on PVC as "avs_deploy.json". This change adds a check to see if the secrets exist in GKE so we can just restore them instead of rerunning the setup and replacing values (which will break any contracts configured to the previous "avs_deploy.json" values.