### PR TITLE
Add missing setup job envars

### DIFF
--- a/helm/gas-killer/templates/setup-job.yaml
+++ b/helm/gas-killer/templates/setup-job.yaml
@@ -272,6 +272,12 @@ spec:
               value: {{ required "eigenlayer.contracts.lstStrategy must be set (use an overrides file matching your target network)" .Values.eigenlayer.contracts.lstStrategy | quote }}
             - name: ALLOCATION_MANAGER_ADDRESS
               value: {{ required "eigenlayer.contracts.allocationManager must be set (use an overrides file matching your target network)" .Values.eigenlayer.contracts.allocationManager | quote }}
+            - name: QUORUM_THRESHOLD
+              value: {{ .Values.eigenlayer.sdk.quorumThreshold | quote }}
+            - name: THRESHOLD_DENOMINATOR
+              value: {{ .Values.eigenlayer.sdk.thresholdDenominator | quote }}
+            - name: BLOCK_STALE_MEASURE
+              value: {{ .Values.eigenlayer.sdk.blockStaleMeasure | quote }}
           volumeMounts:
             - name: shared-data
               mountPath: /root/.nodes

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -145,6 +145,15 @@ eigenlayer:
     lstContract: ""
     lstStrategy: ""
     allocationManager: ""
+  # Immutable constructor parameters for AvsServiceManagerWrapper — baked into the
+  # contract at deploy time. Cannot be changed without redeploying (rerun.setup=true).
+  sdk:
+    # Fraction of stake-weighted operators that must co-sign a task: threshold/denominator.
+    # Default 2/3 = two-thirds supermajority.
+    quorumThreshold: "2"
+    thresholdDenominator: "3"
+    # Maximum age (in blocks) of a valid reference block. At ~12s/block, 300 ≈ 1 hour.
+    blockStaleMeasure: "300"
   resources:
     requests:
       memory: "1Gi"


### PR DESCRIPTION
Add `QUORUM_THRESHOLD`, `THRESHOLD_DENOMINATOR`, and `BLOCK_STALE_MEASURE` envars to scope of Helm setup job.