### PR TITLE
Extend "helm install" timeout

### DIFF
--- a/.github/workflows/helm-integration-tests.yml
+++ b/.github/workflows/helm-integration-tests.yml
@@ -141,6 +141,7 @@ jobs:
           # Install without --wait to avoid circular dependency
           # (pods wait for setup job, setup job is post-install hook)
           helm install gas-killer ./helm/gas-killer \
+            --timeout 10m \
             --set global.environment=LOCAL \
             --set global.nodeCount=3 \
             --set eigenlayer.contracts.delegationManager="$DELEGATION_MANAGER" \


### PR DESCRIPTION
We're seeing failures during "helm install" with "context deadline exceeded". Extending the timeout by 5 mins (it's 5 mins by default) should eliminate these failures.