### PR TITLE
Deploy the smoke-test target via a Helm job and auto-resolve it in `run_scenario`

### DIFF
--- a/helm/gas-killer/mainnet-overrides.yaml
+++ b/helm/gas-killer/mainnet-overrides.yaml
@@ -42,13 +42,6 @@ eigenlayer:
     thresholdDenominator: "3"
     blockStaleMeasure: "300"
 
-<<<<<<< Updated upstream
-secretManager:
-  enabled: true
-  keyPrefix: "gas-killer-mainnet"
-
-=======
->>>>>>> Stashed changes
 ingress:
   enabled: true
   host: mainnet.gaskiller.xyz

--- a/helm/gas-killer/mainnet-overrides.yaml
+++ b/helm/gas-killer/mainnet-overrides.yaml
@@ -19,6 +19,12 @@ global:
 imagePullSecrets:
   - name: ghcr-pull-secret
 
+secretManager:
+  enabled: true
+  projectId: gas-killer-mainnet
+  keyPrefix: gas-killer-mainnet
+  gcpServiceAccount: gas-killer-app@gas-killer-mainnet.iam.gserviceaccount.com
+
 eigenlayer:
   contracts:
     delegationManager: "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A"
@@ -36,10 +42,13 @@ eigenlayer:
     thresholdDenominator: "3"
     blockStaleMeasure: "300"
 
+<<<<<<< Updated upstream
 secretManager:
   enabled: true
   keyPrefix: "gas-killer-mainnet"
 
+=======
+>>>>>>> Stashed changes
 ingress:
   enabled: true
   host: mainnet.gaskiller.xyz

--- a/helm/gas-killer/templates/_helpers.tpl
+++ b/helm/gas-killer/templates/_helpers.tpl
@@ -130,6 +130,13 @@ Bridge job name
 {{- end }}
 
 {{/*
+Deploy-target job name
+*/}}
+{{- define "gas-killer.deployTarget.fullname" -}}
+{{- printf "%s-deploy-target" (include "gas-killer.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 L2 service name
 */}}
 {{- define "gas-killer.l2.fullname" -}}

--- a/helm/gas-killer/templates/deploy-target-job.yaml
+++ b/helm/gas-killer/templates/deploy-target-job.yaml
@@ -1,12 +1,7 @@
 {{- /*
-Deploy-target job: deploys a demo GasKillerSDK target (ArraySummation) wired to a REAL
-BLSSignatureChecker against the freshly-deployed AVS, then publishes its address to a
-ConfigMap for the local smoke test. Runs after setup; opt-in via deployTarget.enabled.
-
-Why this exists: the on-chain checker a target calls checkSignatures on must NOT be the
-BLSSigCheckOperatorStateRetriever (avs_deploy.json -> blsSigCheck, the router's off-chain
-helper). The enhanced ArraySummation.s.sol deploys a fresh checker bound to the registry
-coordinator when SIG_CHECKER_ADDRESS is unset, so the target is correct-by-construction.
+Deploy-target job: deploys a demo GasKillerSDK target (ArraySummation) against the
+freshly-deployed AVS and publishes its address to a ConfigMap for the local smoke test.
+Runs after setup; opt-in via deployTarget.enabled.
 */ -}}
 {{- if and .Values.deployTarget.enabled (or .Release.IsInstall .Values.rerun.deployTarget) }}
 apiVersion: batch/v1
@@ -58,7 +53,7 @@ spec:
               mountPath: /app/.nodes
               readOnly: true
 
-        # 2. Deploy the target (+ a fresh real checker) and write its address to the PVC.
+        # 2. Deploy the target and write its address to the PVC.
         #    Runs as an initContainer so a transient publish failure does NOT redeploy.
         - name: deploy
           image: "{{ .Values.deployTarget.image.repository }}:{{ required "deployTarget.image.tag must be set" .Values.deployTarget.image.tag }}"
@@ -70,7 +65,7 @@ spec:
               set -euo pipefail
               AVS_JSON=/app/.nodes/avs_deploy.json
 
-              # Registry coordinator is what the checker must bind to; service manager is the AVS namespace.
+              # Registry coordinator and service manager (AVS) addresses read from avs_deploy.json.
               export REGISTRY_COORDINATOR_ADDRESS=$(jq -r '.addresses.registryCoordinator // .addresses.RegistryCoordinator' "$AVS_JSON")
               export AVS_ADDRESS=$(jq -r '.addresses.IncredibleSquaringServiceManager // .addresses.avsServiceManagerWrapper' "$AVS_JSON")
               export ARRAY_SIZE={{ .Values.deployTarget.arraySize | quote }}
@@ -82,8 +77,7 @@ spec:
                 echo "ERROR: registryCoordinator not found in $AVS_JSON"; jq '.addresses' "$AVS_JSON"; exit 1
               fi
 
-              # SIG_CHECKER_ADDRESS intentionally unset -> the script deploys a fresh
-              # BLSSignatureChecker bound to REGISTRY_COORDINATOR_ADDRESS and asserts the wiring.
+              # SIG_CHECKER_ADDRESS intentionally unset -> the script provisions one from REGISTRY_COORDINATOR_ADDRESS.
               set +e
               OUT=$(forge script script/ArraySummation.s.sol:ArraySummationScript \
                 --rpc-url "$HTTP_RPC" --private-key "$PRIVATE_KEY" --broadcast 2>&1)

--- a/helm/gas-killer/templates/deploy-target-job.yaml
+++ b/helm/gas-killer/templates/deploy-target-job.yaml
@@ -1,0 +1,146 @@
+{{- /*
+Deploy-target job: deploys a demo GasKillerSDK target (ArraySummation) wired to a REAL
+BLSSignatureChecker against the freshly-deployed AVS, then publishes its address to a
+ConfigMap for the local smoke test. Runs after setup; opt-in via deployTarget.enabled.
+
+Why this exists: the on-chain checker a target calls checkSignatures on must NOT be the
+BLSSigCheckOperatorStateRetriever (avs_deploy.json -> blsSigCheck, the router's off-chain
+helper). The enhanced ArraySummation.s.sol deploys a fresh checker bound to the registry
+coordinator when SIG_CHECKER_ADDRESS is unset, so the target is correct-by-construction.
+*/ -}}
+{{- if and .Values.deployTarget.enabled (or .Release.IsInstall .Values.rerun.deployTarget) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "gas-killer.deployTarget.fullname" . }}
+  labels:
+    {{- include "gas-killer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: deploy-target
+  annotations:
+    # Runs automatically on helm install. On helm upgrade, only fires when rerun.deployTarget=true.
+    "helm.sh/resource-policy": keep
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "gas-killer.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: deploy-target
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "gas-killer.deployTarget.fullname" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        # 1. Wait for setup to complete (avs_deploy.json must exist)
+        - name: wait-for-setup
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for setup to complete (timeout: {{ .Values.global.initTimeout }}s)..."
+              TIMEOUT={{ .Values.global.initTimeout }}
+              ELAPSED=0
+              until [ -f /app/.nodes/.setup_complete ] && [ -f /app/.nodes/avs_deploy.json ]; do
+                if [ $ELAPSED -ge $TIMEOUT ]; then
+                  echo "ERROR: Timeout waiting for setup after ${TIMEOUT}s"; exit 1
+                fi
+                echo "Setup not complete, waiting for .setup_complete + avs_deploy.json... (${ELAPSED}s elapsed)"
+                sleep 10; ELAPSED=$((ELAPSED + 10))
+              done
+              echo "Setup complete! avs_deploy.json found."
+          volumeMounts:
+            - name: shared-data
+              mountPath: /app/.nodes
+              readOnly: true
+
+        # 2. Deploy the target (+ a fresh real checker) and write its address to the PVC.
+        #    Runs as an initContainer so a transient publish failure does NOT redeploy.
+        - name: deploy
+          image: "{{ .Values.deployTarget.image.repository }}:{{ required "deployTarget.image.tag must be set" .Values.deployTarget.image.tag }}"
+          imagePullPolicy: {{ .Values.deployTarget.image.pullPolicy }}
+          workingDir: /sdk
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              AVS_JSON=/app/.nodes/avs_deploy.json
+
+              # Registry coordinator is what the checker must bind to; service manager is the AVS namespace.
+              export REGISTRY_COORDINATOR_ADDRESS=$(jq -r '.addresses.registryCoordinator // .addresses.RegistryCoordinator' "$AVS_JSON")
+              export AVS_ADDRESS=$(jq -r '.addresses.IncredibleSquaringServiceManager // .addresses.avsServiceManagerWrapper' "$AVS_JSON")
+              export ARRAY_SIZE={{ .Values.deployTarget.arraySize | quote }}
+              export MAX_VALUE={{ .Values.deployTarget.maxValue | quote }}
+              export ARRAY_SEED={{ .Values.deployTarget.arraySeed | quote }}
+
+              echo "[deploy-target] RC=$REGISTRY_COORDINATOR_ADDRESS AVS=$AVS_ADDRESS"
+              if [ -z "$REGISTRY_COORDINATOR_ADDRESS" ] || [ "$REGISTRY_COORDINATOR_ADDRESS" = "null" ]; then
+                echo "ERROR: registryCoordinator not found in $AVS_JSON"; jq '.addresses' "$AVS_JSON"; exit 1
+              fi
+
+              # SIG_CHECKER_ADDRESS intentionally unset -> the script deploys a fresh
+              # BLSSignatureChecker bound to REGISTRY_COORDINATOR_ADDRESS and asserts the wiring.
+              set +e
+              OUT=$(forge script script/ArraySummation.s.sol:ArraySummationScript \
+                --rpc-url "$HTTP_RPC" --private-key "$PRIVATE_KEY" --broadcast 2>&1)
+              CODE=$?
+              set -e
+              echo "$OUT"
+              [ $CODE -ne 0 ] && { echo "ERROR: forge script failed ($CODE)"; exit 1; }
+
+              TARGET=$(echo "$OUT" | grep -oE 'DEPLOYED_TARGET=0x[0-9a-fA-F]{40}' | tail -1 | cut -d= -f2)
+              if [ -z "$TARGET" ]; then
+                echo "ERROR: could not parse DEPLOYED_TARGET from forge output"; exit 1
+              fi
+              echo "[deploy-target] deployed target=$TARGET"
+              printf '%s' "$TARGET" > /app/.nodes/demo_target.txt
+              chmod 644 /app/.nodes/demo_target.txt
+          env:
+            - name: PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gas-killer.secret.fullname" . }}
+                  key: {{ .Values.deployTarget.deployerSecretKey | default "PRIVATE_KEY" }}
+            - name: HTTP_RPC
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gas-killer.secret.fullname" . }}
+                  key: HTTP_RPC
+          volumeMounts:
+            - name: shared-data
+              mountPath: /app/.nodes
+          resources:
+            {{- toYaml .Values.deployTarget.resources | nindent 12 }}
+
+      containers:
+        # 3. Publish the deployed address to a ConfigMap for the local smoke test.
+        - name: publish
+          image: "{{ .Values.deployTarget.kubectlImage }}"
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              TARGET=$(cat /app/.nodes/demo_target.txt)
+              echo "Publishing target $TARGET to ConfigMap {{ .Values.deployTarget.configMapName }} (ns {{ .Release.Namespace }})"
+              kubectl create configmap {{ .Values.deployTarget.configMapName }} \
+                --from-literal=target="$TARGET" \
+                --namespace {{ .Release.Namespace }} \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "Done. Read it locally with:"
+              echo "  kubectl get configmap {{ .Values.deployTarget.configMapName }} -o jsonpath='{.data.target}'"
+          volumeMounts:
+            - name: shared-data
+              mountPath: /app/.nodes
+              readOnly: true
+          resources:
+            {{- toYaml .Values.deployTarget.resources | nindent 12 }}
+
+      volumes:
+        - name: shared-data
+          persistentVolumeClaim:
+            claimName: {{ include "gas-killer.shareddata.fullname" . }}
+{{- end }}

--- a/helm/gas-killer/templates/deploy-target-rbac.yaml
+++ b/helm/gas-killer/templates/deploy-target-rbac.yaml
@@ -1,0 +1,42 @@
+{{- /*
+RBAC for the deploy-target job's "publish" step: a plain Kubernetes ServiceAccount
+allowed to write the address ConfigMap in this namespace. Separate from the
+secretManager Workload-Identity SA — this job needs the k8s API, not GCP.
+*/ -}}
+{{- if and .Values.deployTarget.enabled (or .Release.IsInstall .Values.rerun.deployTarget) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gas-killer.deployTarget.fullname" . }}
+  labels:
+    {{- include "gas-killer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: deploy-target
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gas-killer.deployTarget.fullname" . }}
+  labels:
+    {{- include "gas-killer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: deploy-target
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gas-killer.deployTarget.fullname" . }}
+  labels:
+    {{- include "gas-killer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: deploy-target
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gas-killer.deployTarget.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "gas-killer.deployTarget.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/gas-killer/testnet-overrides.yaml
+++ b/helm/gas-killer/testnet-overrides.yaml
@@ -42,13 +42,6 @@ eigenlayer:
     thresholdDenominator: "3"
     blockStaleMeasure: "300"
 
-<<<<<<< Updated upstream
-secretManager:
-  enabled: true
-  keyPrefix: "gas-killer-testnet"
-
-=======
->>>>>>> Stashed changes
 ingress:
   enabled: true
   host: testnet.gaskiller.xyz

--- a/helm/gas-killer/testnet-overrides.yaml
+++ b/helm/gas-killer/testnet-overrides.yaml
@@ -19,6 +19,12 @@ global:
 imagePullSecrets:
   - name: ghcr-pull-secret
 
+secretManager:
+  enabled: true
+  projectId: gas-killer-testnet
+  keyPrefix: gas-killer-testnet
+  gcpServiceAccount: gas-killer-app@gas-killer-testnet.iam.gserviceaccount.com
+
 eigenlayer:
   contracts:
     delegationManager: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"
@@ -36,10 +42,13 @@ eigenlayer:
     thresholdDenominator: "3"
     blockStaleMeasure: "300"
 
+<<<<<<< Updated upstream
 secretManager:
   enabled: true
   keyPrefix: "gas-killer-testnet"
 
+=======
+>>>>>>> Stashed changes
 ingress:
   enabled: true
   host: testnet.gaskiller.xyz
@@ -54,3 +63,18 @@ monitoring:
 router:
   ingress:
     timeoutMs: "0"
+
+# Deploy the smoke-test target (ArraySummation) wired to a real BLSSignatureChecker after
+# AVS setup, then publish its address to a ConfigMap. Read it for the local smoke test:
+#   kubectl get configmap gas-killer-smoke-target -o jsonpath='{.data.target}'
+deployTarget:
+  enabled: true
+  image:
+    # `latest` is published on pushes to main (solidity-sdk docker-publish workflow).
+    # Pin with --set deployTarget.image.tag=<sha> if you need a specific build.
+    tag: latest
+  configMapName: gas-killer-smoke-target
+  # ArraySummation params (smoke test sums indexes [1,2,3], so arraySize must be >= 4).
+  arraySize: 10
+  maxValue: 10000
+  arraySeed: 1

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -67,6 +67,8 @@ rerun:
   setup: false
   bridge: false
   keyExport: false
+  # Re-run the deploy-target job to deploy a fresh demo target + checker against the current AVS.
+  deployTarget: false
   # Re-run the generate-router-key job (TESTNET+secretManager only).
   # Only set this if you intentionally want to rotate the router BLS keypair —
   # doing so requires all nodes to restart and pick up the new public key from GCP.
@@ -356,6 +358,35 @@ bridge:
     limits:
       memory: "1Gi"
       cpu: "500m"
+
+# Deploy-target job: deploys a demo GasKillerSDK target (ArraySummation) wired to a real
+# BLSSignatureChecker against the freshly-deployed AVS, then publishes its address to a
+# ConfigMap for the local smoke test. Opt-in (off by default; enable on testnet).
+deployTarget:
+  enabled: false
+  image:
+    # Built from gas-killer/solidity-sdk (forge + the SDK contracts). Tag must be set at deploy.
+    repository: ghcr.io/gas-killer/solidity-sdk
+    tag: ""
+    pullPolicy: IfNotPresent
+  # Image used by the publish step to write the ConfigMap (needs kubectl + a shell).
+  # Alpine-based (has /bin/sh for the apply pipe); bitnami/kubectl was retired from Docker Hub.
+  kubectlImage: "alpine/kubectl:1.33.4"
+  # ConfigMap that receives the deployed target address under key "target".
+  configMapName: gas-killer-smoke-target
+  # Secret key (in the app secret) holding the funded deployer key: PRIVATE_KEY or FUNDED_KEY.
+  deployerSecretKey: PRIVATE_KEY
+  # ArraySummation constructor params. Smoke test sums indexes [1,2,3], so arraySize must be >= 4.
+  arraySize: 10
+  maxValue: 10000
+  arraySeed: 1
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "250m"
 
 # Yield Distribution test configuration - only used in LOCAL mode with l2.enabled
 # Defaults to disabled; enable explicitly via --set yieldDistribution.enabled=true (e.g. in CI)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,7 +111,7 @@ An annotated example config lives at `scripts/scenarios/example.toml`.
 | Field | Required | Default | Description |
 |---|---|---|---|
 | `label` | No | `request N` | Human-readable label for output |
-| `target_address` | Yes | — | Contract address to call |
+| `target_address` | Yes | — | Contract address to call, or `"kubectl"` to resolve it at runtime from the `gas-killer-smoke-target` ConfigMap via `kubectl` (also accepts `"kubectl:<configmap>[/<key>]"`; namespace follows the current kube-context unless `SMOKE_TARGET_NAMESPACE` is set) |
 | `call_data` | Yes | — | ABI-encoded calldata as a `0x`-prefixed hex string |
 | `from_address` | Yes | — | Sender address |
 | `transition_index` | No | `"auto"` | State transition sequence number, or `"auto"` to fetch `stateTransitionCount()` from the contract (requires `http_rpc`) |

--- a/scripts/run_scenario.rs
+++ b/scripts/run_scenario.rs
@@ -4,6 +4,7 @@ use gas_killer_common::ReadOnlyProvider;
 use gas_killer_common::bindings::gaskillersdk::GasKillerSDK;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -561,6 +562,62 @@ fn interpolate_env(s: &str) -> Result<String, String> {
     Ok(out)
 }
 
+/// Parse a `kubectl` target_address sentinel into `(configmap, key)`.
+///
+/// Returns `None` for any other value (i.e. a literal address). Supported forms:
+///   "kubectl"                    → configmap "gas-killer-smoke-target", key "target"
+///   "kubectl:<configmap>"        → key "target"
+///   "kubectl:<configmap>/<key>"
+fn parse_kubectl_sentinel(value: &str) -> Option<(String, String)> {
+    let rest = if value == "kubectl" {
+        ""
+    } else {
+        value.strip_prefix("kubectl:")?
+    };
+    let (configmap, key) = if rest.is_empty() {
+        ("gas-killer-smoke-target", "target")
+    } else if let Some((cm, k)) = rest.split_once('/') {
+        (cm, k)
+    } else {
+        (rest, "target")
+    };
+    Some((configmap.to_string(), key.to_string()))
+}
+
+/// Read a value from a Kubernetes ConfigMap via the local `kubectl`.
+/// Namespace follows the current kube-context unless `SMOKE_TARGET_NAMESPACE` is set.
+fn fetch_configmap_value(configmap: &str, key: &str) -> Result<String, String> {
+    let mut cmd = std::process::Command::new("kubectl");
+    cmd.args([
+        "get",
+        "configmap",
+        configmap,
+        "-o",
+        &format!("jsonpath={{.data.{key}}}"),
+    ]);
+    if let Ok(ns) = std::env::var("SMOKE_TARGET_NAMESPACE")
+        && !ns.is_empty()
+    {
+        cmd.args(["-n", &ns]);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to run kubectl (is it installed and on PATH?): {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "`kubectl get configmap {configmap}` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        return Err(format!(
+            "configmap '{configmap}' has no value at key '{key}' — has the deploy-target job run?"
+        ));
+    }
+    Ok(value)
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -606,6 +663,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if config.scenarios.is_empty() {
         eprintln!("No scenarios defined in config.");
         std::process::exit(1);
+    }
+
+    // Resolve any `kubectl` target_address sentinels to live addresses from a ConfigMap.
+    // The deploy-target job publishes the smoke target to `gas-killer-smoke-target`, so the
+    // toml can carry `target_address = "kubectl"` instead of a hardcoded address. Resolved
+    // once per distinct sentinel so repeated requests don't re-shell out.
+    {
+        let mut cache: HashMap<String, String> = HashMap::new();
+        for scenario in &mut config.scenarios {
+            for req in &mut scenario.requests {
+                let Some((configmap, key)) = parse_kubectl_sentinel(&req.target_address) else {
+                    continue;
+                };
+                let sentinel = req.target_address.clone();
+                let resolved = match cache.get(&sentinel) {
+                    Some(v) => v.clone(),
+                    None => {
+                        let v = fetch_configmap_value(&configmap, &key)
+                            .map_err(|e| format!("resolving target_address \"{sentinel}\": {e}"))?;
+                        v.parse::<Address>().map_err(|e| {
+                            format!(
+                                "target_address \"{sentinel}\" resolved to {v:?}, not a valid address: {e}"
+                            )
+                        })?;
+                        println!("Resolved target_address \"{sentinel}\" → {v}");
+                        cache.insert(sentinel.clone(), v.clone());
+                        v
+                    }
+                };
+                req.target_address = resolved;
+            }
+        }
     }
 
     let needs_rpc = config

--- a/scripts/run_scenario.rs
+++ b/scripts/run_scenario.rs
@@ -588,12 +588,14 @@ fn parse_kubectl_sentinel(value: &str) -> Option<(String, String)> {
 /// Namespace follows the current kube-context unless `SMOKE_TARGET_NAMESPACE` is set.
 fn fetch_configmap_value(configmap: &str, key: &str) -> Result<String, String> {
     let mut cmd = std::process::Command::new("kubectl");
+    // Bracket notation so keys containing '.' or '-' (valid ConfigMap key chars) are taken
+    // literally instead of being misparsed as nested fields by kubectl's jsonpath.
     cmd.args([
         "get",
         "configmap",
         configmap,
         "-o",
-        &format!("jsonpath={{.data.{key}}}"),
+        &format!("jsonpath={{.data['{key}']}}"),
     ]);
     if let Ok(ns) = std::env::var("SMOKE_TARGET_NAMESPACE")
         && !ns.is_empty()

--- a/scripts/scenarios/testnet_smoke.toml
+++ b/scripts/scenarios/testnet_smoke.toml
@@ -4,7 +4,7 @@
 #   cargo run -p scripts --bin run_scenario -- scripts/scenarios/testnet_smoke.toml
 
 router_url = "https://testnet.gaskiller.xyz"
-http_rpc   = "$FORK_URL"
+http_rpc   = "$HTTP_RPC"
 
 # ── Serial smoke test with on-chain verification ─────────────────
 [[scenarios]]

--- a/scripts/scenarios/testnet_smoke.toml
+++ b/scripts/scenarios/testnet_smoke.toml
@@ -4,7 +4,7 @@
 #   cargo run -p scripts --bin run_scenario -- scripts/scenarios/testnet_smoke.toml
 
 router_url = "https://testnet.gaskiller.xyz"
-http_rpc   = "$GNOSIS_RPC_URL"
+http_rpc   = "$FORK_URL"
 
 # ── Serial smoke test with on-chain verification ─────────────────
 [[scenarios]]
@@ -14,7 +14,10 @@ delay_between_ms = 0
 
   [[scenarios.requests]]
   label               = "array_summation_sum"
-  target_address      = "0x5DC77FCc9E71F3A0DD0EffC144B697B74F5C5287"
+  # "kubectl" resolves to the address the deploy-target job published in the
+  # gas-killer-smoke-target ConfigMap. Use a literal 0x… address to pin a target,
+  # or "kubectl:<configmap>[/<key>]" to point at a different ConfigMap.
+  target_address      = "kubectl"
   call_data           = "0194db8e00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003"   # ABI-encoded calldata (function selector + params)
   from_address        = "0xff467a85932cF543Df50255f00A8A829c12a3A11"
   transition_index    = "auto"


### PR DESCRIPTION
## What

Automate deploying the smoke-test target and wiring the smoke test to it, so a fresh testnet deploy needs neither a hand-deployed contract nor a hardcoded address.

- **`deploy-target` Helm job** (`templates/deploy-target-job.yaml` + `deploy-target-rbac.yaml`) — runs after AVS setup. It deploys an `ArraySummation` demo target against the freshly-deployed AVS (self-deploying a **real** `BLSSignatureChecker` for it), then publishes the deployed address to the `gas-killer-smoke-target` ConfigMap. Opt-in via `deployTarget.enabled`; gated to run on install or an explicit `rerun.deployTarget=true`.
- **`run_scenario` kubectl resolution** — `target_address = "kubectl"` in a scenario now resolves at runtime from the `gas-killer-smoke-target` ConfigMap. Also accepts `kubectl:<configmap>[/<key>]`; namespace follows the current kube-context unless `SMOKE_TARGET_NAMESPACE` is set. `testnet_smoke.toml` uses it, so the smoke test always hits the current target with no manual edit.
- **values / overrides** — a `deployTarget` config block (image, `arraySize`/`maxValue`/`arraySeed`, `configMapName`, publish image), `rerun.deployTarget`, and `testnet-overrides.yaml` enables it with `image.tag: latest`.
- **`scripts/README.md`** — documents the `kubectl` `target_address` form in the scenario config reference.

## Why

On a fresh AVS deploy the demo target must be (re)deployed and wired to a **real** `BLSSignatureChecker` — pointing it at the wrong contract (e.g. the `blsSigCheck` OperatorStateRetriever) makes `verifyAndUpdate` revert with an empty `0x`. This job makes that correct-by-construction and removes the manual "deploy a contract, then paste its address into the smoke test" step.

## How it's used

```bash
# the job publishes the deployed target here:
kubectl get configmap gas-killer-smoke-target -o jsonpath='{.data.target}'

# the toml's target_address = "kubectl" resolves it automatically:
cargo run -p scripts --bin run_scenario -- scripts/scenarios/testnet_smoke.toml
```

## Notes

- Requires the solidity-sdk deploy image (`ghcr.io/gas-killer/solidity-sdk`) — companion PR gas-killer/solidity-sdk#41. The image must be published before the job is enabled.
