### PR TITLE
Reuse pre-built per-chain read providers in validator and ingress

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bindings;
 pub mod config;
+pub mod providers;
 pub mod task_data;
 pub mod validator;
 
@@ -8,6 +9,7 @@ pub use config::{
     ChainId, KeyConfig, OrchestratorConfig, detect_chain_for_address, get_operator_states,
     load_key_from_file, load_orchestrator_config,
 };
+pub use providers::{build_read_providers, chain_rpc_urls_from_env};
 pub use task_data::GasKillerTaskData;
 pub use validator::{GasKillerValidator, ValidatorMetrics};
 

--- a/common/src/providers.rs
+++ b/common/src/providers.rs
@@ -1,0 +1,89 @@
+//! Construction of read-only RPC providers shared across components.
+//!
+//! Reads the per-chain RPC endpoints from the environment (`HTTP_RPC`, `L2_HTTP_RPC`)
+//! and builds one provider per chain.
+
+use std::collections::HashMap;
+use std::env;
+
+use url::Url;
+
+use crate::ReadOnlyProvider;
+use crate::config::ChainId;
+
+/// Reads the per-chain RPC URLs from the environment.
+///
+/// - `HTTP_RPC` → [`ChainId::L1`] (required)
+/// - `L2_HTTP_RPC` → [`ChainId::L2`] (optional)
+///
+/// Returns an error if `HTTP_RPC` is not set.
+pub fn chain_rpc_urls_from_env() -> anyhow::Result<HashMap<ChainId, String>> {
+    let mut urls = HashMap::new();
+
+    let l1_rpc = env::var("HTTP_RPC")
+        .map_err(|_| anyhow::anyhow!("HTTP_RPC environment variable is not set"))?;
+    urls.insert(ChainId::L1, l1_rpc);
+
+    if let Ok(l2_rpc) = env::var("L2_HTTP_RPC") {
+        urls.insert(ChainId::L2, l2_rpc);
+    }
+
+    Ok(urls)
+}
+
+/// Builds a read-only HTTP provider for each chain URL.
+///
+/// URLs that fail to parse are skipped with a warning; a chain with no provider
+/// has its lookups error at call time.
+pub fn build_read_providers(
+    chain_rpc_urls: &HashMap<ChainId, String>,
+) -> HashMap<ChainId, ReadOnlyProvider> {
+    use alloy_provider::ProviderBuilder;
+
+    let mut providers = HashMap::with_capacity(chain_rpc_urls.len());
+    for (&chain_id, rpc_url) in chain_rpc_urls {
+        match Url::parse(rpc_url) {
+            Ok(url) => {
+                providers.insert(chain_id, ProviderBuilder::new().connect_http(url));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    chain = %chain_id,
+                    error = %e,
+                    "Skipping read provider for chain with unparseable RPC URL"
+                );
+            }
+        }
+    }
+    providers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_a_provider_per_valid_url() {
+        let mut urls = HashMap::new();
+        urls.insert(ChainId::L1, "https://example.com".to_string());
+        urls.insert(ChainId::L2, "https://l2.example.com".to_string());
+
+        let providers = build_read_providers(&urls);
+
+        assert_eq!(providers.len(), 2);
+        assert!(providers.contains_key(&ChainId::L1));
+        assert!(providers.contains_key(&ChainId::L2));
+    }
+
+    #[test]
+    fn skips_unparseable_urls() {
+        let mut urls = HashMap::new();
+        urls.insert(ChainId::L1, "https://example.com".to_string());
+        urls.insert(ChainId::L2, "not a url".to_string());
+
+        let providers = build_read_providers(&urls);
+
+        assert!(providers.contains_key(&ChainId::L1));
+        assert!(!providers.contains_key(&ChainId::L2));
+    }
+}

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -6,13 +6,12 @@ use prometheus_client::encoding::text::encode;
 use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
 use std::collections::HashMap;
-use std::env;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::Mutex;
 use tracing::debug;
-use url::Url;
 
+use crate::ReadOnlyProvider;
 use crate::config::ChainId;
 use crate::task_data::GasKillerTaskData;
 use commonware_avs_router::validator::ValidatorTrait;
@@ -80,6 +79,8 @@ const DEFAULT_EXECUTOR_CACHE_CAPACITY: usize = 4;
 pub struct GasKillerValidator {
     /// RPC URLs per chain for the gas analyzer
     chain_rpc_urls: HashMap<ChainId, String>,
+    /// Read-only providers per chain for chain detection and `stateTransitionCount` reads.
+    providers: Arc<HashMap<ChainId, ReadOnlyProvider>>,
     /// Default chain for backwards compatibility
     default_chain: ChainId,
     /// Cache: (transition_index, block_height) -> computed digest
@@ -103,20 +104,12 @@ impl GasKillerValidator {
     ///
     /// Returns an error if L1 RPC is not set.
     pub fn new() -> Result<Self> {
-        let mut chain_rpc_urls = HashMap::new();
-
-        // Load L1 RPC URL (required)
-        let l1_rpc = env::var("HTTP_RPC")
-            .map_err(|_| anyhow::anyhow!("HTTP_RPC environment variable is not set"))?;
-        chain_rpc_urls.insert(ChainId::L1, l1_rpc);
-
-        // Load L2 RPC URL (optional)
-        if let Ok(l2_rpc) = env::var("L2_HTTP_RPC") {
-            chain_rpc_urls.insert(ChainId::L2, l2_rpc);
-        }
+        let chain_rpc_urls = crate::chain_rpc_urls_from_env()?;
+        let providers = Arc::new(crate::build_read_providers(&chain_rpc_urls));
 
         Ok(Self {
             chain_rpc_urls,
+            providers,
             default_chain: ChainId::L1,
             digest_cache: Arc::new(Mutex::new(HashMap::new())),
             executor_cache: Arc::new(EvmSketchExecutorCache::new(DEFAULT_EXECUTOR_CACHE_CAPACITY)),
@@ -130,8 +123,10 @@ impl GasKillerValidator {
     pub fn with_rpc_url(rpc_url: impl Into<String>) -> Self {
         let mut chain_rpc_urls = HashMap::new();
         chain_rpc_urls.insert(ChainId::L1, rpc_url.into());
+        let providers = Arc::new(crate::build_read_providers(&chain_rpc_urls));
         Self {
             chain_rpc_urls,
+            providers,
             default_chain: ChainId::L1,
             digest_cache: Arc::new(Mutex::new(HashMap::new())),
             executor_cache: Arc::new(EvmSketchExecutorCache::new(DEFAULT_EXECUTOR_CACHE_CAPACITY)),
@@ -141,8 +136,10 @@ impl GasKillerValidator {
 
     /// Creates a new GasKillerValidator with RPC URLs for multiple chains.
     pub fn with_chain_rpc_urls(chain_rpc_urls: HashMap<ChainId, String>) -> Self {
+        let providers = Arc::new(crate::build_read_providers(&chain_rpc_urls));
         Self {
             chain_rpc_urls,
+            providers,
             default_chain: ChainId::L1,
             digest_cache: Arc::new(Mutex::new(HashMap::new())),
             executor_cache: Arc::new(EvmSketchExecutorCache::new(DEFAULT_EXECUTOR_CACHE_CAPACITY)),
@@ -187,25 +184,21 @@ impl GasKillerValidator {
         &self,
         address: alloy::primitives::Address,
     ) -> Result<ChainId> {
-        use alloy_provider::ProviderBuilder;
-
         debug!(
             address = %address,
             "Detecting chain for address"
         );
 
         let supported = self.supported_chains();
-        // Clone the RPC URLs so the closure doesn't borrow self
-        let chain_rpc_urls = self.chain_rpc_urls.clone();
+        // Clone the Arc so the closure doesn't borrow self
+        let providers = Arc::clone(&self.providers);
 
         crate::config::detect_chain_for_address(address, &supported, |chain_id, addr| {
-            let chain_rpc_urls = chain_rpc_urls.clone();
+            let providers = Arc::clone(&providers);
             async move {
-                let rpc_url = chain_rpc_urls
+                let provider = providers
                     .get(&chain_id)
-                    .ok_or_else(|| anyhow::anyhow!("No RPC URL for chain {}", chain_id))?;
-                let url = Url::parse(rpc_url)?;
-                let provider = ProviderBuilder::new().connect_http(url);
+                    .ok_or_else(|| anyhow::anyhow!("No provider for chain {}", chain_id))?;
                 let code = provider.get_code_at(addr).await?;
                 Ok(code)
             }
@@ -223,14 +216,12 @@ impl GasKillerValidator {
         chain_id: ChainId,
     ) -> Result<u64> {
         use crate::bindings::gaskillersdk::GasKillerSDK;
-        use alloy_provider::ProviderBuilder;
 
-        let rpc_url = self
-            .rpc_url_for_chain(chain_id)
-            .ok_or_else(|| anyhow::anyhow!("No RPC URL for chain {}", chain_id))?;
-        let url = Url::parse(rpc_url)?;
-        let provider = ProviderBuilder::new().connect_http(url);
-        let count = GasKillerSDK::new(address, provider)
+        let provider = self
+            .providers
+            .get(&chain_id)
+            .ok_or_else(|| anyhow::anyhow!("No provider for chain {}", chain_id))?;
+        let count = GasKillerSDK::new(address, provider.clone())
             .stateTransitionCount()
             .call()
             .await
@@ -514,6 +505,17 @@ mod tests {
     async fn test_validator_creation() {
         let _validator =
             GasKillerValidator::with_rpc_url("https://ethereum-sepolia.publicnode.com");
+    }
+
+    #[test]
+    fn test_providers_prebuilt_for_each_chain() {
+        let mut urls = HashMap::new();
+        urls.insert(ChainId::L1, "https://example.com".to_string());
+        urls.insert(ChainId::L2, "https://l2.example.com".to_string());
+        let validator = GasKillerValidator::with_chain_rpc_urls(urls);
+
+        assert!(validator.providers.contains_key(&ChainId::L1));
+        assert!(validator.providers.contains_key(&ChainId::L2));
     }
 
     #[tokio::test]

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -106,6 +106,9 @@ impl GasKillerValidator {
     pub fn new() -> Result<Self> {
         let chain_rpc_urls = crate::chain_rpc_urls_from_env()?;
         let providers = Arc::new(crate::build_read_providers(&chain_rpc_urls));
+        if !providers.contains_key(&ChainId::L1) {
+            anyhow::bail!("HTTP_RPC is set but is not a valid URL");
+        }
 
         Ok(Self {
             chain_rpc_urls,
@@ -217,11 +220,20 @@ impl GasKillerValidator {
     ) -> Result<u64> {
         use crate::bindings::gaskillersdk::GasKillerSDK;
 
-        let provider = self
-            .providers
-            .get(&chain_id)
-            .ok_or_else(|| anyhow::anyhow!("No provider for chain {}", chain_id))?;
-        let count = GasKillerSDK::new(address, provider.clone())
+        let provider = match self.providers.get(&chain_id) {
+            Some(p) => p.clone(),
+            None => {
+                if let Some(rpc_url) = self.chain_rpc_urls.get(&chain_id) {
+                    anyhow::bail!(
+                        "RPC URL for chain {} is not a valid URL (provider was not built): {}",
+                        chain_id,
+                        rpc_url
+                    );
+                }
+                anyhow::bail!("No RPC URL configured for chain {}", chain_id);
+            }
+        };
+        let count = GasKillerSDK::new(address, provider)
             .stateTransitionCount()
             .call()
             .await

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -70,7 +70,7 @@ pub async fn create_listening_creator_with_server(
         dispatch_time,
     )
     .with_metrics(Arc::clone(&metrics));
-    let providers = build_ingress_providers().await?;
+    let providers = build_ingress_providers()?;
     let ingress_password = env::var("INGRESS_PASSWORD").ok().filter(|p| !p.is_empty());
     if ingress_password.is_none() {
         tracing::warn!(
@@ -130,27 +130,10 @@ pub async fn create_listening_creator_with_server(
     Ok(GasKillerCreatorType::Listening(Box::new(creator)))
 }
 
-async fn build_ingress_providers()
--> anyhow::Result<HashMap<ChainId, gas_killer_common::ReadOnlyProvider>> {
-    let mut providers = HashMap::new();
-
-    if let Ok(rpc) = env::var("HTTP_RPC") {
-        let p = ProviderBuilder::new()
-            .connect(&rpc)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to create L1 ingress provider: {e}"))?;
-        providers.insert(ChainId::L1, p);
-        info!(chain = "l1", "Created L1 ingress read provider");
-    }
-
-    if let Ok(rpc) = env::var("L2_HTTP_RPC") {
-        let p = ProviderBuilder::new()
-            .connect(&rpc)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to create L2 ingress provider: {e}"))?;
-        providers.insert(ChainId::L2, p);
-        info!(chain = "l2", "Created L2 ingress read provider");
-    }
+fn build_ingress_providers() -> anyhow::Result<HashMap<ChainId, gas_killer_common::ReadOnlyProvider>>
+{
+    let chain_rpc_urls = gas_killer_common::chain_rpc_urls_from_env()?;
+    let providers = gas_killer_common::build_read_providers(&chain_rpc_urls);
 
     if providers.is_empty() {
         anyhow::bail!("no ingress providers could be created: set HTTP_RPC and/or L2_HTTP_RPC");


### PR DESCRIPTION
Closes #221

## Problem
`GasKillerValidator::detect_chain_for_address` and `get_state_transition_count_on_chain` called `ProviderBuilder::new().connect_http(url)` on every invocation, allocating a new HTTP client per call. Both run in the creator's hot path every round.

## Change
Extracted per-chain read-provider construction into a shared `common::providers` module, since the validator (node + router) and the router's ingress server all build the same `HashMap<ChainId, ReadOnlyProvider>` from the same env vars:

- **`common/src/providers.rs`** (new):
  - `chain_rpc_urls_from_env()` — reads `HTTP_RPC` (required) / `L2_HTTP_RPC` (optional).
  - `build_read_providers(&urls)` — builds one `ReadOnlyProvider` per chain; skips unparseable URLs with a warning.
- **`common/src/validator.rs`**: stores a pre-built `Arc<HashMap<ChainId, ReadOnlyProvider>>`, built once at construction. The two hot-path methods now look up the cached provider instead of rebuilding one per call.
- **`router/src/factories.rs`**: `build_ingress_providers` now delegates to the shared helpers.

## Behavior notes
- Ingress switched from async `.connect()` to sync `connect_http` — no real difference, HTTP connect is lazy and wasn't validated at startup before either.
- Ingress now requires `HTTP_RPC` rather than allowing an L2-only config, matching the rest of the system (operator state lives on L1; `new()` and the executor already require it).

## Tests
- `providers::tests::{builds_a_provider_per_valid_url, skips_unparseable_urls}`
- `validator::tests::test_providers_prebuilt_for_each_chain`
- `cargo fmt` / `clippy -D warnings` / `check` / `test` all pass workspace-wide.