### PR TITLE
Document `AvsServiceManagerWrapper` immutable params in `example.env`

### DIFF
--- a/example.env
+++ b/example.env
@@ -36,6 +36,22 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # QUORUM_NUMBER=0
 
 # =============================================================================
+# AVS Service Manager Wrapper Configuration
+# =============================================================================
+# These values are passed as immutable constructor parameters when deploying
+# AvsServiceManagerWrapper and CANNOT be changed after deployment.
+#
+# QUORUM_THRESHOLD / THRESHOLD_DENOMINATOR: fraction of total registered
+# operator stake that must sign a task for it to be accepted. 2/3 means at
+# least two-thirds of stake-weighted operators must co-sign.
+#
+# BLOCK_STALE_MEASURE: maximum age (in blocks) of a valid reference block.
+# At ~12 s/block on Ethereum, 300 blocks ≈ 1 hour.
+QUORUM_THRESHOLD=2
+THRESHOLD_DENOMINATOR=3
+BLOCK_STALE_MEASURE=300
+
+# =============================================================================
 # Environment Mode
 # =============================================================================
 ENVIRONMENT=LOCAL


### PR DESCRIPTION
## Summary

`QUORUM_THRESHOLD`, `THRESHOLD_DENOMINATOR`, and `BLOCK_STALE_MEASURE` are immutable constructor parameters in `AvsServiceManagerWrapper` — they cannot be changed after deployment. Previously they were undocumented and silently fell through to forge's `vm.envOr(...)` defaults (2, 3, 300).

- Adds a dedicated `AVS Service Manager Wrapper Configuration` section to `example.env` documenting the intended production values (2/3 quorum, 300-block staleness ≈ 1 hour at ~12 s/block) and explaining the immutability constraint
- `service/example.env` is the env source for the `eigenlayer` container when running the full E2E stack via `service/docker-compose.yml`, so these values must be present here as well as in `eigenlayer-bls-local/example.env` (see BreadchainCoop/eigenlayer-bls-local#35)

Closes #228