### PR TITLE
feat: add end-to-end round-latency histogram and dashboard panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#07e5a4e9ebe26967b0f57bd83c0328058527e9a2"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#b20d0a512ae4e95c8e657b4b00403327d83fb86a"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#07e5a4e9ebe26967b0f57bd83c0328058527e9a2"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#b20d0a512ae4e95c8e657b4b00403327d83fb86a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#07e5a4e9ebe26967b0f57bd83c0328058527e9a2"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#b20d0a512ae4e95c8e657b4b00403327d83fb86a"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#07e5a4e9ebe26967b0f57bd83c0328058527e9a2"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#b20d0a512ae4e95c8e657b4b00403327d83fb86a"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2260,7 +2260,6 @@ dependencies = [
  "futures",
  "futures-util",
  "governor",
- "prometheus-client 0.23.1",
  "prost",
  "prost-build",
  "rand 0.9.2",
@@ -2275,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#07e5a4e9ebe26967b0f57bd83c0328058527e9a2"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#b20d0a512ae4e95c8e657b4b00403327d83fb86a"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2308,7 +2307,7 @@ dependencies = [
  "governor",
  "hex",
  "num-bigint 0.4.6",
- "prometheus-client 0.23.1",
+ "prometheus-client",
  "prost",
  "prost-build",
  "rand 0.9.2",
@@ -2395,7 +2394,7 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits",
- "prometheus-client 0.22.3",
+ "prometheus-client",
  "rand 0.8.5",
  "rand_distr",
  "thiserror 2.0.18",
@@ -2422,7 +2421,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "prometheus-client 0.22.3",
+ "prometheus-client",
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
@@ -3780,7 +3779,7 @@ dependencies = [
  "dotenv",
  "futures",
  "gas-analyzer-evmsketch",
- "prometheus-client 0.23.1",
+ "prometheus-client",
  "serde",
  "serde_json",
  "tokio",
@@ -3860,7 +3859,7 @@ dependencies = [
  "governor",
  "hex",
  "num-bigint 0.4.6",
- "prometheus-client 0.23.1",
+ "prometheus-client",
  "prost",
  "prost-build",
  "rand 0.9.2",
@@ -5067,7 +5066,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6136,18 +6135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
 name = "prometheus-client-derive-encode"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6194,7 +6181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6214,7 +6201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ gas-killer-common = { path = "common" }
 governor = "0.6.3"
 hex = "0.4"
 num-bigint = "0.4"
-prometheus-client = "0.23.1"
+prometheus-client = "0.22.3"
 prost = "0.13.5"
 rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/common/src/validator.rs
+++ b/common/src/validator.rs
@@ -31,7 +31,7 @@ impl ValidatorMetrics {
     pub fn new() -> Self {
         let mut registry = Registry::default();
         let evmsketch_duration_seconds =
-            Histogram::new([0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0, 120.0]);
+            Histogram::new([0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0, 120.0].into_iter());
         registry.register(
             "gas_killer_node_evmsketch_duration_seconds",
             "Duration of gas analysis (EVMSketch + RPC calls) on the node, cache-miss path only. Excludes chain detection.",

--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -288,17 +288,137 @@ data:
           }
         },
         {
+          "id": 60,
+          "type": "text",
+          "title": "Orchestrator Internals",
+          "gridPos": { "x": 0, "y": 32, "w": 24, "h": 1 },
+          "options": { "mode": "markdown", "content": "## Orchestrator Internals\n\nRound-internal metrics from the commonware orchestrator and BLS executor registries, surfaced via the runtime context on the same `/metrics` endpoint.\n\nTime to quorum = round broadcast → signature threshold reached (isolates aggregation from EigenLayer reads). Round timeouts = aggregation windows that expired before the round completed — the primary signal for tuning `AGGREGATION_FREQUENCY`. EigenLayer state retrieval = operator resolution + non-signer stakes/signature reads between quorum and `handle_verification`; subtract it and time-to-quorum from P2P round-trip to estimate pure transport+signing overhead." }
+        },
+        {
+          "id": 61,
+          "type": "timeseries",
+          "title": "Time to Quorum (p50 / p95)",
+          "gridPos": { "x": 0, "y": 33, "w": 6, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(orchestrator_time_to_quorum_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(orchestrator_time_to_quorum_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 62,
+          "type": "timeseries",
+          "title": "Signature Arrival Spread (p50 / p99)",
+          "description": "Round broadcast → each accepted signature. A wide p50→p99 gap means straggler operators are holding rounds open.",
+          "gridPos": { "x": 6, "y": 33, "w": 6, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(orchestrator_signature_arrival_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.99, rate(orchestrator_signature_arrival_seconds_bucket[5m]))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 63,
+          "type": "timeseries",
+          "title": "Round Outcomes / min",
+          "description": "Window timeouts re-broadcast the round on the next pass; sustained timeouts mean AGGREGATION_FREQUENCY is shorter than time-to-quorum.",
+          "gridPos": { "x": 12, "y": 33, "w": 6, "h": 8 },
+          "targets": [
+            {
+              "expr": "rate(orchestrator_round_executions_total{status=\"Success\"}[2m]) * 60",
+              "legendFormat": "executed"
+            },
+            {
+              "expr": "rate(orchestrator_round_executions_total{status=\"Failure\"}[2m]) * 60",
+              "legendFormat": "execution failed"
+            },
+            {
+              "expr": "rate(orchestrator_round_timeouts_total[2m]) * 60",
+              "legendFormat": "window timeout"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        },
+        {
+          "id": 64,
+          "type": "timeseries",
+          "title": "Signatures / min by Outcome",
+          "description": "Success = accepted and stored. Invalid = failed decode, validation, or BLS verification. Dropped = duplicates, unknown senders/rounds, already-executed rounds.",
+          "gridPos": { "x": 18, "y": 33, "w": 6, "h": 8 },
+          "targets": [
+            {
+              "expr": "rate(orchestrator_signatures_total{status=\"Success\"}[2m]) * 60",
+              "legendFormat": "accepted"
+            },
+            {
+              "expr": "rate(orchestrator_signatures_total{status=\"Invalid\"}[2m]) * 60",
+              "legendFormat": "invalid"
+            },
+            {
+              "expr": "rate(orchestrator_signatures_total{status=\"Dropped\"}[2m]) * 60",
+              "legendFormat": "dropped"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        },
+        {
+          "id": 65,
+          "type": "timeseries",
+          "title": "EigenLayer State Retrieval (p50 / p95)",
+          "description": "Operator-address resolution + current-block query + getNonSignerStakesAndSignature, per execution. Runs between quorum and handle_verification, so it is included in the P2P Round-Trip measurement above.",
+          "gridPos": { "x": 0, "y": 41, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(executor_state_retrieval_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(executor_state_retrieval_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 66,
+          "type": "stat",
+          "title": "Operator Cache Misses (total)",
+          "description": "pubkeyHashToOperator RPC lookups. Expected at startup and when new operators register; steady growth otherwise indicates the cache is not retaining entries.",
+          "gridPos": { "x": 12, "y": 41, "w": 12, "h": 8 },
+          "targets": [{
+            "expr": "executor_operator_cache_misses_total",
+            "legendFormat": "cache misses"
+          }],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "area"
+          }
+        },
+        {
           "id": 30,
           "type": "text",
           "title": "Ingress",
-          "gridPos": { "x": 0, "y": 33, "w": 24, "h": 1 },
+          "gridPos": { "x": 0, "y": 49, "w": 24, "h": 1 },
           "options": { "mode": "markdown", "content": "## Ingress" }
         },
         {
           "id": 31,
           "type": "timeseries",
           "title": "Ingress Request Rate / min",
-          "gridPos": { "x": 0, "y": 34, "w": 12, "h": 8 },
+          "gridPos": { "x": 0, "y": 50, "w": 12, "h": 8 },
           "targets": [
             {
               "expr": "rate(gas_killer_ingress_requests_accepted_total[2m]) * 60",
@@ -315,7 +435,7 @@ data:
           "id": 32,
           "type": "stat",
           "title": "Tasks Created (total)",
-          "gridPos": { "x": 12, "y": 34, "w": 6, "h": 8 },
+          "gridPos": { "x": 12, "y": 50, "w": 6, "h": 8 },
           "targets": [{
             "expr": "gas_killer_tasks_created_total",
             "legendFormat": "tasks"
@@ -330,14 +450,14 @@ data:
           "id": 50,
           "type": "text",
           "title": "Executor Phase Breakdown",
-          "gridPos": { "x": 0, "y": 42, "w": 24, "h": 1 },
+          "gridPos": { "x": 0, "y": 58, "w": 24, "h": 1 },
           "options": { "mode": "markdown", "content": "## Executor Phase Breakdown\n\nPer-phase latency inside `handle_verification`. getMessageHash preflight → supportsInterface check → tx send (includes gas estimation) → receipt confirmation (block inclusion wait)." }
         },
         {
           "id": 52,
           "type": "timeseries",
           "title": "Hash Preflight (p50 / p95)",
-          "gridPos": { "x": 0, "y": 43, "w": 12, "h": 8 },
+          "gridPos": { "x": 0, "y": 59, "w": 12, "h": 8 },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(gas_killer_executor_hash_preflight_seconds_bucket[5m]))",
@@ -354,7 +474,7 @@ data:
           "id": 53,
           "type": "timeseries",
           "title": "supportsInterface Check (p50 / p95)",
-          "gridPos": { "x": 12, "y": 43, "w": 12, "h": 8 },
+          "gridPos": { "x": 12, "y": 59, "w": 12, "h": 8 },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(gas_killer_executor_supports_interface_seconds_bucket[5m]))",
@@ -372,7 +492,7 @@ data:
           "type": "timeseries",
           "title": "TX Send (p50 / p95)",
           "description": "Time from calling verifyAndUpdate to receiving the pending tx handle. Includes eth_estimateGas simulation.",
-          "gridPos": { "x": 0, "y": 51, "w": 12, "h": 8 },
+          "gridPos": { "x": 0, "y": 67, "w": 12, "h": 8 },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(gas_killer_executor_tx_send_seconds_bucket[5m]))",
@@ -390,7 +510,7 @@ data:
           "type": "timeseries",
           "title": "Receipt Confirmation (p50 / p95)",
           "description": "Time waiting for the verifyAndUpdate transaction to be included in a block.",
-          "gridPos": { "x": 12, "y": 51, "w": 12, "h": 8 },
+          "gridPos": { "x": 12, "y": 67, "w": 12, "h": 8 },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(gas_killer_executor_receipt_confirmation_seconds_bucket[5m]))",

--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -202,13 +202,35 @@ data:
           "type": "text",
           "title": "Latency Breakdown",
           "gridPos": { "x": 0, "y": 23, "w": 24, "h": 1 },
-          "options": { "mode": "markdown", "content": "## Latency Breakdown\n\nP2P round-trip = time from creator dispatching a task (after router-side storage computation) to the executor receiving threshold signatures. Includes P2P transit ×2, node EVMSketch, BLS signing, and aggregation.\n\nEstimated transport+signing overhead ≈ round-trip − node EVMSketch. Router-side storage computation is **not** part of the round-trip measurement (it completes before the dispatch timestamp is stamped)." }
+          "options": { "mode": "markdown", "content": "## Latency Breakdown\n\nRound latency = end-to-end time from creator dispatch to verifyAndUpdate receipt confirmation, successful rounds only. P2P round-trip = time from creator dispatching a task (after router-side storage computation) to the executor receiving threshold signatures. Includes P2P transit ×2, node EVMSketch, BLS signing, and aggregation.\n\nEstimated transport+signing overhead ≈ round-trip − node EVMSketch. Router-side storage computation and ingress-queue wait are **not** part of either measurement (they complete before the dispatch timestamp is stamped)." }
+        },
+        {
+          "id": 44,
+          "type": "timeseries",
+          "title": "Round Latency (p50 / p95 / p99)",
+          "description": "End-to-end: creator dispatch → verifyAndUpdate receipt confirmation. Successful rounds only.",
+          "gridPos": { "x": 0, "y": 24, "w": 6, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(gas_killer_round_latency_seconds_bucket[5m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(gas_killer_round_latency_seconds_bucket[5m]))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, rate(gas_killer_round_latency_seconds_bucket[5m]))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
         },
         {
           "id": 41,
           "type": "timeseries",
           "title": "P2P Round-Trip (p50 / p99)",
-          "gridPos": { "x": 0, "y": 24, "w": 8, "h": 8 },
+          "gridPos": { "x": 6, "y": 24, "w": 6, "h": 8 },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(gas_killer_p2p_round_trip_seconds_bucket[5m]))",
@@ -226,7 +248,7 @@ data:
           "type": "timeseries",
           "title": "Node EVMSketch Duration (p50 / p99)",
           "description": "Time for call_to_encoded_state_updates_with_evmsketch on the node (cache-miss path). Scraped from the node's /metrics endpoint.",
-          "gridPos": { "x": 8, "y": 24, "w": 8, "h": 8 },
+          "gridPos": { "x": 12, "y": 24, "w": 6, "h": 8 },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(gas_killer_node_evmsketch_duration_seconds_bucket[5m]))",
@@ -244,7 +266,7 @@ data:
           "type": "timeseries",
           "title": "Task Queue Depth",
           "description": "Number of tasks sitting in the ingress queue waiting to be processed. Sustained depth > 0 under burst load indicates the 1 msg/sec P2P rate limit is the bottleneck.",
-          "gridPos": { "x": 16, "y": 24, "w": 8, "h": 8 },
+          "gridPos": { "x": 18, "y": 24, "w": 6, "h": 8 },
           "targets": [
             {
               "expr": "gas_killer_task_queue_depth",

--- a/router/src/builder.rs
+++ b/router/src/builder.rs
@@ -7,7 +7,7 @@ use crate::{GasKillerCreatorType, GasKillerOrchestrator, GasKillerValidator};
 use commonware_avs_router::executor::bls::BlsVerificationData;
 use commonware_avs_router::orchestrator::builder::OrchestratorBuilder;
 
-use commonware_runtime::Clock;
+use commonware_runtime::{Clock, Metrics};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tracing::info;
@@ -30,13 +30,16 @@ impl GasKillerOrchestratorBuilder {
     /// * `validator` - The shared validator, owned by the caller (which also runs its
     ///   speculative pre-build loop), used by both the creator and the orchestrator
     /// * `metrics` - The shared metrics collector
+    /// * `context` - The runtime context the upstream executor registers its
+    ///   EigenLayer state-retrieval metrics on
     ///
     /// # Returns
     /// * `Result<GasKillerOrchestrator<C>>` - The constructed gas killer orchestrator
-    pub async fn build<C: Clock>(
+    pub async fn build<C: Clock + Metrics>(
         builder: OrchestratorBuilder<C>,
         validator: Arc<GasKillerValidator>,
         metrics: Arc<MetricsCollector>,
+        context: &impl Metrics,
     ) -> Result<GasKillerOrchestrator<C>, Box<dyn std::error::Error>> {
         // The validator is created and owned by the caller (which also spawns the speculative
         // pre-build loop on it); it is shared here by both the creator and the orchestrator.
@@ -63,7 +66,7 @@ impl GasKillerOrchestratorBuilder {
             create_creator().await?
         };
 
-        let executor = create_gas_killer_executor(metrics, dispatch_time).await?;
+        let executor = create_gas_killer_executor(metrics, dispatch_time, context).await?;
 
         // Unwrap the Arc to get the validator for the orchestrator
         // This is safe because we control all references

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -367,8 +367,10 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
     ) -> Result<ExecutionResult> {
         // Record P2P round-trip: time from this round's creator dispatch to threshold signatures
         // received. Consume the entry keyed by `round` so a failed earlier round (which never
-        // reaches here) cannot contribute a stale, inflated sample.
-        if let Some(start) = take_dispatch_time(&self.dispatch_time, round)
+        // reaches here) cannot contribute a stale, inflated sample. The dispatch instant is kept
+        // so the end-to-end round latency can be observed once execution completes.
+        let dispatch_start = take_dispatch_time(&self.dispatch_time, round);
+        if let Some(start) = dispatch_start
             && let Some(m) = &self.metrics
         {
             m.p2p_round_trip_seconds
@@ -393,6 +395,13 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
             match &result {
                 Ok(_) => {
                     m.aggregation_rounds_completed.inc();
+                    // End-to-end round latency: creator dispatch through receipt confirmation.
+                    // Failed rounds are skipped — they have no on-chain confirmation, and a
+                    // receipt-timeout sample would distort the percentiles.
+                    if let Some(start) = dispatch_start {
+                        m.round_latency_seconds
+                            .observe(start.elapsed().as_secs_f64());
+                    }
                 }
                 Err(_) => {
                     m.aggregation_rounds_failed.inc();

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -22,6 +22,7 @@ use commonware_avs_eigenlayer::AvsDeployment;
 use commonware_avs_router::bindings::bls_apk_registry::BLSApkRegistry;
 use commonware_avs_router::bindings::bls_sig_check_operator_state_retriever::BLSSigCheckOperatorStateRetriever;
 use commonware_avs_router::executor::bls::BlsEigenlayerExecutor;
+use commonware_runtime::Metrics;
 use gas_killer_common::{ChainRole, GasKillerValidator};
 use std::collections::HashMap;
 use std::{env, str::FromStr, sync::Arc};
@@ -189,6 +190,7 @@ async fn create_wallet_provider_for_chain(
 pub async fn create_gas_killer_executor(
     metrics: Arc<MetricsCollector>,
     dispatch_time: DispatchTime,
+    context: &impl Metrics,
 ) -> Result<BlsEigenlayerExecutor<GasKillerHandler<SimpleWalletProvider>>> {
     let http_rpc = env::var("HTTP_RPC").expect("HTTP_RPC must be set");
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
@@ -303,5 +305,6 @@ pub async fn create_gas_killer_executor(
         bls_operator_state_retriever,
         registry_coordinator_address,
         gas_killer_handler,
-    ))
+    )
+    .with_metrics(context))
 }

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -304,7 +304,7 @@ fn main() {
         }
 
         let orchestrator =
-            GasKillerOrchestratorBuilder::build(builder, validator, Arc::clone(&metrics))
+            GasKillerOrchestratorBuilder::build(builder, validator, Arc::clone(&metrics), &context)
                 .await
                 .expect("Failed to build orchestrator");
 

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -70,7 +70,7 @@ impl MetricsCollector {
         );
 
         let storage_computation_seconds =
-            Histogram::new([0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0, 120.0, 300.0]);
+            Histogram::new([0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0, 120.0, 300.0].into_iter());
         registry.register(
             "gas_killer_storage_computation_seconds",
             "EVM storage-update computation duration in seconds",
@@ -92,9 +92,12 @@ impl MetricsCollector {
         );
 
         // Fast reverts (~sub-second, fail at tx send) and confirmed runs (~block-time dominated); Buckets resolve both ends.
-        let execution_duration_seconds = Histogram::new([
-            0.5, 1.0, 2.0, 5.0, 8.0, 12.0, 16.0, 20.0, 24.0, 30.0, 45.0, 60.0, 120.0, 300.0,
-        ]);
+        let execution_duration_seconds = Histogram::new(
+            [
+                0.5, 1.0, 2.0, 5.0, 8.0, 12.0, 16.0, 20.0, 24.0, 30.0, 45.0, 60.0, 120.0, 300.0,
+            ]
+            .into_iter(),
+        );
         registry.register(
             "gas_killer_execution_duration_seconds",
             "Duration of handle_verification including all contract calls and tx submission",
@@ -102,7 +105,7 @@ impl MetricsCollector {
         );
 
         let p2p_round_trip_seconds =
-            Histogram::new([0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0]);
+            Histogram::new([0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0].into_iter());
         registry.register(
             "gas_killer_p2p_round_trip_seconds",
             "Time from creator dispatching a task to executor receiving threshold signatures (P2P transit + node EVMSketch + BLS signing + aggregation)",
@@ -111,9 +114,12 @@ impl MetricsCollector {
 
         // Roughly p2p_round_trip + execution_duration; block-time dominated, so the
         // execution-duration buckets resolve it well.
-        let round_latency_seconds = Histogram::new([
-            0.5, 1.0, 2.0, 5.0, 8.0, 12.0, 16.0, 20.0, 24.0, 30.0, 45.0, 60.0, 120.0, 300.0,
-        ]);
+        let round_latency_seconds = Histogram::new(
+            [
+                0.5, 1.0, 2.0, 5.0, 8.0, 12.0, 16.0, 20.0, 24.0, 30.0, 45.0, 60.0, 120.0, 300.0,
+            ]
+            .into_iter(),
+        );
         registry.register(
             "gas_killer_round_latency_seconds",
             "End-to-end round latency from creator dispatch to verifyAndUpdate receipt confirmation (successful rounds only)",
@@ -131,28 +137,29 @@ impl MetricsCollector {
         let rpc_buckets = [
             0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.15, 0.25, 0.5, 1.0, 2.5,
         ];
-        let executor_chain_detection_seconds = Histogram::new(rpc_buckets);
+        let executor_chain_detection_seconds = Histogram::new(rpc_buckets.into_iter());
         registry.register(
             "gas_killer_executor_chain_detection_seconds",
             "Time to detect which chain a target contract is deployed on",
             executor_chain_detection_seconds.clone(),
         );
 
-        let executor_hash_preflight_seconds = Histogram::new(rpc_buckets);
+        let executor_hash_preflight_seconds = Histogram::new(rpc_buckets.into_iter());
         registry.register(
             "gas_killer_executor_hash_preflight_seconds",
             "Time for the payload-hash preflight computation",
             executor_hash_preflight_seconds.clone(),
         );
 
-        let executor_supports_interface_seconds = Histogram::new(rpc_buckets);
+        let executor_supports_interface_seconds = Histogram::new(rpc_buckets.into_iter());
         registry.register(
             "gas_killer_executor_supports_interface_seconds",
             "Time for the supportsInterface ERC-165 check",
             executor_supports_interface_seconds.clone(),
         );
 
-        let executor_tx_send_seconds = Histogram::new([0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0]);
+        let executor_tx_send_seconds =
+            Histogram::new([0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0].into_iter());
         registry.register(
             "gas_killer_executor_tx_send_seconds",
             "Time from calling verifyAndUpdate to receiving the pending tx handle",
@@ -160,9 +167,12 @@ impl MetricsCollector {
         );
 
         // Block-time driven (~1-2 confirmations); dense through the 8-30s window.
-        let executor_receipt_confirmation_seconds = Histogram::new([
-            1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 15.0, 18.0, 24.0, 30.0, 45.0, 60.0, 120.0,
-        ]);
+        let executor_receipt_confirmation_seconds = Histogram::new(
+            [
+                1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 15.0, 18.0, 24.0, 30.0, 45.0, 60.0, 120.0,
+            ]
+            .into_iter(),
+        );
         registry.register(
             "gas_killer_executor_receipt_confirmation_seconds",
             "Time waiting for the verifyAndUpdate receipt to be mined",

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -24,6 +24,12 @@ pub struct MetricsCollector {
     /// Time from creator dispatching a task to the executor receiving threshold signatures (seconds).
     /// Captures P2P transit + node EVMSketch + BLS signing + aggregation.
     pub p2p_round_trip_seconds: Histogram,
+    /// End-to-end round latency from creator dispatch to verifyAndUpdate receipt confirmation
+    /// (seconds). Observed only for rounds that complete successfully, so failed rounds — which
+    /// have no on-chain confirmation — cannot skew the percentiles with receipt-timeout artifacts.
+    /// Excludes ingress-queue wait and router-side storage computation, which finish before the
+    /// dispatch timestamp is stamped.
+    pub round_latency_seconds: Histogram,
     /// Current number of tasks sitting in the ingress queue waiting to be processed.
     pub task_queue_depth: Gauge<i64, AtomicI64>,
     /// Time to detect which chain a target contract is deployed on (seconds).
@@ -103,6 +109,17 @@ impl MetricsCollector {
             p2p_round_trip_seconds.clone(),
         );
 
+        // Roughly p2p_round_trip + execution_duration; block-time dominated, so the
+        // execution-duration buckets resolve it well.
+        let round_latency_seconds = Histogram::new([
+            0.5, 1.0, 2.0, 5.0, 8.0, 12.0, 16.0, 20.0, 24.0, 30.0, 45.0, 60.0, 120.0, 300.0,
+        ]);
+        registry.register(
+            "gas_killer_round_latency_seconds",
+            "End-to-end round latency from creator dispatch to verifyAndUpdate receipt confirmation (successful rounds only)",
+            round_latency_seconds.clone(),
+        );
+
         let task_queue_depth = Gauge::default();
         registry.register(
             "gas_killer_task_queue_depth",
@@ -162,6 +179,7 @@ impl MetricsCollector {
             aggregation_rounds_failed,
             execution_duration_seconds,
             p2p_round_trip_seconds,
+            round_latency_seconds,
             task_queue_depth,
             executor_chain_detection_seconds,
             executor_hash_preflight_seconds,
@@ -181,5 +199,23 @@ impl MetricsCollector {
 impl Default for MetricsCollector {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_latency_histogram_registered_and_observable() {
+        let metrics = MetricsCollector::new();
+        metrics.round_latency_seconds.observe(12.5);
+
+        let output = metrics.encode();
+        assert!(output.contains(
+            "gas_killer_round_latency_seconds End-to-end round latency from creator dispatch"
+        ));
+        assert!(output.contains("gas_killer_round_latency_seconds_count 1"));
+        assert!(output.contains("gas_killer_round_latency_seconds_sum 12.5"));
     }
 }


### PR DESCRIPTION
Adds the `gas_killer_round_latency_seconds` end-to-end histogram from #265 and surfaces orchestrator internals on the dashboard.

## Changes
- **`router/src/metrics.rs`** — new `gas_killer_round_latency_seconds` histogram measuring creator dispatch → `verifyAndUpdate` receipt confirmation. Observed for **successful rounds only**: failed rounds have no on-chain confirmation, and a receipt-timeout failure would otherwise inject artificial ~120s samples into the percentiles this metric exists to track.
- **`router/src/executor.rs`** — `handle_verification` stamps dispatch time before the P2P round-trip and observes round latency on the success path.
- **`router/src/factories.rs` / `builder.rs` / `main.rs`** — threads `&context` into `create_gas_killer_executor` and calls `.with_metrics(context)` on the BLS executor so EigenLayer state-retrieval metrics (`executor_operator_cache_misses_total`, etc.) register under the runtime context and surface via `context.encode()` on `/metrics`.
- **`Cargo.toml`** — pins `prometheus-client` to 0.22.3 (0.23 changed the `Histogram::new` API; `.into_iter()` adapters added throughout).
- **`helm/.../monitoring-grafana-dashboard.yaml`** — new **Orchestrator Internals** section (y=32) with six panels:
  - Time to Quorum (p50/p95) — round broadcast → threshold reached, isolates aggregation from EigenLayer reads
  - Signature Arrival Spread (p50/p99) — detects straggler operators holding rounds open
  - Round Outcomes / min — executed / execution failed / window timeout
  - Signatures / min by Outcome — success / invalid / dropped
  - EigenLayer State Retrieval (p50/p95) — operator resolution + non-signer reads between quorum and `handle_verification`
  - Operator Cache Misses — stat panel for cache miss counter
  - Existing Ingress and Executor Phase Breakdown sections shifted down to y=49+.

## Notes on issue #265 scope
- The **DispatchTime single-slot staleness caveat** called out in the issue is already resolved on `main`: dispatch timestamps are keyed per-round with eviction, so the new histogram reuses the same per-round instant with no staleness bleed.
- Orchestrator internals (time-to-quorum, signature-arrival spread, round outcomes) now surface on `/metrics` via `context.encode()` after the `with_metrics` wiring; the new dashboard panels make them immediately visible.
- The start point is creator dispatch (after multi-second storage computation) — this is "dispatch → on-chain confirmation," not "ingress-accept → confirmation." The metric help text and dashboard header state this.

## Testing
- New unit test asserting the histogram is registered and encodes observations.
- `cargo fmt`, `clippy --all-targets --all-features -D warnings`, `check`, `test` all pass.

Closes #265 / part of gas-killer/roadmap#10.