### PR TITLE
Add per-phase executor latency metrics and Grafana round-lifecycle dashboard

### DIFF
--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -303,6 +303,100 @@ data:
             "colorMode": "background",
             "graphMode": "area"
           }
+        },
+        {
+          "id": 50,
+          "type": "text",
+          "title": "Executor Phase Breakdown",
+          "gridPos": { "x": 0, "y": 42, "w": 24, "h": 1 },
+          "options": { "mode": "markdown", "content": "## Executor Phase Breakdown\n\nPer-phase latency inside `handle_verification`. Chain detection → getMessageHash preflight → supportsInterface check → tx send (includes gas estimation) → receipt confirmation (block inclusion wait)." }
+        },
+        {
+          "id": 51,
+          "type": "timeseries",
+          "title": "Chain Detection (p50 / p95)",
+          "gridPos": { "x": 0, "y": 43, "w": 8, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(gas_killer_executor_chain_detection_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(gas_killer_executor_chain_detection_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 52,
+          "type": "timeseries",
+          "title": "Hash Preflight (p50 / p95)",
+          "gridPos": { "x": 8, "y": 43, "w": 8, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(gas_killer_executor_hash_preflight_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(gas_killer_executor_hash_preflight_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 53,
+          "type": "timeseries",
+          "title": "supportsInterface Check (p50 / p95)",
+          "gridPos": { "x": 16, "y": 43, "w": 8, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(gas_killer_executor_supports_interface_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(gas_killer_executor_supports_interface_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 54,
+          "type": "timeseries",
+          "title": "TX Send (p50 / p95)",
+          "description": "Time from calling verifyAndUpdate to receiving the pending tx handle. Includes eth_estimateGas simulation.",
+          "gridPos": { "x": 0, "y": 51, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(gas_killer_executor_tx_send_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(gas_killer_executor_tx_send_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 55,
+          "type": "timeseries",
+          "title": "Receipt Confirmation (p50 / p95)",
+          "description": "Time waiting for the verifyAndUpdate transaction to be included in a block.",
+          "gridPos": { "x": 12, "y": 51, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(gas_killer_executor_receipt_confirmation_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(gas_killer_executor_receipt_confirmation_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
         }
       ]
     }

--- a/router/bench-baseline.md
+++ b/router/bench-baseline.md
@@ -1,0 +1,37 @@
+# Executor Performance Baseline
+
+Snapshot p50/p95 values here after each significant testnet deploy. Use the PromQL
+queries below against the in-cluster Prometheus (or Grafana Explore) over a window
+that includes at least ~50 completed rounds.
+
+## How to capture a baseline
+
+```promql
+# Replace 5m with whatever window gives you a stable rate (10m+ preferred)
+histogram_quantile(0.50, rate(gas_killer_executor_chain_detection_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(gas_killer_executor_chain_detection_seconds_bucket[5m]))
+
+histogram_quantile(0.50, rate(gas_killer_executor_hash_preflight_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(gas_killer_executor_hash_preflight_seconds_bucket[5m]))
+
+histogram_quantile(0.50, rate(gas_killer_executor_supports_interface_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(gas_killer_executor_supports_interface_seconds_bucket[5m]))
+
+histogram_quantile(0.50, rate(gas_killer_executor_tx_send_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(gas_killer_executor_tx_send_seconds_bucket[5m]))
+
+histogram_quantile(0.50, rate(gas_killer_executor_receipt_confirmation_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(gas_killer_executor_receipt_confirmation_seconds_bucket[5m]))
+
+histogram_quantile(0.50, rate(gas_killer_execution_duration_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(gas_killer_execution_duration_seconds_bucket[5m]))
+
+histogram_quantile(0.50, rate(gas_killer_p2p_round_trip_seconds_bucket[5m]))
+histogram_quantile(0.99, rate(gas_killer_p2p_round_trip_seconds_bucket[5m]))
+```
+
+## Snapshots
+
+| Date | Commit | chain_detection p50/p95 | hash_preflight p50/p95 | supports_interface p50/p95 | tx_send p50/p95 | receipt_confirmation p50/p95 | execution_duration p50/p95 | p2p_round_trip p50/p99 | Notes |
+|------|--------|------------------------|------------------------|---------------------------|-----------------|------------------------------|---------------------------|------------------------|-------|
+| — | — | — | — | — | — | — | — | — | First deploy with per-phase metrics — fill in after steady-state traffic |

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -129,13 +129,14 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
 
         // Detect which chain the contract is on
         let chain_detect_start = Instant::now();
-        let chain_id = self
+        let chain_detect_result = self
             .detect_chain_for_address(task_data.target_address)
-            .await?;
+            .await;
         if let Some(m) = &self.metrics {
             m.executor_chain_detection_seconds
                 .observe(chain_detect_start.elapsed().as_secs_f64());
         }
+        let chain_id = chain_detect_result?;
 
         // Get the chain-specific provider
         let provider = self

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -128,9 +128,14 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             .ok_or_else(|| anyhow::anyhow!("Task data is required for gas killer verification"))?;
 
         // Detect which chain the contract is on
+        let chain_detect_start = Instant::now();
         let chain_id = self
             .detect_chain_for_address(task_data.target_address)
             .await?;
+        if let Some(m) = &self.metrics {
+            m.executor_chain_detection_seconds
+                .observe(chain_detect_start.elapsed().as_secs_f64());
+        }
 
         // Get the chain-specific provider
         let provider = self
@@ -161,12 +166,18 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         );
 
         let gas_killer_sdk = GasKillerSDK::new(target_addr, provider.clone());
+
         // Query the contract's getMessageHash and compare with the provided msg_hash
-        match gas_killer_sdk
+        let hash_preflight_start = Instant::now();
+        let hash_result = gas_killer_sdk
             .getMessageHash(transition_index, target_function, storage_updates.clone())
             .call()
-            .await
-        {
+            .await;
+        if let Some(m) = &self.metrics {
+            m.executor_hash_preflight_seconds
+                .observe(hash_preflight_start.elapsed().as_secs_f64());
+        }
+        match hash_result {
             Ok(expected_hash) => {
                 if expected_hash != msg_hash {
                     warn!(
@@ -194,7 +205,13 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
 
         // Ensure contract implements the GasKiller interface via ERC-165 check
         let interface_id = FixedBytes::<4>::from([0x93, 0xde, 0x45, 0x31]);
-        match gas_killer_sdk.supportsInterface(interface_id).call().await {
+        let supports_interface_start = Instant::now();
+        let supports_result = gas_killer_sdk.supportsInterface(interface_id).call().await;
+        if let Some(m) = &self.metrics {
+            m.executor_supports_interface_seconds
+                .observe(supports_interface_start.elapsed().as_secs_f64());
+        }
+        match supports_result {
             Ok(supported) => {
                 if !supported {
                     warn!("Target contract does not support GasKiller interface (0x93de4531)");
@@ -216,7 +233,8 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         // Without the decrement, eth_estimateGas at block N sees referenceBlockNumber == N
         // and reverts with FutureBlockNumber.
         info!("Sending verifyAndUpdate transaction");
-        let call_return = gas_killer_sdk
+        let tx_send_start = Instant::now();
+        let send_result = gas_killer_sdk
             .verifyAndUpdate(
                 msg_hash,
                 quorum_numbers,
@@ -228,12 +246,23 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             )
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to send verifyAndUpdate transaction: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to send verifyAndUpdate transaction: {}", e));
+        if let Some(m) = &self.metrics {
+            m.executor_tx_send_seconds
+                .observe(tx_send_start.elapsed().as_secs_f64());
+        }
+        let call_return = send_result?;
 
-        let receipt = call_return
+        let receipt_start = Instant::now();
+        let receipt_result = call_return
             .get_receipt()
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get transaction receipt: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to get transaction receipt: {}", e));
+        if let Some(m) = &self.metrics {
+            m.executor_receipt_confirmation_seconds
+                .observe(receipt_start.elapsed().as_secs_f64());
+        }
+        let receipt = receipt_result?;
         info!(
             tx = %receipt.transaction_hash,
             block = receipt.block_number,

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -26,6 +26,16 @@ pub struct MetricsCollector {
     pub p2p_round_trip_seconds: Histogram,
     /// Current number of tasks sitting in the ingress queue waiting to be processed.
     pub task_queue_depth: Gauge<i64, AtomicI64>,
+    /// Time to detect which chain a target contract is deployed on (seconds).
+    pub executor_chain_detection_seconds: Histogram,
+    /// Time for getMessageHash RPC preflight call (seconds).
+    pub executor_hash_preflight_seconds: Histogram,
+    /// Time for supportsInterface ERC-165 check (seconds).
+    pub executor_supports_interface_seconds: Histogram,
+    /// Time from calling verifyAndUpdate to receiving the pending tx handle (seconds).
+    pub executor_tx_send_seconds: Histogram,
+    /// Time waiting for the verifyAndUpdate receipt to be mined (seconds).
+    pub executor_receipt_confirmation_seconds: Histogram,
 }
 
 impl MetricsCollector {
@@ -98,6 +108,43 @@ impl MetricsCollector {
             task_queue_depth.clone(),
         );
 
+        let rpc_buckets = [0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0];
+        let executor_chain_detection_seconds = Histogram::new(rpc_buckets);
+        registry.register(
+            "gas_killer_executor_chain_detection_seconds",
+            "Time to detect which chain a target contract is deployed on",
+            executor_chain_detection_seconds.clone(),
+        );
+
+        let executor_hash_preflight_seconds = Histogram::new(rpc_buckets);
+        registry.register(
+            "gas_killer_executor_hash_preflight_seconds",
+            "Time for the getMessageHash RPC preflight call",
+            executor_hash_preflight_seconds.clone(),
+        );
+
+        let executor_supports_interface_seconds = Histogram::new(rpc_buckets);
+        registry.register(
+            "gas_killer_executor_supports_interface_seconds",
+            "Time for the supportsInterface ERC-165 check",
+            executor_supports_interface_seconds.clone(),
+        );
+
+        let executor_tx_send_seconds = Histogram::new([0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0]);
+        registry.register(
+            "gas_killer_executor_tx_send_seconds",
+            "Time from calling verifyAndUpdate to receiving the pending tx handle",
+            executor_tx_send_seconds.clone(),
+        );
+
+        let executor_receipt_confirmation_seconds =
+            Histogram::new([0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0]);
+        registry.register(
+            "gas_killer_executor_receipt_confirmation_seconds",
+            "Time waiting for the verifyAndUpdate receipt to be mined",
+            executor_receipt_confirmation_seconds.clone(),
+        );
+
         Self {
             registry,
             ingress_accepted,
@@ -109,6 +156,11 @@ impl MetricsCollector {
             execution_duration_seconds,
             p2p_round_trip_seconds,
             task_queue_depth,
+            executor_chain_detection_seconds,
+            executor_hash_preflight_seconds,
+            executor_supports_interface_seconds,
+            executor_tx_send_seconds,
+            executor_receipt_confirmation_seconds,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds 5 new `Histogram` metrics to `MetricsCollector` covering each executor sub-operation: chain detection, `getMessageHash` preflight, `supportsInterface` check, tx send, and receipt confirmation
- Instruments `execute_verification` to observe each phase; metrics are recorded on both success and error paths
- Extends the Grafana dashboard with an "Executor Phase Breakdown" section (p50/p95 per phase)
- Adds `router/bench-baseline.md` with PromQL snippets and a snapshot table for tracking improvements over deploys

Closes #214

## Test plan

- [ ] `cargo clippy -p gas-killer-router -- -D warnings` passes
- [ ] `cargo check --all-targets --all-features` passes
- [ ] Deploy to testnet, run ~50 rounds, confirm all 5 new histograms appear in `/metrics` output
- [ ] Open Grafana → Gas Killer dashboard → verify "Executor Phase Breakdown" panels populate
- [ ] Record first baseline row in `router/bench-baseline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)