### PR TITLE
Opt orchestrator into typed BlsVerificationData path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#86afa8c05ceece3d61f9632a34eab8bc8fb79517"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#86afa8c05ceece3d61f9632a34eab8bc8fb79517"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#86afa8c05ceece3d61f9632a34eab8bc8fb79517"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#86afa8c05ceece3d61f9632a34eab8bc8fb79517"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#86afa8c05ceece3d61f9632a34eab8bc8fb79517"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5066,7 +5066,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6193,7 +6193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6213,7 +6213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Ftyped-verification-data#19ce9b558e7336fe2f79e1faee605436d52b3b89"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5066,7 +5066,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6193,7 +6193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6213,7 +6213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ async-trait = "0.1"
 axum = "0.7"
 bytes = "1.10.1"
 clap = "4.5.37"
-commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
-commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
-commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
-commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
-commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
+commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
 commonware-codec = "0.0.63"
 commonware-cryptography = "0.0.63"
 commonware-macros = "0.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ async-trait = "0.1"
 axum = "0.7"
 bytes = "1.10.1"
 clap = "4.5.37"
-commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
+commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
+commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
+commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
+commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/typed-verification-data" }
 commonware-codec = "0.0.63"
 commonware-cryptography = "0.0.63"
 commonware-macros = "0.0.63"

--- a/router/src/builder.rs
+++ b/router/src/builder.rs
@@ -4,6 +4,7 @@ use crate::factories::{
 };
 use crate::metrics::MetricsCollector;
 use crate::{GasKillerCreatorType, GasKillerOrchestrator, GasKillerValidator};
+use commonware_avs_router::executor::bls::BlsVerificationData;
 use commonware_avs_router::orchestrator::builder::OrchestratorBuilder;
 
 use commonware_runtime::Clock;
@@ -63,6 +64,10 @@ impl GasKillerOrchestratorBuilder {
         // This is safe because we control all references
         let validator_for_orchestrator = Arc::unwrap_or_clone(validator);
 
-        builder.build(task_creator, executor, validator_for_orchestrator)
+        builder.build_with::<_, _, _, BlsVerificationData>(
+            task_creator,
+            executor,
+            validator_for_orchestrator,
+        )
     }
 }

--- a/router/src/orchestrator.rs
+++ b/router/src/orchestrator.rs
@@ -4,7 +4,7 @@ use crate::{GasKillerCreatorType, GasKillerValidator};
 use commonware_avs_router::executor::bls::{BlsEigenlayerExecutor, BlsVerificationData};
 use commonware_avs_router::orchestrator::types::Orchestrator;
 
-/// Type alias for counter orchestrator using the generic framework
+/// Type alias for orchestrator using the generic framework
 pub type GasKillerOrchestrator<C> = Orchestrator<
     GasKillerCreatorType,
     BlsEigenlayerExecutor<GasKillerHandler<SimpleWalletProvider>>,

--- a/router/src/orchestrator.rs
+++ b/router/src/orchestrator.rs
@@ -1,7 +1,7 @@
 use crate::executor::GasKillerHandler;
 use crate::factories::SimpleWalletProvider;
 use crate::{GasKillerCreatorType, GasKillerValidator};
-use commonware_avs_router::executor::bls::BlsEigenlayerExecutor;
+use commonware_avs_router::executor::bls::{BlsEigenlayerExecutor, BlsVerificationData};
 use commonware_avs_router::orchestrator::types::Orchestrator;
 
 /// Type alias for counter orchestrator using the generic framework
@@ -10,4 +10,5 @@ pub type GasKillerOrchestrator<C> = Orchestrator<
     BlsEigenlayerExecutor<GasKillerHandler<SimpleWalletProvider>>,
     GasKillerValidator,
     C,
+    BlsVerificationData,
 >;


### PR DESCRIPTION
Service-side opt-in for the typed `BlsVerificationData` path. Follow-up to the upstream change in `BreadchainCoop/commonware-restaking`.

## What
- `GasKillerOrchestrator` alias now sets `VD = BlsVerificationData`.
- `GasKillerOrchestratorBuilder::build` calls `build_with::<_, _, _, BlsVerificationData>`, so the orchestrator hands the typed aggregation output straight to `BlsEigenlayerExecutor` — no `VerificationData` serialize/deserialize round-trip.
- `BlsSignatureVerificationHandler` impl is unchanged.

## ⚠️ Temporary dependency pin — must revert before merge
The `commonware-avs-*` deps are pinned to the upstream branch `bagelface/typed-verification-data` to validate against the typed API. **Before merge:** land upstream PR #160, then drop `branch = "…"` from the `commonware-avs-*` deps in `Cargo.toml` (back to the default branch) and update `Cargo.lock` to the merged commit. Kept as a draft until then.

## CI
Rust CI (Format / Clippy / Check) is green against the branch dependency.
