### PR TITLE
Track P2P dispatch time per round to prevent stale latency samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#3190525551615dbeaefd472ad72306fe5d2c5e15"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#3190525551615dbeaefd472ad72306fe5d2c5e15"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#3190525551615dbeaefd472ad72306fe5d2c5e15"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#3190525551615dbeaefd472ad72306fe5d2c5e15"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#3190525551615dbeaefd472ad72306fe5d2c5e15"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5066,7 +5066,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6193,7 +6193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6213,7 +6213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#fd6d04e50cf8d99d55eb69658daafe5a35af9b28"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking?branch=bagelface%2Fhandle_verification-round-number#d6b9dd610e442479ea65a1a68d961ced7ba2b722"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5066,7 +5066,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6193,7 +6193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6213,7 +6213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,11 @@ async-trait = "0.1"
 axum = "0.7"
 bytes = "1.10.1"
 clap = "4.5.37"
-# TEMP: tracking PR #161 (round number in handle_verification) until it merges; revert branch back to default afterwards.
-commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
-commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
-commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
-commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
-commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
+commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
 commonware-codec = "0.0.63"
 commonware-cryptography = "0.0.63"
 commonware-macros = "0.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,12 @@ async-trait = "0.1"
 axum = "0.7"
 bytes = "1.10.1"
 clap = "4.5.37"
-commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
-commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking" }
+# TEMP: tracking PR #161 (round number in handle_verification) until it merges; revert branch back to default afterwards.
+commonware-avs-bindings = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
+commonware-avs-core = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
+commonware-avs-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
+commonware-avs-node = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
+commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-restaking", branch = "bagelface/handle_verification-round-number" }
 commonware-codec = "0.0.63"
 commonware-cryptography = "0.0.63"
 commonware-macros = "0.0.63"

--- a/router/src/builder.rs
+++ b/router/src/builder.rs
@@ -8,6 +8,7 @@ use commonware_avs_router::executor::bls::BlsVerificationData;
 use commonware_avs_router::orchestrator::builder::OrchestratorBuilder;
 
 use commonware_runtime::Clock;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tracing::info;
 
@@ -36,9 +37,9 @@ impl GasKillerOrchestratorBuilder {
         // Create shared validator first - used by both creator and orchestrator
         let validator = Arc::new(GasKillerValidator::new()?);
 
-        // Shared timestamp for P2P round-trip measurement: set by the creator when it
-        // dispatches a payload, read+cleared by the executor when threshold sigs arrive.
-        let dispatch_time: DispatchTime = Arc::new(Mutex::new(None));
+        // Per-round dispatch timestamps for P2P round-trip measurement: the creator inserts a
+        // timestamp keyed by round, the executor removes it when threshold sigs arrive.
+        let dispatch_time: DispatchTime = Arc::new(Mutex::new(HashMap::new()));
 
         // Create gas-killer-specific dependencies
         let use_ingress = std::env::var("INGRESS").unwrap_or_default().to_lowercase() == "true";

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use commonware_codec::Encode;
 use commonware_cryptography::{Hasher, Sha256};
+use std::collections::HashMap;
 use std::env;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -16,16 +17,33 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, info, warn};
 
-/// Shared timestamp set by the creator when it dispatches a task and consumed by the executor
-/// to compute the P2P round-trip duration.
+/// Per-round dispatch timestamps: the creator inserts `round -> Instant::now()` when it dispatches
+/// a task, and the executor removes the matching entry in `handle_verification` to compute the P2P
+/// round-trip duration.
 ///
-/// This is a single slot, not a per-round map. It is accurate as long as rounds are sequential
-/// (one task in flight at a time), which the commonware orchestrator currently guarantees.
-/// If a consensus round fails without calling `handle_verification`, the stale timestamp bleeds
-/// into the next round's measurement. A per-round `HashMap<u64, Instant>` would fix this, but
-/// requires `handle_verification` to receive the round number — tracked upstream in
-/// https://github.com/BreadchainCoop/commonware-restaking/issues/154.
-pub type DispatchTime = Arc<Mutex<Option<Instant>>>;
+/// Keying by round (rather than a single shared slot) means a consensus round that fails without
+/// calling `handle_verification` cannot bleed its stale timestamp into the next round's
+/// measurement. Rounds advance monotonically and the orchestrator runs one at a time, so the
+/// creator evicts any entry older than the round it is dispatching, keeping the map bounded even
+/// when rounds fail.
+pub type DispatchTime = Arc<Mutex<HashMap<u64, Instant>>>;
+
+/// Records `round`'s dispatch instant for later round-trip measurement, first evicting any entry
+/// from an earlier round. Rounds advance monotonically and the orchestrator runs one at a time, so
+/// an older entry belongs to a round that failed without completing; dropping it here keeps the map
+/// bounded even when rounds repeatedly fail.
+pub(crate) fn stamp_dispatch_time(times: &DispatchTime, round: u64) {
+    if let Ok(mut times) = times.lock() {
+        times.retain(|&r, _| r >= round);
+        times.insert(round, Instant::now());
+    }
+}
+
+/// Removes and returns `round`'s dispatch instant, if one was recorded. Consuming the entry both
+/// yields the round-trip start and prevents the completed round from lingering in the map.
+pub(crate) fn take_dispatch_time(times: &DispatchTime, round: u64) -> Option<Instant> {
+    times.lock().ok().and_then(|mut times| times.remove(&round))
+}
 
 pub type TaskSender = UnboundedSender<GasKillerTaskRequest>;
 pub type TaskReceiver = UnboundedReceiver<GasKillerTaskRequest>;
@@ -313,10 +331,8 @@ impl Creator for ListeningGasKillerCreator {
         let round = self.round_counter.fetch_add(1, Ordering::SeqCst);
         info!(round = round, "Creator returning payload with round");
 
-        // Stamp the dispatch time so the executor can compute P2P round-trip duration.
-        if let Ok(mut t) = self.dispatch_time.lock() {
-            *t = Some(Instant::now());
-        }
+        // Stamp this round's dispatch time so the executor can compute P2P round-trip duration.
+        stamp_dispatch_time(&self.dispatch_time, round);
 
         Ok((payload, round))
     }
@@ -398,6 +414,31 @@ mod tests {
         let (payload, round) = result.unwrap();
         assert!(!payload.is_empty());
         assert_eq!(round, 0); // Default round is 0
+    }
+
+    #[test]
+    fn test_dispatch_time_evicts_failed_rounds_and_isolates_measurements() {
+        let times: DispatchTime = Arc::new(Mutex::new(HashMap::new()));
+
+        // Round 0 is dispatched but its consensus round fails, so it is never consumed.
+        stamp_dispatch_time(&times, 0);
+        assert_eq!(times.lock().unwrap().len(), 1);
+
+        // Dispatching round 1 evicts the stale round-0 entry rather than letting it accumulate
+        // or bleed into round 1's measurement.
+        stamp_dispatch_time(&times, 1);
+        {
+            let map = times.lock().unwrap();
+            assert_eq!(map.len(), 1, "stale failed-round entry should be evicted");
+            assert!(map.contains_key(&1));
+            assert!(!map.contains_key(&0));
+        }
+
+        // The executor consumes round 1's own timestamp exactly once; the failed round 0 is gone.
+        assert!(take_dispatch_time(&times, 0).is_none());
+        assert!(take_dispatch_time(&times, 1).is_some());
+        assert!(take_dispatch_time(&times, 1).is_none());
+        assert!(times.lock().unwrap().is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -1,4 +1,4 @@
-use crate::creator::DispatchTime;
+use crate::creator::{DispatchTime, take_dispatch_time};
 use crate::metrics::MetricsCollector;
 use gas_killer_common::bindings::GAS_KILLER_INTERFACE_ID;
 use gas_killer_common::bindings::gaskillersdk::{BN254, GasKillerSDK, IBLSSignatureCheckerTypes as GasKillerIBLSTypes};
@@ -372,17 +372,18 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
 
     async fn handle_verification(
         &mut self,
+        round: u64,
         msg_hash: FixedBytes<32>,
         quorum_numbers: Bytes,
         current_block_number: u32,
         non_signer_data: getNonSignerStakesAndSignatureReturn,
         task_data: Option<&Self::TaskData>,
     ) -> Result<ExecutionResult> {
-        // Record P2P round-trip: time from creator dispatch to threshold signatures received.
-        // Check metrics first so we never consume the timestamp when there's nowhere to record it.
-        if let Some(m) = &self.metrics
-            && let Ok(mut t) = self.dispatch_time.lock()
-            && let Some(start) = t.take()
+        // Record P2P round-trip: time from this round's creator dispatch to threshold signatures
+        // received. Consume the entry keyed by `round` so a failed earlier round (which never
+        // reaches here) cannot contribute a stale, inflated sample.
+        if let Some(start) = take_dispatch_time(&self.dispatch_time, round)
+            && let Some(m) = &self.metrics
         {
             m.p2p_round_trip_seconds
                 .observe(start.elapsed().as_secs_f64());


### PR DESCRIPTION
Closes #209.

## Summary

`DispatchTime` was a single `Arc<Mutex<Option<Instant>>>` slot shared between the creator and executor to measure P2P round-trip latency. That is only correct while rounds are strictly sequential and always succeed: when a consensus round fails without calling `handle_verification`, its stale timestamp bleeds into the next round's histogram sample.

This replaces the single slot with a per-round map so each measurement is isolated to its own round.

## Changes

- `DispatchTime` → `Arc<Mutex<HashMap<u64, Instant>>>`.
- Creator stamps `round -> Instant::now()` when it dispatches a task.
- `GasKillerHandler::handle_verification` now receives `round: u64` (matching the updated upstream trait) and consumes the entry keyed by that round, so a failed earlier round can't contribute a stale sample.
- Stale-entry cleanup: because rounds advance monotonically and the orchestrator runs one at a time, the creator evicts any entry older than the round it is dispatching. This bounds the map even under repeated round failures without a background task.

The map operations are extracted into `stamp_dispatch_time` / `take_dispatch_time` helpers so the new behaviour is unit-testable (the production call sites are otherwise buried in RPC-bound code).

There is no interim max-age workaround to remove — it was never merged into this codebase, so this goes straight to the proper per-round fix.

## Tests

- `test_dispatch_time_evicts_failed_rounds_and_isolates_measurements` — asserts a failed round's timestamp is evicted on the next dispatch and that each round's measurement is consumed exactly once.
- `cargo fmt`, `clippy --all-targets --all-features -D warnings`, `check`, and `test` all pass against the feature-branch upstream.
