### PR TITLE
Use LRU executor cache to avoid calling `build()` more than once per block number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,7 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 [[package]]
 name = "gas-analyzer-core"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
+source = "git+https://github.com/gas-killer/gas-analyzer#5911a3436587b59f7f253b23ae14acacff0128b5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-estimator"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
+source = "git+https://github.com/gas-killer/gas-analyzer#5911a3436587b59f7f253b23ae14acacff0128b5"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-evmsketch"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
+source = "git+https://github.com/gas-killer/gas-analyzer#5911a3436587b59f7f253b23ae14acacff0128b5"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
+source = "git+https://github.com/gas-killer/gas-analyzer#5911a3436587b59f7f253b23ae14acacff0128b5"
 dependencies = [
  "alloy",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,10 +288,31 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "op-revm",
- "revm",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types-engine 0.22.4",
+ "op-revm 12.0.2",
+ "revm 31.0.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc719f3501f4b6761c0da9e1c657adc7ac37739dea51a373d5849efbe4f55e52"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "op-alloy",
+ "op-revm 14.1.0",
+ "revm 33.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -449,7 +470,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.16.3",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -3670,7 +3691,6 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 [[package]]
 name = "gas-analyzer-core"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#2c5529520fddc7504a0db976ac179ca6028e4e2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -3679,12 +3699,12 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "gas-analyzer-estimator"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#2c5529520fddc7504a0db976ac179ca6028e4e2d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3692,39 +3712,45 @@ dependencies = [
  "gas-analyzer-core",
  "getrandom 0.2.17",
  "hex",
- "revm",
+ "revm 31.0.2",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "gas-analyzer-evmsketch"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#2c5529520fddc7504a0db976ac179ca6028e4e2d"
 dependencies = [
  "alloy",
  "alloy-eips",
+ "alloy-evm 0.25.3",
  "alloy-provider",
  "anyhow",
  "gas-analyzer-core",
  "gas-analyzer-estimator",
  "gas-analyzer-rpc",
+ "lru 0.13.0",
  "reth-primitives",
- "revm",
+ "revm 31.0.2",
  "sp1-cc-client-executor",
  "sp1-cc-host-executor",
+ "tokio",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "gas-analyzer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#2c5529520fddc7504a0db976ac179ca6028e4e2d"
 dependencies = [
  "alloy",
  "alloy-eips",
  "alloy-provider",
+ "alloy-rpc-types",
  "anyhow",
  "gas-analyzer-core",
+ "gas-analyzer-estimator",
+ "revm 31.0.2",
 ]
 
 [[package]]
@@ -4031,6 +4057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4704,6 +4731,15 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -5025,7 +5061,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5068,6 +5104,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "op-alloy"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
+dependencies = [
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-network",
+ "op-alloy-provider",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine 0.23.1",
+]
+
+[[package]]
 name = "op-alloy-consensus"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5085,6 +5134,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-consensus"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-rpc-types",
+]
+
+[[package]]
+name = "op-alloy-provider"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "op-alloy-rpc-types-engine 0.23.1",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.23.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5098,7 +5215,29 @@ dependencies = [
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.22.4",
+ "snap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "op-alloy-consensus 0.23.1",
+ "serde",
+ "sha2 0.10.9",
  "snap",
  "thiserror 2.0.18",
 ]
@@ -5110,7 +5249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31622d03b29c826e48800f4c8f389c8a9c440eb796a3e35203561a288f12985"
 dependencies = [
  "auto_impl",
- "revm",
+ "revm 31.0.2",
+ "serde",
+]
+
+[[package]]
+name = "op-revm"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
+dependencies = [
+ "auto_impl",
+ "revm 33.1.0",
  "serde",
 ]
 
@@ -6038,7 +6188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6058,7 +6208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6419,7 +6569,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -6443,7 +6593,7 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.22.4",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -6562,7 +6712,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -6573,7 +6723,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 31.0.2",
 ]
 
 [[package]]
@@ -6583,7 +6733,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -6594,7 +6744,7 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits",
  "reth-storage-errors",
- "revm",
+ "revm 31.0.2",
 ]
 
 [[package]]
@@ -6602,7 +6752,7 @@ name = "reth-execution-errors"
 version = "1.9.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5f46c598c7f541a1510f32"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -6617,13 +6767,13 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-primitives",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm",
+ "revm 31.0.2",
  "serde",
  "serde_with",
 ]
@@ -6673,7 +6823,7 @@ dependencies = [
  "derive_more",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.22.4",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
@@ -6832,14 +6982,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
 dependencies = [
  "revm-bytecode",
- "revm-context",
- "revm-context-interface",
+ "revm-context 11.0.2",
+ "revm-context-interface 12.0.1",
  "revm-database",
  "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
+ "revm-handler 12.0.2",
+ "revm-inspector 12.0.2",
+ "revm-interpreter 29.0.1",
+ "revm-precompile 29.0.1",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm"
+version = "33.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
+dependencies = [
+ "revm-bytecode",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler 14.1.0",
+ "revm-inspector 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
  "revm-primitives",
  "revm-state",
 ]
@@ -6866,7 +7035,24 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode",
- "revm-context-interface",
+ "revm-context-interface 12.0.1",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "12.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface 13.1.0",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
@@ -6878,6 +7064,22 @@ name = "revm-context-interface"
 version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d701e2c2347d65216b066489ab22a0a8e1f7b2568256110d73a7d5eff3385c"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -6925,11 +7127,30 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode",
- "revm-context",
- "revm-context-interface",
+ "revm-context 11.0.2",
+ "revm-context-interface 12.0.1",
  "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
+ "revm-interpreter 29.0.1",
+ "revm-precompile 29.0.1",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -6943,10 +7164,28 @@ checksum = "c99801eac7da06cc112df2244bd5a64024f4ef21240e923b26e73c4b4a0e5da6"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
+ "revm-context 11.0.2",
  "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
+ "revm-handler 12.0.2",
+ "revm-interpreter 29.0.1",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 12.1.0",
+ "revm-database-interface",
+ "revm-handler 14.1.0",
+ "revm-interpreter 31.1.0",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -6965,7 +7204,7 @@ dependencies = [
  "alloy-sol-types",
  "anstyle",
  "colorchoice",
- "revm",
+ "revm 31.0.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6978,7 +7217,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
 dependencies = [
  "revm-bytecode",
- "revm-context-interface",
+ "revm-context-interface 12.0.1",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "31.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface 13.1.0",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -7008,6 +7260,30 @@ dependencies = [
  "secp256k1 0.31.1",
  "sha2 0.10.9",
  "substrate-bn",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256 0.13.4",
+ "p256",
+ "revm-primitives",
+ "ripemd",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7094,7 +7370,7 @@ version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.1b#1ddb68b4bcf7060af7eb4930e79a17f927c99c93"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7111,7 +7387,7 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits",
  "reth-trie",
- "revm",
+ "revm 31.0.2",
  "revm-primitives",
  "rsp-mpt",
  "rsp-primitives",
@@ -7968,7 +8244,7 @@ source = "git+https://github.com/BreadchainCoop/sp1-contract-call?branch=cancun-
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
@@ -7982,7 +8258,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-primitives",
- "revm",
+ "revm 31.0.2",
  "revm-inspectors",
  "revm-primitives",
  "rsp-client-executor",
@@ -8003,7 +8279,7 @@ source = "git+https://github.com/BreadchainCoop/sp1-contract-call?branch=cancun-
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.23.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
@@ -8017,7 +8293,7 @@ dependencies = [
  "reqwest",
  "reth-chainspec",
  "reth-primitives",
- "revm",
+ "revm 31.0.2",
  "revm-primitives",
  "rsp-client-executor",
  "rsp-mpt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,7 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 [[package]]
 name = "gas-analyzer-core"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-estimator"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3722,11 +3722,13 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-evmsketch"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
 dependencies = [
  "alloy",
  "alloy-eips",
  "alloy-evm 0.25.3",
+ "alloy-genesis",
+ "alloy-hardforks",
  "alloy-provider",
  "anyhow",
  "gas-analyzer-core",
@@ -3745,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#9169a0e69540fe80a1c414bda0972d9b9ff9dc06"
 dependencies = [
  "alloy",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 [[package]]
 name = "gas-analyzer-core"
 version = "0.1.0"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -3705,6 +3706,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-estimator"
 version = "0.1.0"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3720,6 +3722,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-evmsketch"
 version = "0.1.0"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -3742,6 +3745,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-rpc"
 version = "0.1.0"
+source = "git+https://github.com/gas-killer/gas-analyzer?branch=bagelface%2Fcache-build-by-block-number#aae86c44ad500159627fb913439d149ff8a54bc5"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -4278,7 +4282,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -9569,7 +9573,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -9579,23 +9583,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -9610,32 +9601,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ eigen-services-operatorsinfo = "2.0.0"
 eigen-utils = "2.0.0"
 futures = "0.3.31"
 futures-util = "0.3.31"
-gas-analyzer = { git = "https://github.com/gas-killer/gas-analyzer", package = "gas-analyzer-evmsketch" }
+gas-analyzer = { git = "https://github.com/gas-killer/gas-analyzer", branch="bagelface/cache-build-by-block-number", package = "gas-analyzer-evmsketch" }
 gas-killer-common = { path = "common" }
 governor = "0.6.3"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ eigen-services-operatorsinfo = "2.0.0"
 eigen-utils = "2.0.0"
 futures = "0.3.31"
 futures-util = "0.3.31"
-gas-analyzer = { git = "https://github.com/gas-killer/gas-analyzer", branch="bagelface/cache-build-by-block-number", package = "gas-analyzer-evmsketch" }
+gas-analyzer = { git = "https://github.com/gas-killer/gas-analyzer", package = "gas-analyzer-evmsketch" }
 gas-killer-common = { path = "common" }
 governor = "0.6.3"
 hex = "0.4"

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -23,7 +23,7 @@ use commonware_avs_router::wire;
 
 use alloy::eips::BlockNumberOrTag;
 use alloy::rpc::types::TransactionRequest;
-use gas_analyzer::call_to_encoded_state_updates_with_evmsketch;
+use gas_analyzer::{EvmSketchExecutorCache, call_to_encoded_state_updates_with_evmsketch};
 
 /// Prometheus metrics for validator timing, exposed on the node's /metrics endpoint.
 pub struct ValidatorMetrics {
@@ -73,6 +73,12 @@ pub struct AnalysisResult {
     pub block_height: u64,
 }
 
+/// Default LRU capacity for the executor cache.
+///
+/// 4 entries covers all realistic burst scenarios on mainnet (~12 s blocks):
+/// one entry per chain (mainnet + L2) at the current and previous block height.
+const DEFAULT_EXECUTOR_CACHE_CAPACITY: usize = 4;
+
 /// Validator implementation for the gas killer use case with multi-chain support
 #[derive(Clone)]
 pub struct GasKillerValidator {
@@ -84,6 +90,10 @@ pub struct GasKillerValidator {
     /// Prevents re-running expensive EVMSketch for the same round when the
     /// orchestrator validates multiple signatures for identical task data.
     digest_cache: Arc<Mutex<HashMap<(u64, u64), Digest>>>,
+    /// LRU cache of pre-built EvmSketch executors keyed by (rpc_url, block_number).
+    /// Eliminates the 2× eth_getBlockByNumber build cost (~80–120 ms) for the
+    /// 2nd…Nth request at the same block height.
+    executor_cache: Arc<EvmSketchExecutorCache>,
     /// Optional Prometheus metrics — injected on the node, absent on the router.
     validator_metrics: Option<Arc<ValidatorMetrics>>,
 }
@@ -113,6 +123,7 @@ impl GasKillerValidator {
             chain_rpc_urls,
             default_chain: ChainId::L1,
             digest_cache: Arc::new(Mutex::new(HashMap::new())),
+            executor_cache: Arc::new(EvmSketchExecutorCache::new(DEFAULT_EXECUTOR_CACHE_CAPACITY)),
             validator_metrics: None,
         })
     }
@@ -127,6 +138,7 @@ impl GasKillerValidator {
             chain_rpc_urls,
             default_chain: ChainId::L1,
             digest_cache: Arc::new(Mutex::new(HashMap::new())),
+            executor_cache: Arc::new(EvmSketchExecutorCache::new(DEFAULT_EXECUTOR_CACHE_CAPACITY)),
             validator_metrics: None,
         }
     }
@@ -137,6 +149,7 @@ impl GasKillerValidator {
             chain_rpc_urls,
             default_chain: ChainId::L1,
             digest_cache: Arc::new(Mutex::new(HashMap::new())),
+            executor_cache: Arc::new(EvmSketchExecutorCache::new(DEFAULT_EXECUTOR_CACHE_CAPACITY)),
             validator_metrics: None,
         }
     }
@@ -256,7 +269,7 @@ impl GasKillerValidator {
             .rpc_url_for_chain(chain_id)
             .ok_or_else(|| anyhow::anyhow!("No RPC URL configured for chain: {}", chain_id))?;
 
-        let result = Self::analyze_transaction(
+        let result = self.analyze_transaction(
             rpc_url,
             contract_address,
             call_data,
@@ -370,16 +383,16 @@ impl GasKillerValidator {
         payload_hash
     }
 
-    /// Performs the core gas analysis using gas-analyzer
+    /// Performs the core gas analysis using gas-analyzer.
     ///
-    /// This method contains the core logic for:
-    /// 1. Forking the blockchain state
-    /// 2. Executing the transaction
-    /// 3. Extracting storage changes and gas information
+    /// Uses the shared executor cache to skip the 2× `eth_getBlockByNumber` build
+    /// cost (~80–120 ms) when a request arrives at the same block height as a
+    /// recent prior request.
     ///
     /// Takes an explicit RPC URL parameter for flexibility.
     /// Forks at the specified block for deterministic results.
     pub async fn analyze_transaction(
+        &self,
         rpc_url: &str,
         contract_address: alloy::primitives::Address,
         call_data: &[u8],
@@ -404,9 +417,12 @@ impl GasKillerValidator {
             .value(tx_value)
             .input(alloy::primitives::Bytes::copy_from_slice(call_data).into());
 
-        // Call gas-analyzer to get storage updates and gas estimate using EvmSketch
+        // Call gas-analyzer to get storage updates and gas estimate using EvmSketch.
+        // The executor cache eliminates the build cost on repeated requests at the
+        // same block height.
         let (storage_updates, gas_estimate, _is_heuristic, _skipped_opcodes) =
             call_to_encoded_state_updates_with_evmsketch(
+                &self.executor_cache,
                 rpc_url,
                 tx_request,
                 BlockNumberOrTag::Number(block_height),
@@ -453,7 +469,7 @@ impl GasKillerValidator {
         );
 
         let evmsketch_start = Instant::now();
-        let result = Self::analyze_transaction(
+        let result = self.analyze_transaction(
             rpc_url,
             task_data.target_address,
             &task_data.call_data,

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -21,7 +21,6 @@ use crate::task_data::GasKillerTaskData;
 use commonware_avs_router::validator::ValidatorTrait;
 use commonware_avs_router::wire;
 
-use alloy::eips::BlockNumberOrTag;
 use alloy::rpc::types::TransactionRequest;
 use gas_analyzer::{EvmSketchExecutorCache, call_to_encoded_state_updates_with_evmsketch};
 
@@ -439,7 +438,7 @@ impl GasKillerValidator {
                 &self.executor_cache,
                 rpc_url,
                 tx_request,
-                BlockNumberOrTag::Number(block_height),
+                block_height,
             )
             .await
             .map_err(|e| anyhow::anyhow!("Gas analysis failed: {}", e))?;

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -282,15 +282,16 @@ impl GasKillerValidator {
             .rpc_url_for_chain(chain_id)
             .ok_or_else(|| anyhow::anyhow!("No RPC URL configured for chain: {}", chain_id))?;
 
-        let result = self.analyze_transaction(
-            rpc_url,
-            contract_address,
-            call_data,
-            from_address,
-            value,
-            block_height,
-        )
-        .await?;
+        let result = self
+            .analyze_transaction(
+                rpc_url,
+                contract_address,
+                call_data,
+                from_address,
+                value,
+                block_height,
+            )
+            .await?;
         Ok((result.storage_updates, result.block_height, chain_id))
     }
 
@@ -482,15 +483,16 @@ impl GasKillerValidator {
         );
 
         let evmsketch_start = Instant::now();
-        let result = self.analyze_transaction(
-            rpc_url,
-            task_data.target_address,
-            &task_data.call_data,
-            Some(task_data.from_address),
-            Some(task_data.value),
-            task_data.block_height,
-        )
-        .await?;
+        let result = self
+            .analyze_transaction(
+                rpc_url,
+                task_data.target_address,
+                &task_data.call_data,
+                Some(task_data.from_address),
+                Some(task_data.value),
+                task_data.block_height,
+            )
+            .await?;
         if let Some(m) = &self.validator_metrics {
             m.evmsketch_duration_seconds
                 .observe(evmsketch_start.elapsed().as_secs_f64());


### PR DESCRIPTION
## Summary

Integrates the new `EvmSketchExecutorCache` from the gas-analyzer library to avoid repeated `build()` calls at the same block height.

Corresponds to gas-analyzer changes in gas-killer/gas-analyzer#143.

> **Note:** This PR temporarily points the `gas-analyzer` dependency at the feature branch from gas-killer/gas-analyzer#143. Once those changes are merged into `main`, this PR will be updated to target the default branch.

## Test plan

- [x] gas-killer/gas-analyzer#143 is merged first
- [x] Update `gas-analyzer` dependency to target default branch
- [x] `cargo fmt --all && cargo clippy -- -D warnings && cargo check && cargo test` pass