### PR TITLE
feat: add configurable timeout to verifyAndUpdate receipt wait

### DIFF
--- a/example.env
+++ b/example.env
@@ -35,6 +35,12 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # Quorum number to use (default: 0)
 # QUORUM_NUMBER=0
 
+# Max seconds the executor waits for a verifyAndUpdate transaction receipt before
+# timing out the round and proceeding to the next one. Prevents an indefinite
+# stall under L1 mempool congestion or RPC degradation. Applies to all chains;
+# leave unset to use the per-chain defaults (L1: 120s, L2: 30s).
+# EXECUTOR_RECEIPT_TIMEOUT_SECS=120
+
 # =============================================================================
 # AVS Service Manager Wrapper Configuration
 # =============================================================================

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -305,6 +305,10 @@ spec:
             {{- end }}
             - name: AGGREGATION_FREQUENCY
               value: {{ .Values.router.aggregationFrequency | quote }}
+            {{- if .Values.router.receiptTimeoutSecs }}
+            - name: EXECUTOR_RECEIPT_TIMEOUT_SECS
+              value: {{ .Values.router.receiptTimeoutSecs | quote }}
+            {{- end }}
             - name: HEALTHZ_PORT
               value: {{ .Values.router.healthzPort | quote }}
             - name: PRIVATE_KEY

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -271,6 +271,11 @@ router:
   # Aggregation window duration in seconds. Must exceed the time nodes need to compute
   # EVMSketch storage updates. L2 computation takes ~60s, so 90s gives a safe margin.
   aggregationFrequency: "90"
+  # Max seconds the executor waits for a verifyAndUpdate transaction receipt before
+  # timing out the round and proceeding to the next one. Prevents an indefinite stall
+  # under L1 mempool congestion or RPC degradation. Leave empty to use the per-chain
+  # defaults baked into the router (L1: 120s, L2: 30s).
+  receiptTimeoutSecs: ""
   ingress:
     enabled: true
     # IMPORTANT: Must be quoted string to prevent YAML from converting to scientific notation.

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -14,9 +14,15 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+
+/// Default receipt-wait timeout on L1. At ~12s/block this covers several blocks
+/// plus mempool-replacement headroom before the round is abandoned.
+const DEFAULT_RECEIPT_TIMEOUT_L1_SECS: u64 = 120;
+/// Default receipt-wait timeout on L2, where blocks land in seconds or less.
+const DEFAULT_RECEIPT_TIMEOUT_L2_SECS: u64 = 30;
 
 /// Handler for executing verifyAndUpdate transactions with multi-chain support
 pub struct GasKillerHandler<P> {
@@ -28,6 +34,10 @@ pub struct GasKillerHandler<P> {
     /// Memoizes ERC-165 GasKiller interface support per target address. A deployed
     /// contract's supported interfaces are immutable, so entries never expire.
     interface_cache: Arc<RwLock<HashMap<Address, bool>>>,
+    /// Optional override (seconds) for the verifyAndUpdate receipt-wait timeout,
+    /// applied to every chain. When unset, per-chain defaults apply. Sourced from
+    /// `EXECUTOR_RECEIPT_TIMEOUT_SECS`.
+    receipt_timeout_override: Option<u64>,
 }
 
 impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> {
@@ -40,6 +50,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             metrics: None,
             dispatch_time: Default::default(),
             interface_cache: Arc::new(RwLock::new(HashMap::new())),
+            receipt_timeout_override: None,
         }
     }
 
@@ -50,6 +61,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             metrics: None,
             dispatch_time: Default::default(),
             interface_cache: Arc::new(RwLock::new(HashMap::new())),
+            receipt_timeout_override: None,
         }
     }
 
@@ -63,6 +75,13 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         self
     }
 
+    /// Overrides the receipt-wait timeout (seconds) for all chains. `None` keeps
+    /// the per-chain defaults.
+    pub fn with_receipt_timeout(mut self, timeout_secs: Option<u64>) -> Self {
+        self.receipt_timeout_override = timeout_secs;
+        self
+    }
+
     /// Adds a provider for a specific chain
     pub fn add_provider(&mut self, chain_id: ChainId, provider: P) {
         self.providers.insert(chain_id, provider);
@@ -71,6 +90,16 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
     /// Gets the provider for a specific chain
     fn get_provider(&self, chain_id: ChainId) -> Option<&P> {
         self.providers.get(&chain_id)
+    }
+
+    /// Resolves the receipt-wait timeout for `chain_id`: the configured override
+    /// if set, otherwise the per-chain default.
+    fn receipt_timeout(&self, chain_id: ChainId) -> Duration {
+        let secs = self.receipt_timeout_override.unwrap_or(match chain_id {
+            ChainId::L1 => DEFAULT_RECEIPT_TIMEOUT_L1_SECS,
+            ChainId::L2 => DEFAULT_RECEIPT_TIMEOUT_L2_SECS,
+        });
+        Duration::from_secs(secs)
     }
 
     /// Detects which chain has code deployed at the given address
@@ -290,16 +319,33 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         }
         let call_return = send_result?;
 
+        // Bound the receipt wait so L1 mempool congestion, RPC degradation, or a
+        // dropped transaction can't stall the executor indefinitely. On timeout we
+        // return an error so the orchestrator counts the round as failed and moves on.
+        let receipt_timeout = self.receipt_timeout(chain_id);
         let receipt_start = Instant::now();
-        let receipt_result = call_return
-            .get_receipt()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get transaction receipt: {}", e));
-        if let Some(m) = &self.metrics {
-            m.executor_receipt_confirmation_seconds
-                .observe(receipt_start.elapsed().as_secs_f64());
-        }
-        let receipt = receipt_result?;
+        let receipt = match tokio::time::timeout(receipt_timeout, call_return.get_receipt()).await {
+            Ok(receipt_result) => {
+                if let Some(m) = &self.metrics {
+                    m.executor_receipt_confirmation_seconds
+                        .observe(receipt_start.elapsed().as_secs_f64());
+                }
+                receipt_result
+                    .map_err(|e| anyhow::anyhow!("Failed to get transaction receipt: {}", e))?
+            }
+            Err(_) => {
+                warn!(
+                    chain = %chain_id,
+                    timeout_secs = receipt_timeout.as_secs(),
+                    "get_receipt timed out waiting for transaction inclusion"
+                );
+                return Err(anyhow::anyhow!(
+                    "get_receipt timed out after {}s on chain {}",
+                    receipt_timeout.as_secs(),
+                    chain_id
+                ));
+            }
+        };
         info!(
             tx = %receipt.transaction_hash,
             block = receipt.block_number,
@@ -471,6 +517,38 @@ mod tests {
                 .supports_gas_killer_interface(provider.clone(), unsupported_addr)
                 .await
                 .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_receipt_timeout_defaults_per_chain() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let handler = GasKillerHandler::new(provider);
+
+        assert_eq!(
+            handler.receipt_timeout(ChainId::L1),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            handler.receipt_timeout(ChainId::L2),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_receipt_timeout_override_applies_to_all_chains() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let handler = GasKillerHandler::new(provider).with_receipt_timeout(Some(45));
+
+        assert_eq!(
+            handler.receipt_timeout(ChainId::L1),
+            Duration::from_secs(45)
+        );
+        assert_eq!(
+            handler.receipt_timeout(ChainId::L2),
+            Duration::from_secs(45)
         );
     }
 }

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -270,10 +270,17 @@ pub async fn create_gas_killer_executor(
         view_only_provider.clone(),
     );
 
+    // Optional override (seconds) for the verifyAndUpdate receipt-wait timeout.
+    // Unset falls back to the executor's per-chain defaults.
+    let receipt_timeout_override = env::var("EXECUTOR_RECEIPT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok());
+
     // Create handler with multi-chain providers
     let gas_killer_handler = GasKillerHandler::with_providers(providers)
         .with_metrics(metrics)
-        .with_dispatch_time(dispatch_time);
+        .with_dispatch_time(dispatch_time)
+        .with_receipt_timeout(receipt_timeout_override);
 
     Ok(BlsEigenlayerExecutor::new(
         view_only_provider,


### PR DESCRIPTION
## Problem

The executor's `get_receipt()` call waited indefinitely for transaction inclusion. Under L1 mempool congestion, RPC degradation, or a dropped transaction, this stalled the entire system with no timeout, no error, and no recovery path — particularly acute on L1, where blocks take ~12s and mempool replacement is possible.

## Changes

- Wrap the `verifyAndUpdate` receipt wait in `tokio::time::timeout`. On timeout the executor logs a warning and returns an error, so `handle_verification` increments `aggregation_rounds_failed` and the orchestrator proceeds to the next round instead of hanging.
- Resolve the timeout per chain using the chain already detected for the target contract: defaults are 120s (L1) and 30s (L2).
- Override both chains via the `EXECUTOR_RECEIPT_TIMEOUT_SECS` env var.
- Record the receipt-confirmation metric only on actual completion, so timeouts don't skew the histogram.

## Config

- `example.env`: documents `EXECUTOR_RECEIPT_TIMEOUT_SECS`.
- Helm: `router.receiptTimeoutSecs` (empty by default → per-chain code defaults); the env var is injected only when set.

## Testing

- `cargo fmt`, `clippy -D warnings`, `cargo check --all-targets --all-features`, and `cargo test` all pass.
- Added unit tests for per-chain default and override resolution.
- `helm lint` and template render verified — env present when set, omitted when empty.

Closes #220
