### PR TITLE
Use Arc-backed Bytes for `storage_updates` in GasKillerTaskData

### DIFF
--- a/common/src/task_data.rs
+++ b/common/src/task_data.rs
@@ -2,7 +2,7 @@
 
 use alloy::primitives::FixedBytes;
 use alloy::sol_types::SolValue;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use anyhow::Result;
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Read, ReadExt, Write};
@@ -14,8 +14,11 @@ use tracing::debug;
 /// Task data specific to the gas killer use case
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GasKillerTaskData {
-    /// Encoded storage updates to be applied
-    pub storage_updates: Vec<u8>,
+    /// Encoded storage updates to be applied.
+    ///
+    /// `Bytes` is `Arc`-backed, so cloning the task data through the router hot path
+    /// (creator → `current_task` → executor) is a reference-count bump.
+    pub storage_updates: Bytes,
     /// Index of the state transition
     pub transition_index: u64,
     /// Target contract address for function call
@@ -142,7 +145,7 @@ impl GasKillerTaskData {
 impl Default for GasKillerTaskData {
     fn default() -> Self {
         Self {
-            storage_updates: vec![],
+            storage_updates: Bytes::new(),
             transition_index: 0,
             target_address: Address::ZERO,
             call_data: vec![],
@@ -240,7 +243,7 @@ impl Read for GasKillerTaskData {
         let block_height = u64::read(buf)?;
 
         Ok(Self {
-            storage_updates,
+            storage_updates: storage_updates.into(),
             transition_index,
             target_address,
             call_data,
@@ -285,7 +288,7 @@ mod tests {
     #[test]
     fn test_validate_with_normal_data() {
         let task_data = GasKillerTaskData {
-            storage_updates: vec![0u8; 1024],
+            storage_updates: vec![0u8; 1024].into(),
             call_data: vec![0u8; 256],
             ..Default::default()
         };
@@ -331,7 +334,7 @@ mod tests {
         // Each field is under the limit individually, but combined they exceed it
         let half_limit = MAX_EVM_TX_CALLDATA_SIZE / 2 + 1;
         let task_data = GasKillerTaskData {
-            storage_updates: vec![0u8; half_limit],
+            storage_updates: vec![0u8; half_limit].into(),
             call_data: vec![0u8; half_limit],
             ..Default::default()
         };
@@ -360,7 +363,7 @@ mod tests {
         // Combined exactly at the limit should pass
         let half_limit = MAX_EVM_TX_CALLDATA_SIZE / 2;
         let task_data = GasKillerTaskData {
-            storage_updates: vec![0u8; half_limit],
+            storage_updates: vec![0u8; half_limit].into(),
             call_data: vec![0u8; half_limit],
             ..Default::default()
         };

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -500,7 +500,7 @@ mod tests {
 
     fn create_test_task_data() -> GasKillerTaskData {
         GasKillerTaskData {
-            storage_updates: vec![0x01, 0x02, 0x03, 0x04],
+            storage_updates: vec![0x01, 0x02, 0x03, 0x04].into(),
             transition_index: 1,
             target_address: Address::from([1u8; 20]),
             call_data: vec![0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x01],

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -4,6 +4,7 @@ use commonware_avs_router::creator::Creator;
 use gas_killer_common::GasKillerValidator;
 use gas_killer_common::task_data::GasKillerTaskData;
 
+use alloy_primitives::Bytes;
 use anyhow::Result;
 use async_trait::async_trait;
 use commonware_codec::Encode;
@@ -85,7 +86,7 @@ impl Creator for GasKillerCreator {
 /// Enriched task data that includes computed storage updates and block height
 struct EnrichedTask {
     task: GasKillerTaskRequest,
-    storage_updates: Vec<u8>,
+    storage_updates: Bytes,
     block_height: u64,
     /// Resolved transition index (sentinel `None` → concrete count from chain).
     transition_index: u64,
@@ -286,7 +287,7 @@ impl Creator for ListeningGasKillerCreator {
         // Store enriched task with computed storage updates and block height for metadata access
         let enriched = EnrichedTask {
             task,
-            storage_updates,
+            storage_updates: storage_updates.into(),
             block_height,
             transition_index: resolved_transition_index,
         };
@@ -415,7 +416,7 @@ mod tests {
         let validator = GasKillerValidator::with_rpc_url("https://ethereum-sepolia.publicnode.com");
 
         let task_data = GasKillerTaskData {
-            storage_updates: vec![0x01, 0x02, 0x03, 0x04],
+            storage_updates: vec![0x01, 0x02, 0x03, 0x04].into(),
             transition_index: 1,
             target_address: Address::from([1u8; 20]),
             call_data: vec![0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x01],
@@ -485,7 +486,7 @@ mod tests {
         };
 
         let task_data = GasKillerTaskData {
-            storage_updates: vec![0x01, 0x02, 0x03, 0x04], // would be computed by GasAnalyzer
+            storage_updates: vec![0x01, 0x02, 0x03, 0x04].into(), // would be computed by GasAnalyzer
             transition_index: task.body.transition_index.unwrap_or(0),
             target_address: task.body.target_address,
             call_data: task.body.call_data.clone(),

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -195,7 +195,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         );
 
         // Extract task data parameters - use pre-computed storage_updates from task data
-        let storage_updates = Bytes::from(task_data.storage_updates.clone());
+        let storage_updates = task_data.storage_updates.clone();
         let transition_index = U256::from(task_data.transition_index);
         let target_function = task_data.function_selector();
         let target_addr = task_data.target_address;

--- a/scripts/verify_message_hash_parity.rs
+++ b/scripts/verify_message_hash_parity.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), BoxError> {
             .map_err(|e| format!("getMessageHash call failed: {e}"))?;
 
         let task_data = GasKillerTaskData {
-            storage_updates: storage_updates.clone(),
+            storage_updates: Bytes::from(storage_updates.clone()),
             transition_index,
             target_address,
             call_data: selector.to_vec(),


### PR DESCRIPTION
Closes #223.

## What

Change `GasKillerTaskData.storage_updates` from `Vec<u8>` to `alloy_primitives::Bytes` (internally `Arc<[u8]>`) and thread `Bytes` through the router so the field is cloned by reference-count bump.

- `common/src/task_data.rs` — field type `Vec<u8>` → `Bytes`; `Default`, the `Read` codec (one-time zero-copy `Vec → Bytes` on decode), and tests updated. `Write` / `EncodeSize` are byte-for-byte unchanged.
- `router/src/creator.rs` — `EnrichedTask.storage_updates` is also `Bytes`, so the clone in `get_task_metadata` is an `Arc` bump. Computed updates are converted to `Bytes` once, when stored.
- `router/src/executor.rs` — removes the redundant `Bytes::from(task_data.storage_updates.clone())` conversion; the clone is now a refcount bump.
- `common/src/validator.rs`, `scripts/verify_message_hash_parity.rs` — construction sites updated.

## Wire format

Unchanged. The custom binary `Write`/`Read` codec encodes the same length-prefixed bytes; only the in-memory representation changes. `test_validator_produces_consistent_hash` exercises the round trip and confirms parity.

## Impact

Primarily a type-correctness / consistency change. `storage_updates` is bounded by the 128 KB EVM calldata limit, and the creator/executor paths are dominated by EVMSketch (seconds) and network I/O — so the eliminated copies are **not** a measurable latency change. Concrete effects: the two task-data clones become O(1) refcount bumps, one redundant `Bytes::from(Vec)` conversion is removed, and per-task allocator churn drops.

## Testing

Full service CI gate green locally:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` (zero warnings)
- `cargo check --all-targets --all-features`
- `cargo test --all-targets --all-features` (all binaries `ok`)

## Not included

Carrying `Bytes` end-to-end through `AnalysisResult` (dropping the `.to_vec()` in `analyze_transaction`) was considered. It touches only the creator/validator side — not the executor — and the same bounded-size / EVMSketch-dominated reasoning makes it cleanup rather than a perf change, so it's deferred.
