### PR TITLE
Replace polling queue with tokio mpsc channel to eliminate artificial task dispatch latency

### DIFF
--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -147,7 +147,13 @@ impl ListeningGasKillerCreator {
                 })?
                 .ok_or_else(|| anyhow::anyhow!("task channel closed"))?
         };
-        let depth = self.queue_depth.fetch_sub(1, Ordering::Relaxed) - 1;
+        let depth = self
+            .queue_depth
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            })
+            .unwrap()
+            .saturating_sub(1);
         if let Some(m) = &self.metrics {
             m.task_queue_depth.set(depth as i64);
         }

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -12,6 +12,7 @@ use std::env;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, info, warn};
 
 /// Shared timestamp set by the creator when it dispatches a task and consumed by the executor
@@ -25,143 +26,22 @@ use tracing::{debug, error, info, warn};
 /// https://github.com/BreadchainCoop/commonware-restaking/issues/154.
 pub type DispatchTime = Arc<Mutex<Option<Instant>>>;
 
-/// A queue that can hold and provide task requests
-pub trait TaskQueue: Send + Sync {
-    /// Add a task to the queue
-    fn push(&self, task: GasKillerTaskRequest);
+pub type TaskSender = UnboundedSender<GasKillerTaskRequest>;
+pub type TaskReceiver = UnboundedReceiver<GasKillerTaskRequest>;
+/// Shared atomic counter tracking tasks in flight between the ingress sender and creator receiver.
+pub type TaskQueueDepth = Arc<AtomicUsize>;
 
-    /// Remove and return the next task from the queue
-    fn pop(&self) -> Option<GasKillerTaskRequest>;
-
-    /// Current number of pending tasks in the queue
-    fn len(&self) -> usize;
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
+pub fn task_channel() -> (TaskSender, TaskReceiver) {
+    mpsc::unbounded_channel()
 }
 
-/// Simple in-memory task queue using Arc<Mutex> with proper error handling
-#[derive(Clone)]
-pub struct GasKillerTaskQueue {
-    queue: Arc<Mutex<Vec<GasKillerTaskRequest>>>,
-    timeout_ms: u64,
-    max_retries: u32,
-    /// Maintained atomically so `len()` is always accurate even when the mutex is held.
-    count: Arc<AtomicUsize>,
-}
-
-impl GasKillerTaskQueue {
-    pub fn new() -> Self {
-        Self {
-            queue: Arc::new(Mutex::new(Vec::new())),
-            timeout_ms: 1000, // 1 second default timeout
-            max_retries: 3,   // 3 retries by default
-            count: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    pub fn with_timeout(timeout_ms: u64) -> Self {
-        Self {
-            queue: Arc::new(Mutex::new(Vec::new())),
-            timeout_ms,
-            max_retries: 3,
-            count: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    pub fn with_config(timeout_ms: u64, max_retries: u32) -> Self {
-        Self {
-            queue: Arc::new(Mutex::new(Vec::new())),
-            timeout_ms,
-            max_retries,
-            count: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    /// Try to acquire the lock with timeout and retries
-    fn try_lock_with_timeout(
-        &self,
-    ) -> Result<std::sync::MutexGuard<'_, Vec<GasKillerTaskRequest>>, String> {
-        let start_time = Instant::now();
-        let timeout_duration = Duration::from_millis(self.timeout_ms);
-
-        for attempt in 0..self.max_retries {
-            // Try to acquire the lock
-            match self.queue.try_lock() {
-                Ok(guard) => return Ok(guard),
-                Err(_) => {
-                    // Check if we've exceeded the timeout
-                    if start_time.elapsed() >= timeout_duration {
-                        return Err(format!(
-                            "Failed to acquire lock after {}ms timeout ({} attempts)",
-                            self.timeout_ms,
-                            attempt + 1
-                        ));
-                    }
-
-                    // Small delay before retry to avoid busy waiting
-                    std::thread::sleep(Duration::from_millis(1));
-                }
-            }
-        }
-
-        Err(format!(
-            "Failed to acquire lock after {} retries",
-            self.max_retries
-        ))
-    }
-}
-
-impl Default for GasKillerTaskQueue {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// Align naming with the counter usecase so factories and ingress can share a consistent type.
-pub type SimpleTaskQueue = GasKillerTaskQueue;
-
-impl TaskQueue for GasKillerTaskQueue {
-    fn len(&self) -> usize {
-        self.count.load(Ordering::Relaxed)
-    }
-
-    fn push(&self, task: GasKillerTaskRequest) {
-        match self.try_lock_with_timeout() {
-            Ok(mut queue) => {
-                queue.push(task);
-                let new_len = self.count.fetch_add(1, Ordering::Relaxed) + 1;
-                info!("Task enqueued: queue_len={} (after push)", new_len);
-            }
-            Err(e) => {
-                error!("Failed to push task to queue: {}", e);
-                warn!("Task dropped due to lock timeout: {:?}", task);
-            }
-        }
-    }
-
-    fn pop(&self) -> Option<GasKillerTaskRequest> {
-        match self.try_lock_with_timeout() {
-            Ok(mut queue) => {
-                let item = queue.pop();
-                if item.is_some() {
-                    self.count.fetch_sub(1, Ordering::Relaxed);
-                }
-                item
-            }
-            Err(e) => {
-                error!("Failed to pop task from queue: {}", e);
-                None
-            }
-        }
-    }
+pub fn task_queue_depth() -> TaskQueueDepth {
+    Arc::new(AtomicUsize::new(0))
 }
 
 /// Configuration for listening creators
 #[derive(Debug, Clone)]
 pub struct GasKillerConfig {
-    pub polling_interval_ms: u64,
     pub timeout_ms: u64,
 }
 
@@ -172,10 +52,7 @@ impl Default for GasKillerConfig {
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
 
-        Self {
-            polling_interval_ms: 100,
-            timeout_ms,
-        }
+        Self { timeout_ms }
     }
 }
 
@@ -215,8 +92,9 @@ struct EnrichedTask {
 }
 
 /// Creator for the gas killer usecase that listens for external requests
-pub struct ListeningGasKillerCreator<Q: TaskQueue + Send + Sync + 'static> {
-    queue: Arc<Q>,
+pub struct ListeningGasKillerCreator {
+    receiver: tokio::sync::Mutex<TaskReceiver>,
+    queue_depth: TaskQueueDepth,
     config: GasKillerConfig,
     validator: Arc<GasKillerValidator>,
     current_task: Mutex<Option<EnrichedTask>>,
@@ -227,15 +105,17 @@ pub struct ListeningGasKillerCreator<Q: TaskQueue + Send + Sync + 'static> {
     dispatch_time: DispatchTime,
 }
 
-impl<Q: TaskQueue + Send + Sync + 'static> ListeningGasKillerCreator<Q> {
+impl ListeningGasKillerCreator {
     pub fn new(
-        queue: Q,
+        receiver: TaskReceiver,
+        queue_depth: TaskQueueDepth,
         config: GasKillerConfig,
         validator: Arc<GasKillerValidator>,
         dispatch_time: DispatchTime,
     ) -> Self {
         Self {
-            queue: Arc::new(queue),
+            receiver: tokio::sync::Mutex::new(receiver),
+            queue_depth,
             config,
             validator,
             current_task: Mutex::new(None),
@@ -251,37 +131,32 @@ impl<Q: TaskQueue + Send + Sync + 'static> ListeningGasKillerCreator<Q> {
     }
 
     async fn wait_for_task(&self) -> Result<GasKillerTaskRequest> {
-        use tokio::time::{Duration, sleep};
-        // timeout_ms == 0 means wait indefinitely
-        let max_attempts = if self.config.timeout_ms == 0 {
-            None
+        let mut rx = self.receiver.lock().await;
+        let task = if self.config.timeout_ms == 0 {
+            rx.recv()
+                .await
+                .ok_or_else(|| anyhow::anyhow!("task channel closed"))?
         } else {
-            Some(self.config.timeout_ms / self.config.polling_interval_ms)
+            tokio::time::timeout(Duration::from_millis(self.config.timeout_ms), rx.recv())
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "Timeout waiting for task after {}ms",
+                        self.config.timeout_ms
+                    )
+                })?
+                .ok_or_else(|| anyhow::anyhow!("task channel closed"))?
         };
-        let mut attempts = 0u64;
-        loop {
-            if let Some(task) = self.queue.pop() {
-                if let Some(m) = &self.metrics {
-                    m.task_queue_depth.set(self.queue.len() as i64);
-                }
-                return Ok(task);
-            }
-            attempts += 1;
-            if let Some(max) = max_attempts
-                && attempts >= max
-            {
-                return Err(anyhow::anyhow!(
-                    "Timeout waiting for task after {}ms",
-                    self.config.timeout_ms
-                ));
-            }
-            sleep(Duration::from_millis(self.config.polling_interval_ms)).await;
+        let depth = self.queue_depth.fetch_sub(1, Ordering::Relaxed) - 1;
+        if let Some(m) = &self.metrics {
+            m.task_queue_depth.set(depth as i64);
         }
+        Ok(task)
     }
 }
 
 #[async_trait]
-impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningGasKillerCreator<Q> {
+impl Creator for ListeningGasKillerCreator {
     type TaskData = GasKillerTaskData;
 
     async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
@@ -480,7 +355,7 @@ pub enum GasKillerCreatorType {
     /// Basic gas killer creator without ingress
     Basic(GasKillerCreator),
     /// Listening gas killer creator with HTTP ingress
-    Listening(Box<ListeningGasKillerCreator<GasKillerTaskQueue>>),
+    Listening(Box<ListeningGasKillerCreator>),
 }
 
 #[async_trait]
@@ -570,9 +445,9 @@ mod tests {
         // If they fail (no Anvil/RPC), that's expected in unit tests
     }
 
-    #[test]
-    fn test_task_queue_push_pop() {
-        let queue = GasKillerTaskQueue::new();
+    #[tokio::test]
+    async fn test_channel_send_recv() {
+        let (sender, mut receiver) = task_channel();
         let task = GasKillerTaskRequest {
             body: crate::ingress::GasKillerTaskRequestBody {
                 target_address: Address::from([1u8; 20]),
@@ -584,10 +459,10 @@ mod tests {
             },
         };
 
-        queue.push(task.clone());
-        let popped = queue.pop();
-        assert!(popped.is_some());
-        assert_eq!(popped.unwrap().body.transition_index, Some(1));
+        sender.send(task.clone()).unwrap();
+        let received = receiver.try_recv().unwrap();
+        assert_eq!(received.body.transition_index, Some(1));
+        assert!(receiver.try_recv().is_err());
     }
 
     #[test]

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -1,7 +1,7 @@
 use crate::GasKillerHandler;
 use crate::creator::{
     DispatchTime, GasKillerConfig, GasKillerCreator, GasKillerCreatorType,
-    ListeningGasKillerCreator, SimpleTaskQueue,
+    ListeningGasKillerCreator, task_channel, task_queue_depth,
 };
 use crate::ingress::{
     AvsMetadata, AvsOperatorSetMetadata, AvsOperatorSetSoftware, IngressState,
@@ -59,10 +59,17 @@ pub async fn create_listening_creator_with_server(
     metrics: Arc<MetricsCollector>,
     dispatch_time: DispatchTime,
 ) -> anyhow::Result<GasKillerCreatorType> {
-    let queue = SimpleTaskQueue::new();
+    let (sender, receiver) = task_channel();
+    let queue_depth = task_queue_depth();
     let config = GasKillerConfig::default();
-    let creator = ListeningGasKillerCreator::new(queue.clone(), config, validator, dispatch_time)
-        .with_metrics(Arc::clone(&metrics));
+    let creator = ListeningGasKillerCreator::new(
+        receiver,
+        queue_depth.clone(),
+        config,
+        validator,
+        dispatch_time,
+    )
+    .with_metrics(Arc::clone(&metrics));
     let providers = build_ingress_providers().await?;
     let ingress_password = env::var("INGRESS_PASSWORD").ok().filter(|p| !p.is_empty());
     if ingress_password.is_none() {
@@ -70,7 +77,6 @@ pub async fn create_listening_creator_with_server(
             "INGRESS_PASSWORD is not set — /trigger endpoint is unauthenticated; set INGRESS_PASSWORD in production"
         );
     }
-    let queue_arc = Arc::new(queue);
     let operator_sets = {
         let opset_name = env::var("AVS_OPSET_NAME").unwrap_or_default();
         if opset_name.is_empty() {
@@ -111,7 +117,8 @@ pub async fn create_listening_creator_with_server(
         operator_sets,
     };
     let ingress_state = IngressState::new(
-        Arc::clone(&queue_arc),
+        sender,
+        queue_depth,
         metrics,
         providers,
         ingress_password,

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,4 +1,4 @@
-use crate::creator::{SimpleTaskQueue, TaskQueue};
+use crate::creator::{TaskQueueDepth, TaskSender};
 use crate::metrics::MetricsCollector;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use tracing::{info, warn};
 
 /// AVS identity metadata served at `GET /avs-metadata`.
@@ -55,7 +56,8 @@ pub struct AvsOperatorSetSoftware {
 
 #[derive(Clone)]
 pub struct IngressState {
-    pub queue: Arc<SimpleTaskQueue>,
+    pub sender: TaskSender,
+    pub queue_depth: TaskQueueDepth,
     pub metrics: Option<Arc<MetricsCollector>>,
     pub providers: Arc<HashMap<ChainId, ReadOnlyProvider>>,
     /// Bearer token password. `None` disables authentication.
@@ -65,14 +67,16 @@ pub struct IngressState {
 
 impl IngressState {
     pub fn new(
-        queue: Arc<SimpleTaskQueue>,
+        sender: TaskSender,
+        queue_depth: TaskQueueDepth,
         metrics: Arc<MetricsCollector>,
         providers: HashMap<ChainId, ReadOnlyProvider>,
         password: Option<String>,
         avs_metadata: AvsMetadata,
     ) -> Self {
         Self {
-            queue,
+            sender,
+            queue_depth,
             metrics: Some(metrics),
             providers: Arc::new(providers),
             password,
@@ -80,9 +84,10 @@ impl IngressState {
         }
     }
 
-    pub fn without_metrics(queue: Arc<SimpleTaskQueue>) -> Self {
+    pub fn without_metrics(sender: TaskSender, queue_depth: TaskQueueDepth) -> Self {
         Self {
-            queue,
+            sender,
+            queue_depth,
             metrics: None,
             providers: Arc::new(HashMap::new()),
             password: None,
@@ -429,10 +434,20 @@ pub async fn trigger_task_handler(
         call_data_len = request.body.call_data.len(),
         "Task accepted"
     );
-    state.queue.push(request);
+    if state.sender.send(request).is_err() {
+        tracing::error!("task channel closed, dropping request");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(GasKillerTaskResponse {
+                success: false,
+                message: "Internal error: task queue unavailable".to_string(),
+            }),
+        );
+    }
+    let depth = state.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
     if let Some(m) = &state.metrics {
         m.ingress_accepted.inc();
-        m.task_queue_depth.set(state.queue.len() as i64);
+        m.task_queue_depth.set(depth as i64);
     }
     (
         StatusCode::OK,
@@ -643,19 +658,21 @@ mod tests {
         use axum::http::{Method, Request, StatusCode};
         use tower::util::ServiceExt; // for `oneshot`
 
-        fn make_app() -> (Router, Arc<SimpleTaskQueue>) {
-            let queue = Arc::new(SimpleTaskQueue::new());
-            let state = IngressState::without_metrics(queue.clone());
+        fn make_app() -> (Router, crate::creator::TaskReceiver) {
+            let (sender, receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let state = IngressState::without_metrics(sender, queue_depth);
             let app = build_app().with_state(state);
-            (app, queue)
+            (app, receiver)
         }
 
-        fn make_app_with_password(password: &str) -> (Router, Arc<SimpleTaskQueue>) {
-            let queue = Arc::new(SimpleTaskQueue::new());
-            let mut state = IngressState::without_metrics(queue.clone());
+        fn make_app_with_password(password: &str) -> (Router, crate::creator::TaskReceiver) {
+            let (sender, receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let mut state = IngressState::without_metrics(sender, queue_depth);
             state.password = Some(password.to_string());
             let app = build_app().with_state(state);
-            (app, queue)
+            (app, receiver)
         }
 
         fn json_request(body: &str) -> Request<Body> {
@@ -703,7 +720,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_valid_request_returns_200_and_queues_task() {
-            let (app, queue) = make_app();
+            let (app, mut receiver) = make_app();
             let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
 
             assert_eq!(resp.status(), StatusCode::OK);
@@ -711,7 +728,7 @@ mod tests {
             assert!(body.success);
             assert_eq!(body.message, "Task queued");
             assert!(
-                queue.pop().is_some(),
+                receiver.try_recv().is_ok(),
                 "task should have been pushed to queue"
             );
         }
@@ -920,18 +937,25 @@ mod tests {
         #[tokio::test]
         async fn test_valid_request_does_not_leave_extra_tasks() {
             // Two sequential valid requests → queue should hold exactly two tasks
-            let queue = Arc::new(SimpleTaskQueue::new());
-            let app1 = build_app().with_state(IngressState::without_metrics(queue.clone()));
-            let app2 = build_app().with_state(IngressState::without_metrics(queue.clone()));
+            let (sender, mut receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let app1 = build_app().with_state(IngressState::without_metrics(
+                sender.clone(),
+                queue_depth.clone(),
+            ));
+            let app2 = build_app().with_state(IngressState::without_metrics(
+                sender.clone(),
+                queue_depth.clone(),
+            ));
 
             app1.oneshot(json_request(&valid_body())).await.unwrap();
             app2.oneshot(json_request(&valid_body())).await.unwrap();
 
-            assert!(queue.pop().is_some());
-            assert!(queue.pop().is_some());
+            assert!(receiver.try_recv().is_ok());
+            assert!(receiver.try_recv().is_ok());
             assert!(
-                queue.pop().is_none(),
-                "queue should be empty after two pops"
+                receiver.try_recv().is_err(),
+                "queue should be empty after two recvs"
             );
         }
 
@@ -993,8 +1017,9 @@ mod tests {
 
         #[tokio::test]
         async fn test_avs_metadata_returns_200_with_valid_json() {
-            let queue = Arc::new(SimpleTaskQueue::new());
-            let mut state = IngressState::without_metrics(queue.clone());
+            let (sender, _receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let mut state = IngressState::without_metrics(sender, queue_depth);
             state.avs_metadata = AvsMetadata {
                 name: "Gas Killer".to_string(),
                 website: "https://gaskiller.xyz".to_string(),
@@ -1036,7 +1061,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_rejected_request_does_not_enqueue() {
-            let (app, queue) = make_app();
+            let (app, mut receiver) = make_app();
             let payload = serde_json::json!({
                 "body": {
                     "target_address": "0x0000000000000000000000000000000000000000",
@@ -1051,7 +1076,7 @@ mod tests {
 
             app.oneshot(json_request(&payload)).await.unwrap();
             assert!(
-                queue.pop().is_none(),
+                receiver.try_recv().is_err(),
                 "invalid task must not be pushed to queue"
             );
         }

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -434,7 +434,9 @@ pub async fn trigger_task_handler(
         call_data_len = request.body.call_data.len(),
         "Task accepted"
     );
+    let depth = state.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
     if state.sender.send(request).is_err() {
+        state.queue_depth.fetch_sub(1, Ordering::Relaxed);
         tracing::error!("task channel closed, dropping request");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -444,7 +446,6 @@ pub async fn trigger_task_handler(
             }),
         );
     }
-    let depth = state.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
     if let Some(m) = &state.metrics {
         m.ingress_accepted.inc();
         m.task_queue_depth.set(depth as i64);

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -94,9 +94,9 @@ echo "Environment configuration complete"
 echo -e "${YELLOW}Step 3: Pulling Docker images...${NC}"
 docker compose pull
 
-# Step 4: Build router image
-echo -e "${YELLOW}Step 4: Building router Docker image...${NC}"
-docker compose build router
+# Step 4: Build service images
+echo -e "${YELLOW}Step 4: Building service Docker images...${NC}"
+docker compose build
 
 # Step 5: Start Docker Compose services
 echo -e "${YELLOW}Step 5: Starting Docker Compose services...${NC}"


### PR DESCRIPTION
## Summary

- Replaces `GasKillerTaskQueue` (`Mutex<Vec<T>>` + 100ms busy-poll loop) with a `tokio::sync::mpsc::UnboundedSender/Receiver` pair
- Eliminates up to 100ms of artificial latency per round introduced by the polling sleep
- Fixes a blocking-in-async anti-pattern: `std::thread::sleep(1ms)` inside `try_lock_with_timeout` was parking the OS thread inside the tokio executor, starving co-located tasks
- Removes the `TaskQueue` trait and `GasKillerTaskQueue` struct; `ListeningGasKillerCreator` is no longer generic
- Maintains the `task_queue_depth` metric gauge via a shared `Arc<AtomicUsize>` incremented on send and decremented on receive

## How it works

`ingress::trigger_task_handler` pushes tasks via `UnboundedSender::send`. `ListeningGasKillerCreator::wait_for_task` calls `receiver.recv().await` — zero spin, zero sleep, wakes instantly when a task arrives. A configurable `timeout_ms` (via `INGRESS_TIMEOUT_MS`) is applied with `tokio::time::timeout` when set; `0` means wait indefinitely.

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo check`, `cargo test` all pass (56/56 tests)
- [x] All existing ingress HTTP handler tests updated to use `receiver.try_recv()` in place of `queue.pop()`
- [x] `test_task_queue_push_pop` replaced with `test_channel_send_recv` covering the new mechanism

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)