### PR TITLE
Replace on-chain `getMessageHash` RPC with local payload-hash check

### DIFF
--- a/common/src/task_data.rs
+++ b/common/src/task_data.rs
@@ -1,11 +1,15 @@
 //! Task data types for the Gas Killer AVS
 
 use alloy::primitives::FixedBytes;
+use alloy::sol_types::SolValue;
 use alloy_primitives::{Address, U256};
 use anyhow::Result;
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Read, ReadExt, Write};
+use commonware_cryptography::sha256::Digest;
+use commonware_cryptography::{Hasher, Sha256};
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 /// Task data specific to the gas killer use case
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -63,6 +67,75 @@ impl GasKillerTaskData {
             ));
         }
         Ok(())
+    }
+
+    /// Builds the payload hash for this task from the given storage updates.
+    ///
+    /// Matches the on-chain `expectedHash` from `GasKillerSDK.verifyAndUpdate` (returned by
+    /// `getMessageHash`):
+    ///
+    /// ```solidity
+    /// sha256(abi.encode(transitionIndex, address(this), targetFunction, storageUpdates))
+    /// ```
+    ///
+    /// `storage_updates` is a separate argument because the validator hashes the storage updates
+    /// it recomputes via EVMSketch.
+    pub fn build_payload_hash(&self, storage_updates: &[u8]) -> Digest {
+        let selector = self.function_selector();
+
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            // Debug: hash the full storage_updates so divergent inputs are detectable from logs.
+            let mut storage_hasher = Sha256::new();
+            storage_hasher.update(storage_updates);
+            let storage_hash = storage_hasher.finalize();
+            let storage_hash_hex: String = storage_hash
+                .iter()
+                .take(8)
+                .map(|b| format!("{b:02x}"))
+                .collect();
+
+            debug!(
+                transition_index = self.transition_index,
+                target_address = %self.target_address,
+                target_function = %selector,
+                storage_updates_len = storage_updates.len(),
+                storage_updates_hash = %storage_hash_hex,
+                "build_payload_hash inputs"
+            );
+        }
+
+        // Build flattened ABI encoding matching
+        // abi.encode(transitionIndex, address(this), selector, storageUpdates).
+        // Heads (32 bytes each)
+        let head_transition = U256::from(self.transition_index).abi_encode();
+        let head_address = self.target_address.abi_encode();
+        let head_selector = selector.abi_encode();
+        // Offset to the dynamic bytes tail: 4 words (3 static + 1 offset) = 0x80
+        let head_offset = U256::from(32u64 * 4u64).abi_encode();
+
+        // Tail for dynamic bytes: length (u256) + data + padding
+        let mut tail = Vec::with_capacity(32 + storage_updates.len() + 31);
+        tail.extend_from_slice(&U256::from(storage_updates.len()).abi_encode());
+        tail.extend_from_slice(storage_updates);
+        let pad_len = (32 - (storage_updates.len() % 32)) % 32;
+        if pad_len > 0 {
+            tail.extend(std::iter::repeat_n(0u8, pad_len));
+        }
+
+        // Concatenate head and tail into final payload
+        let mut payload = Vec::with_capacity(32 * 4 + tail.len());
+        payload.extend_from_slice(&head_transition);
+        payload.extend_from_slice(&head_address);
+        payload.extend_from_slice(&head_selector);
+        payload.extend_from_slice(&head_offset);
+        payload.extend_from_slice(&tail);
+
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        let payload_hash = hasher.finalize();
+
+        debug!("Built payload hash: {:?}", payload_hash);
+        payload_hash
     }
 }
 

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -1,10 +1,7 @@
-use alloy::primitives::U256;
-use alloy::sol_types::SolValue;
 use alloy_provider::Provider;
 use anyhow::Result;
 use commonware_codec::Read;
 use commonware_cryptography::sha256::Digest;
-use commonware_cryptography::{Hasher, Sha256};
 use prometheus_client::encoding::text::encode;
 use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
@@ -323,7 +320,7 @@ impl GasKillerValidator {
     /// the orchestrator's validator can skip running EVMSketch again when verifying each incoming
     /// node signature for the same round.
     pub async fn prime_cache(&self, task_data: &GasKillerTaskData, storage_updates: &[u8]) {
-        let digest = self.build_payload_hash(task_data, storage_updates);
+        let digest = task_data.build_payload_hash(storage_updates);
         let cache_key = (task_data.transition_index, task_data.block_height);
         let mut cache = self.digest_cache.lock().await;
         cache.insert(cache_key, digest);
@@ -332,68 +329,6 @@ impl GasKillerValidator {
             block_height = task_data.block_height,
             "Primed validator digest cache from creator (verification will skip EVMSketch)"
         );
-    }
-
-    /// Builds the payload hash from task data and storage updates
-    ///
-    /// This method must produce the same hash as the on-chain expectedHash
-    /// in GasKillerSDK.verifyAndUpdate to ensure consensus consistency.
-    fn build_payload_hash(&self, task_data: &GasKillerTaskData, storage_updates: &[u8]) -> Digest {
-        // IMPORTANT: This hash must match the on-chain expectedHash in GasKillerSDK.verifyAndUpdate:
-        // sha256(abi.encode(transitionIndex, address(this), targetFunction, storageUpdates))
-
-        let selector = task_data.function_selector();
-
-        // Debug: Log hash of full storage_updates to detect any differences
-        let mut storage_hasher = Sha256::new();
-        storage_hasher.update(storage_updates);
-        let storage_hash = storage_hasher.finalize();
-        let storage_hash_hex: String = storage_hash
-            .iter()
-            .take(8)
-            .map(|b| format!("{:02x}", b))
-            .collect();
-
-        debug!(
-            transition_index = task_data.transition_index,
-            target_address = %task_data.target_address,
-            target_function = %selector,
-            storage_updates_len = storage_updates.len(),
-            storage_updates_hash = %storage_hash_hex,
-            "Validator build_payload_hash inputs"
-        );
-
-        // Build flattened ABI encoding matching abi.encode(transitionIndex, address(this), selector, storageUpdates)
-        // Heads (32 bytes each)
-        let head_transition = U256::from(task_data.transition_index).abi_encode();
-        let head_address = task_data.target_address.abi_encode();
-        let head_selector = selector.abi_encode();
-        // Offset to the dynamic bytes tail: 4 words (3 static + 1 offset) = 0x80
-        let head_offset = U256::from(32u64 * 4u64).abi_encode();
-
-        // Tail for dynamic bytes: length (u256) + data + padding
-        let mut tail = Vec::with_capacity(32 + storage_updates.len() + 31);
-        tail.extend_from_slice(&U256::from(storage_updates.len()).abi_encode());
-        tail.extend_from_slice(storage_updates);
-        let pad_len = (32 - (storage_updates.len() % 32)) % 32;
-        if pad_len > 0 {
-            tail.extend(std::iter::repeat_n(0u8, pad_len));
-        }
-
-        // Concatenate head and tail into final payload
-        let mut payload = Vec::with_capacity(32 * 4 + tail.len());
-        payload.extend_from_slice(&head_transition);
-        payload.extend_from_slice(&head_address);
-        payload.extend_from_slice(&head_selector);
-        payload.extend_from_slice(&head_offset);
-        payload.extend_from_slice(&tail);
-
-        let mut hasher = Sha256::new();
-        hasher.update(&payload);
-        let payload_hash = hasher.finalize();
-
-        debug!("Built payload hash: {:?}", payload_hash);
-        payload_hash
     }
 
     /// Performs the core gas analysis using gas-analyzer.
@@ -531,7 +466,7 @@ impl GasKillerValidator {
         let storage_updates = self.compute_storage_updates(task_data).await?;
 
         // Build expected payload hash using computed storage updates
-        let payload_hash = self.build_payload_hash(task_data, &storage_updates);
+        let payload_hash = task_data.build_payload_hash(&storage_updates);
 
         // Store in cache for subsequent calls with the same round
         {
@@ -644,12 +579,11 @@ mod tests {
 
     #[test]
     fn test_build_payload_hash_deterministic() {
-        let validator = GasKillerValidator::with_rpc_url("https://ethereum-sepolia.publicnode.com");
         let task_data = create_test_task_data();
         let storage_updates = vec![0x01, 0x02, 0x03, 0x04];
 
-        let hash1 = validator.build_payload_hash(&task_data, &storage_updates);
-        let hash2 = validator.build_payload_hash(&task_data, &storage_updates);
+        let hash1 = task_data.build_payload_hash(&storage_updates);
+        let hash2 = task_data.build_payload_hash(&storage_updates);
 
         assert_eq!(hash1, hash2);
         assert_ne!(hash1, Digest::from([0u8; 32]));
@@ -657,11 +591,10 @@ mod tests {
 
     #[test]
     fn test_build_payload_hash_different_inputs() {
-        let validator = GasKillerValidator::with_rpc_url("https://ethereum-sepolia.publicnode.com");
         let task_data = create_test_task_data();
 
-        let hash1 = validator.build_payload_hash(&task_data, &[0x01, 0x02]);
-        let hash2 = validator.build_payload_hash(&task_data, &[0x03, 0x04]);
+        let hash1 = task_data.build_payload_hash(&[0x01, 0x02]);
+        let hash2 = task_data.build_payload_hash(&[0x03, 0x04]);
 
         assert_ne!(hash1, hash2);
     }

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -163,46 +163,36 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             storage_updates_len = storage_updates.len(),
             storage_updates_first_32 = %hex::encode(&task_data.storage_updates[..std::cmp::min(32, task_data.storage_updates.len())]),
             detected_chain = %chain_id,
-            "Executor getMessageHash inputs"
+            "Executor payload hash inputs"
         );
 
         let gas_killer_sdk = GasKillerSDK::new(target_addr, provider.clone());
 
-        // Query the contract's getMessageHash and compare with the provided msg_hash
+        // Confirm the locally computed payload hash matches the quorum's signed hash.
         let hash_preflight_start = Instant::now();
-        let hash_result = gas_killer_sdk
-            .getMessageHash(transition_index, target_function, storage_updates.clone())
-            .call()
-            .await;
+        let expected_hash =
+            FixedBytes::<32>::from(task_data.build_payload_hash(storage_updates.as_ref()).0);
         if let Some(m) = &self.metrics {
             m.executor_hash_preflight_seconds
                 .observe(hash_preflight_start.elapsed().as_secs_f64());
         }
-        match hash_result {
-            Ok(expected_hash) => {
-                if expected_hash != msg_hash {
-                    warn!(
-                        offchain_msg_hash = %msg_hash,
-                        onchain_expected_hash = %expected_hash,
-                        transition_index = %transition_index,
-                        target_address = %target_addr,
-                        target_function = %target_function,
-                        storage_updates_len = storage_updates.len(),
-                        "Message hash mismatch between offchain and onchain"
-                    );
-                    return Err(anyhow::anyhow!(
-                        "Message hash mismatch: offchain {} != onchain {}",
-                        msg_hash,
-                        expected_hash
-                    ));
-                } else {
-                    info!("Message hash match confirmed");
-                }
-            }
-            Err(e) => {
-                warn!("getMessageHash call failed: {}", e);
-            }
+        if expected_hash != msg_hash {
+            warn!(
+                offchain_msg_hash = %msg_hash,
+                local_expected_hash = %expected_hash,
+                transition_index = %transition_index,
+                target_address = %target_addr,
+                target_function = %target_function,
+                storage_updates_len = storage_updates.len(),
+                "Message hash mismatch between aggregation and local computation"
+            );
+            return Err(anyhow::anyhow!(
+                "Message hash mismatch: aggregation {} != local {}",
+                msg_hash,
+                expected_hash
+            ));
         }
+        info!("Message hash match confirmed");
 
         // Ensure contract implements the GasKiller interface via ERC-165 check
         let interface_id = FixedBytes::<4>::from([0x93, 0xde, 0x45, 0x31]);

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -28,7 +28,7 @@ pub struct MetricsCollector {
     pub task_queue_depth: Gauge<i64, AtomicI64>,
     /// Time to detect which chain a target contract is deployed on (seconds).
     pub executor_chain_detection_seconds: Histogram,
-    /// Time for getMessageHash RPC preflight call (seconds).
+    /// Time for the payload-hash preflight computation (seconds).
     pub executor_hash_preflight_seconds: Histogram,
     /// Time for supportsInterface ERC-165 check (seconds).
     pub executor_supports_interface_seconds: Histogram,
@@ -124,7 +124,7 @@ impl MetricsCollector {
         let executor_hash_preflight_seconds = Histogram::new(rpc_buckets);
         registry.register(
             "gas_killer_executor_hash_preflight_seconds",
-            "Time for the getMessageHash RPC preflight call",
+            "Time for the payload-hash preflight computation",
             executor_hash_preflight_seconds.clone(),
         );
 

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -19,6 +19,10 @@ path = "send_request.rs"
 name = "run_scenario"
 path = "run_scenario.rs"
 
+[[bin]]
+name = "verify_message_hash_parity"
+path = "verify_message_hash_parity.rs"
+
 [dependencies]
 alloy = { workspace = true }
 ark-bn254 = { workspace = true }

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -77,6 +77,7 @@ echo -e "${YELLOW}Step 1: Building scripts...${NC}"
 cd "$PROJECT_ROOT/scripts"
 cargo build --release -p scripts --bin deploy_array_summation
 cargo build --release -p scripts --bin send_request
+cargo build --release -p scripts --bin verify_message_hash_parity
 cd "$PROJECT_ROOT"
 
 # Step 2: Assume .env already exists and contains required values
@@ -180,6 +181,18 @@ else
     export GAS_KILLER_TARGET_ADDRESS="$ARRAY_SUMMATION_ADDRESS"
 fi
 
+cd "$PROJECT_ROOT"
+
+# Step 7b: Verify the router's local payload hash matches the contract's getMessageHash
+echo -e "${YELLOW}Step 7b: Verifying message-hash parity (build_payload_hash vs on-chain getMessageHash)...${NC}"
+cd "$PROJECT_ROOT/scripts"
+if ! cargo run --release -p scripts --bin verify_message_hash_parity; then
+    echo -e "${RED}❌ Message-hash parity check FAILED — local build_payload_hash diverges from on-chain getMessageHash${NC}"
+    cd "$PROJECT_ROOT"
+    docker compose logs --tail=100 ethereum || true
+    exit 1
+fi
+echo -e "${GREEN}✅ Message-hash parity verified${NC}"
 cd "$PROJECT_ROOT"
 
 # Step 8: Check service health

--- a/scripts/verify_message_hash_parity.rs
+++ b/scripts/verify_message_hash_parity.rs
@@ -1,0 +1,142 @@
+//! Asserts that `GasKillerTaskData::build_payload_hash` is byte-identical to the deployed
+//! contract's `getMessageHash` across a range of payload shapes.
+//!
+//! Run against a chain with a GasKiller target contract deployed (the e2e stack deploys
+//! ArraySummation). Reads `HTTP_RPC` and the target address from `GAS_KILLER_TARGET_ADDRESS`
+//! (falling back to `addresses.arraySummation` in `AVS_DEPLOYMENT_PATH`).
+//!
+//! Exits non-zero on any mismatch so the e2e workflow fails.
+
+use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+use alloy::providers::{Provider, ProviderBuilder};
+use gas_killer_common::GasKillerTaskData;
+use gas_killer_common::bindings::gaskillersdk::GasKillerSDK;
+use std::env;
+use std::fs;
+use url::Url;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    dotenv::dotenv().ok();
+
+    let rpc = env::var("HTTP_RPC").map_err(|_| "HTTP_RPC environment variable is required")?;
+    let target_address = resolve_target_address()?;
+
+    println!("Verifying message-hash parity against {target_address} via {rpc}");
+
+    let provider = ProviderBuilder::new().connect_http(Url::parse(&rpc)?);
+
+    let code = provider
+        .get_code_at(target_address)
+        .await
+        .map_err(|e| format!("failed to read code at {target_address}: {e}"))?;
+    if code.is_empty() {
+        return Err(format!("target address {target_address} has no code deployed").into());
+    }
+
+    let contract = GasKillerSDK::new(target_address, provider);
+
+    let mut checked = 0usize;
+    let mut mismatches = 0usize;
+
+    for (transition_index, selector, storage_updates) in test_vectors() {
+        let onchain = contract
+            .getMessageHash(
+                U256::from(transition_index),
+                FixedBytes::<4>::from(selector),
+                Bytes::from(storage_updates.clone()),
+            )
+            .call()
+            .await
+            .map_err(|e| format!("getMessageHash call failed: {e}"))?;
+
+        let task_data = GasKillerTaskData {
+            storage_updates: storage_updates.clone(),
+            transition_index,
+            target_address,
+            call_data: selector.to_vec(),
+            from_address: Address::ZERO,
+            value: U256::ZERO,
+            block_height: 0,
+        };
+        let local = FixedBytes::<32>::from(task_data.build_payload_hash(&storage_updates).0);
+
+        checked += 1;
+        if local == onchain {
+            println!(
+                "  ok    ti={transition_index:<20} selector=0x{} len={:<4} hash={local}",
+                hex_selector(&selector),
+                storage_updates.len(),
+            );
+        } else {
+            mismatches += 1;
+            eprintln!(
+                "  FAIL  ti={transition_index:<20} selector=0x{} len={:<4}\n        local   = {local}\n        onchain = {onchain}",
+                hex_selector(&selector),
+                storage_updates.len(),
+            );
+        }
+    }
+
+    if mismatches > 0 {
+        return Err(format!(
+            "{mismatches}/{checked} message-hash parity checks failed: local build_payload_hash diverges from on-chain getMessageHash"
+        )
+        .into());
+    }
+
+    println!("✅ All {checked} message-hash parity checks passed");
+    Ok(())
+}
+
+/// Resolves the target contract address from `GAS_KILLER_TARGET_ADDRESS`, falling back to the
+/// `addresses.arraySummation` field of the deployment JSON at `AVS_DEPLOYMENT_PATH`.
+fn resolve_target_address() -> Result<Address, BoxError> {
+    if let Ok(addr) = env::var("GAS_KILLER_TARGET_ADDRESS")
+        && !addr.is_empty()
+    {
+        return Ok(addr.parse()?);
+    }
+
+    let path = env::var("AVS_DEPLOYMENT_PATH").map_err(
+        |_| "set GAS_KILLER_TARGET_ADDRESS or AVS_DEPLOYMENT_PATH to locate the target contract",
+    )?;
+    let content = fs::read_to_string(&path).map_err(|e| format!("failed to read {path}: {e}"))?;
+    let deployment: serde_json::Value = serde_json::from_str(&content)?;
+    let addr = deployment
+        .get("addresses")
+        .and_then(|a| a.get("arraySummation"))
+        .and_then(|v| v.as_str())
+        .ok_or("addresses.arraySummation not found in deployment JSON")?;
+    Ok(addr.parse()?)
+}
+
+/// `(transition_index, function_selector, storage_updates)` vectors spanning the dynamic-bytes
+/// padding boundaries (0, sub-word, exactly one word, word+1, multi-word) and selector/index edges.
+fn test_vectors() -> Vec<(u64, [u8; 4], Vec<u8>)> {
+    let selectors = [
+        [0x00, 0x00, 0x00, 0x00],
+        [0x12, 0x34, 0x56, 0x78],
+        [0xde, 0xad, 0xbe, 0xef],
+        [0xff, 0xff, 0xff, 0xff],
+    ];
+    let lengths = [0usize, 1, 4, 31, 32, 33, 64, 100];
+    let indices = [0u64, 1, 7, 1_000_000, u64::MAX];
+
+    let mut vectors = Vec::new();
+    for (i, len) in lengths.iter().enumerate() {
+        let selector = selectors[i % selectors.len()];
+        let transition_index = indices[i % indices.len()];
+        let storage_updates = (0..*len)
+            .map(|b| (b as u8).wrapping_mul(7).wrapping_add(1))
+            .collect();
+        vectors.push((transition_index, selector, storage_updates));
+    }
+    vectors
+}
+
+fn hex_selector(selector: &[u8; 4]) -> String {
+    selector.iter().map(|b| format!("{b:02x}")).collect()
+}


### PR DESCRIPTION
## Summary

`execute_verification` queried the target contract's `getMessageHash` over RPC every round to validate the expected hash before submitting `verifyAndUpdate`. That is a pure function whose computation already exists locally as `build_payload_hash`, so the RPC round-trip (~100–200 ms/round) is replaced with the local computation. By the time the executor runs, the BLS quorum has already reached consensus on this hash, so the on-chain query was only defense-in-depth against a router-side encoding bug — that guarantee moves to CI.

Closes #217.

## Changes

- **`router/src/executor.rs`** — compute the expected hash with `build_payload_hash` and compare to the quorum's signed `msg_hash`. A mismatch now always returns `Err`; the previous code swallowed RPC failures with a `warn!` and proceeded.
- **`common`** — move `build_payload_hash` from `GasKillerValidator` (it never used `self`) to a public method on `GasKillerTaskData`. Computation is byte-identical; validator callers and tests updated, unused imports dropped.
- **`router/src/metrics.rs`** — `gas_killer_executor_hash_preflight_seconds` kept (name unchanged for dashboards); description updated to reflect the local computation.

## Encoding parity in CI

`build_payload_hash` hand-rolls the ABI encoding, so parity with the canonical Solidity `abi.encode` is asserted in the e2e flow rather than per-round in production:

- New `scripts/verify_message_hash_parity` calls the deployed contract's `getMessageHash` (via the same `GasKillerSDK` binding the executor uses) and compares against `build_payload_hash` across 8 payload shapes — sizes 0/1/4/31/32/33/64/100 (spanning the dynamic-bytes padding boundaries) plus selector and `transition_index` edges.
- Wired into `run_e2e_test.sh` as Step 7b against the deployed ArraySummation. A mismatch exits non-zero and **fails the e2e run**.

## Verification

- `cargo fmt`, `clippy --all-targets --all-features -D warnings`, `cargo check`, `cargo test` all pass.
- Ran the parity binary against a local anvil contract using the canonical `sha256(abi.encode(...))`: all 8 checks pass. A deliberately divergent (keccak) contract makes every check FAIL and the binary exit 1, confirming the e2e hard-fail.
