### PR TITLE
feat: make P2P message backlog and rate limit configurable

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -189,14 +189,27 @@ pub fn p2p_message_backlog() -> usize {
         .unwrap_or(DEFAULT_P2P_MESSAGE_BACKLOG)
 }
 
-/// Reads the P2P channel rate limit from `P2P_MESSAGES_PER_SECOND`, defaulting to
-/// [`DEFAULT_P2P_MESSAGES_PER_SECOND`].
-pub fn p2p_messages_per_second() -> f64 {
-    env::var("P2P_MESSAGES_PER_SECOND")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .filter(|&v: &f64| v > 0.0 && v.is_finite())
-        .unwrap_or(DEFAULT_P2P_MESSAGES_PER_SECOND)
+/// Reads the P2P channel rate limit from `P2P_MESSAGES_PER_SECOND` and returns the
+/// per-message quota period (`1 / rate`), defaulting to
+/// [`DEFAULT_P2P_MESSAGES_PER_SECOND`] when unset or invalid.
+///
+/// The quota is a smooth rate with no burst allowance: a rate of `5.0` permits one
+/// message every 200 ms, not bursts of five. Values whose reciprocal would overflow
+/// a `Duration` (e.g. `1e-20`) are treated as invalid and fall back to the default.
+pub fn p2p_quota_period() -> std::time::Duration {
+    parse_p2p_quota_period(env::var("P2P_MESSAGES_PER_SECOND").ok().as_deref())
+}
+
+/// Parses a `P2P_MESSAGES_PER_SECOND` value into a quota period, falling back to the
+/// default rate on malformed, non-positive, non-finite, or `Duration`-overflowing input.
+fn parse_p2p_quota_period(value: Option<&str>) -> std::time::Duration {
+    value
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .filter(|&v| v > 0.0 && v.is_finite())
+        .and_then(|v| std::time::Duration::try_from_secs_f64(1.0 / v).ok())
+        .unwrap_or_else(|| {
+            std::time::Duration::from_secs_f64(1.0 / DEFAULT_P2P_MESSAGES_PER_SECOND)
+        })
 }
 
 /// Maximum age (in blocks) of a reference block, falling back to the contract default
@@ -258,5 +271,45 @@ impl SpeculativePrebuildConfig {
             poll_interval: std::time::Duration::from_millis(poll_ms),
             confirmation_depth,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn p2p_quota_period_default_is_one_per_second() {
+        assert_eq!(parse_p2p_quota_period(None), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn p2p_quota_period_converts_rate_to_period() {
+        assert_eq!(
+            parse_p2p_quota_period(Some("5.0")),
+            Duration::from_millis(200)
+        );
+        assert_eq!(parse_p2p_quota_period(Some("0.5")), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn p2p_quota_period_rejects_invalid_values() {
+        let default = Duration::from_secs(1);
+        assert_eq!(parse_p2p_quota_period(Some("")), default);
+        assert_eq!(parse_p2p_quota_period(Some("abc")), default);
+        assert_eq!(parse_p2p_quota_period(Some("0")), default);
+        assert_eq!(parse_p2p_quota_period(Some("-1.5")), default);
+        assert_eq!(parse_p2p_quota_period(Some("inf")), default);
+        assert_eq!(parse_p2p_quota_period(Some("NaN")), default);
+    }
+
+    #[test]
+    fn p2p_quota_period_rejects_duration_overflow() {
+        // 1.0 / 1e-20 overflows Duration; must fall back to the default, not panic.
+        assert_eq!(
+            parse_p2p_quota_period(Some("1e-20")),
+            Duration::from_secs(1)
+        );
     }
 }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -195,18 +195,21 @@ pub fn p2p_message_backlog() -> usize {
 ///
 /// The quota is a smooth rate with no burst allowance: a rate of `5.0` permits one
 /// message every 200 ms, not bursts of five. Values whose reciprocal would overflow
-/// a `Duration` (e.g. `1e-20`) are treated as invalid and fall back to the default.
+/// a `Duration` (e.g. `1e-20`) or round below its 1 ns resolution (e.g. `3e9`) are
+/// treated as invalid and fall back to the default.
 pub fn p2p_quota_period() -> std::time::Duration {
     parse_p2p_quota_period(env::var("P2P_MESSAGES_PER_SECOND").ok().as_deref())
 }
 
 /// Parses a `P2P_MESSAGES_PER_SECOND` value into a quota period, falling back to the
-/// default rate on malformed, non-positive, non-finite, or `Duration`-overflowing input.
+/// default rate on malformed, non-positive, non-finite, or non-representable input
+/// (including `Duration` overflow and sub-nanosecond reciprocals that round to zero).
 fn parse_p2p_quota_period(value: Option<&str>) -> std::time::Duration {
     value
         .and_then(|v| v.trim().parse::<f64>().ok())
         .filter(|&v| v > 0.0 && v.is_finite())
         .and_then(|v| std::time::Duration::try_from_secs_f64(1.0 / v).ok())
+        .filter(|d| !d.is_zero())
         .unwrap_or_else(|| {
             std::time::Duration::from_secs_f64(1.0 / DEFAULT_P2P_MESSAGES_PER_SECOND)
         })
@@ -309,6 +312,15 @@ mod tests {
         // 1.0 / 1e-20 overflows Duration; must fall back to the default, not panic.
         assert_eq!(
             parse_p2p_quota_period(Some("1e-20")),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn p2p_quota_period_rejects_excessive_rate() {
+        // 1.0 / 3e9 rounds below 1 ns and becomes Duration::ZERO; must fall back to default.
+        assert_eq!(
+            parse_p2p_quota_period(Some("3e9")),
             Duration::from_secs(1)
         );
     }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -167,6 +167,38 @@ pub async fn get_operator_states() -> Result<Vec<QuorumInfo>, Box<dyn std::error
     client.get_operator_states().await
 }
 
+/// Default P2P channel message backlog depth.
+///
+/// The backlog bounds how many queued messages the channel will hold before the sender
+/// blocks or drops new messages. Configurable at runtime via `P2P_MESSAGE_BACKLOG`.
+pub const DEFAULT_P2P_MESSAGE_BACKLOG: usize = 256;
+
+/// Default P2P channel rate limit in messages per second.
+///
+/// Configurable at runtime via `P2P_MESSAGES_PER_SECOND`. Accepts fractional values
+/// (e.g. `0.5` for one message every two seconds).
+pub const DEFAULT_P2P_MESSAGES_PER_SECOND: f64 = 1.0;
+
+/// Reads the P2P channel backlog depth from `P2P_MESSAGE_BACKLOG`, defaulting to
+/// [`DEFAULT_P2P_MESSAGE_BACKLOG`].
+pub fn p2p_message_backlog() -> usize {
+    env::var("P2P_MESSAGE_BACKLOG")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v: &usize| v > 0)
+        .unwrap_or(DEFAULT_P2P_MESSAGE_BACKLOG)
+}
+
+/// Reads the P2P channel rate limit from `P2P_MESSAGES_PER_SECOND`, defaulting to
+/// [`DEFAULT_P2P_MESSAGES_PER_SECOND`].
+pub fn p2p_messages_per_second() -> f64 {
+    env::var("P2P_MESSAGES_PER_SECOND")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v: &f64| v > 0.0 && v.is_finite())
+        .unwrap_or(DEFAULT_P2P_MESSAGES_PER_SECOND)
+}
+
 /// Maximum age (in blocks) of a reference block, falling back to the contract default
 /// when `BLOCK_STALE_MEASURE` is unset or unparseable.
 ///

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -319,9 +319,6 @@ mod tests {
     #[test]
     fn p2p_quota_period_rejects_excessive_rate() {
         // 1.0 / 3e9 rounds below 1 ns and becomes Duration::ZERO; must fall back to default.
-        assert_eq!(
-            parse_p2p_quota_period(Some("3e9")),
-            Duration::from_secs(1)
-        );
+        assert_eq!(parse_p2p_quota_period(Some("3e9")), Duration::from_secs(1));
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,7 +8,7 @@ pub mod validator;
 pub use config::{
     ChainRole, KeyConfig, OrchestratorConfig, SpeculativePrebuildConfig, block_stale_measure,
     detect_chain_for_address, get_operator_states, load_key_from_file, load_orchestrator_config,
-    p2p_message_backlog, p2p_messages_per_second,
+    p2p_message_backlog, p2p_quota_period,
 };
 pub use providers::{build_read_providers, chain_rpc_urls_from_env};
 pub use task_data::GasKillerTaskData;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod validator;
 pub use config::{
     ChainRole, KeyConfig, OrchestratorConfig, SpeculativePrebuildConfig, block_stale_measure,
     detect_chain_for_address, get_operator_states, load_key_from_file, load_orchestrator_config,
+    p2p_message_backlog, p2p_messages_per_second,
 };
 pub use providers::{build_read_providers, chain_rpc_urls_from_env};
 pub use task_data::GasKillerTaskData;

--- a/example.env
+++ b/example.env
@@ -42,6 +42,20 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # EXECUTOR_RECEIPT_TIMEOUT_SECS=120
 
 # =============================================================================
+# P2P Channel Configuration
+# =============================================================================
+# P2P_MESSAGE_BACKLOG: depth of the per-channel message queue (default: 256).
+# Once full, incoming messages are dropped. Increase if operators or the router
+# fall behind under bursts; the cost is memory proportional to message size.
+# P2P_MESSAGE_BACKLOG=256
+#
+# P2P_MESSAGES_PER_SECOND: rate limit for the P2P channel (default: 1.0).
+# Accepts floats — use values < 1.0 for sub-second intervals (e.g. 0.5 = one
+# message every two seconds) or > 1.0 for higher throughput. Raising this
+# beyond what gas-analyzer can process will cause queue buildup on the node.
+# P2P_MESSAGES_PER_SECOND=1.0
+
+# =============================================================================
 # AVS Service Manager Wrapper Configuration
 # =============================================================================
 # These values are passed as immutable constructor parameters when deploying

--- a/example.env
+++ b/example.env
@@ -51,8 +51,10 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 #
 # P2P_MESSAGES_PER_SECOND: rate limit for the P2P channel (default: 1.0).
 # Accepts floats — use values < 1.0 for sub-second intervals (e.g. 0.5 = one
-# message every two seconds) or > 1.0 for higher throughput. Raising this
-# beyond what gas-analyzer can process will cause queue buildup on the node.
+# message every two seconds) or > 1.0 for higher throughput. This is a smooth
+# rate with no burst allowance: 5.0 means one message every 200ms, not bursts
+# of five. Raising this beyond what gas-analyzer can process will cause queue
+# buildup on the node.
 # P2P_MESSAGES_PER_SECOND=1.0
 
 # =============================================================================

--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -427,6 +427,10 @@ data:
             {
               "expr": "rate(gas_killer_ingress_requests_rejected_total[2m]) * 60",
               "legendFormat": "rejected"
+            },
+            {
+              "expr": "rate(gas_killer_ingress_requests_at_capacity_total[2m]) * 60",
+              "legendFormat": "at capacity (503)"
             }
           ],
           "fieldConfig": { "defaults": { "unit": "short" } }

--- a/helm/gas-killer/templates/node-deployment.yaml
+++ b/helm/gas-killer/templates/node-deployment.yaml
@@ -219,6 +219,10 @@ spec:
               {{- end }}
             - name: HEALTHZ_PORT
               value: {{ $root.Values.node.healthzPort | quote }}
+            - name: P2P_MESSAGE_BACKLOG
+              value: {{ $root.Values.node.p2pMessageBacklog | quote }}
+            - name: P2P_MESSAGES_PER_SECOND
+              value: {{ $root.Values.node.p2pMessagesPerSecond | quote }}
           ports:
             - name: node
               containerPort: {{ $nodePort }}

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -311,6 +311,10 @@ spec:
             {{- end }}
             - name: HEALTHZ_PORT
               value: {{ .Values.router.healthzPort | quote }}
+            - name: P2P_MESSAGE_BACKLOG
+              value: {{ .Values.router.p2pMessageBacklog | quote }}
+            - name: P2P_MESSAGES_PER_SECOND
+              value: {{ .Values.router.p2pMessagesPerSecond | quote }}
             - name: PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -233,6 +233,12 @@ node:
   #   socketAddressOverrides:
   #     "1": "203.0.113.42:3001"
   socketAddressOverrides: {}
+  # P2P channel message queue depth. Messages are dropped when the queue is full.
+  # Increase for bursty workloads; the cost is memory proportional to message size.
+  p2pMessageBacklog: 256
+  # P2P channel rate limit in messages per second. Accepts floats (e.g. 0.5 = one
+  # message every two seconds). Raising beyond gas-analyzer throughput causes queue buildup.
+  p2pMessagesPerSecond: "1.0"
   # Port for the node's /healthz HTTP endpoint (used by Kubernetes probes)
   healthzPort: 8081
   # How long Kubernetes waits for a node to finish in-flight work after SIGTERM.
@@ -262,6 +268,12 @@ router:
   # 0.0.0.0 (all interfaces) is required in Kubernetes so the pod can receive
   # traffic from the Service. Override to 127.0.0.1 for local-only access.
   ingressBindHost: "0.0.0.0"
+  # P2P channel message queue depth. Messages are dropped when the queue is full.
+  # Increase for bursty workloads; the cost is memory proportional to message size.
+  p2pMessageBacklog: 256
+  # P2P channel rate limit in messages per second. Accepts floats (e.g. 0.5 = one
+  # message every two seconds). Raising beyond gas-analyzer throughput causes queue buildup.
+  p2pMessagesPerSecond: "1.0"
   # Port for the router's /healthz and /readyz HTTP endpoints (used by Kubernetes probes)
   healthzPort: 8081
   # How long Kubernetes waits for a router to finish in-flight work after SIGTERM.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,11 +13,12 @@ use commonware_avs_node::contributor::{AggregationInput, Contribute, Contributor
 use commonware_p2p::Manager;
 use commonware_p2p::authenticated::lookup::{self, Network};
 use commonware_runtime::{Metrics, Runner, Spawner, tokio};
-use commonware_utils::{NZU32, set::OrderedAssociated};
+use commonware_utils::set::OrderedAssociated;
 use eigen_logging::log_level::LogLevel;
 use gas_killer_common::{
     GasKillerTaskData, GasKillerValidator, OrchestratorConfig, SpeculativePrebuildConfig,
     ValidatorMetrics, get_operator_states, load_key_from_file, load_orchestrator_config,
+    p2p_message_backlog, p2p_messages_per_second,
 };
 use governor::Quota;
 use std::collections::HashMap;
@@ -350,9 +351,11 @@ fn main() {
         let aggregation_input = AggregationInput::new(threshold, g1_map);
 
         // Create network channel
-        const DEFAULT_MESSAGE_BACKLOG: usize = 256;
-        let (sender, receiver) =
-            network.register(0, Quota::per_second(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
+        let p2p_backlog = p2p_message_backlog();
+        let p2p_quota =
+            Quota::with_period(Duration::from_secs_f64(1.0 / p2p_messages_per_second()))
+                .expect("P2P_MESSAGES_PER_SECOND must be positive and finite");
+        let (sender, receiver) = network.register(0, p2p_quota, p2p_backlog);
 
         // Create validator metrics and validator for the gas killer use case
         let validator_metrics = Arc::new(ValidatorMetrics::new());

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -18,7 +18,7 @@ use eigen_logging::log_level::LogLevel;
 use gas_killer_common::{
     GasKillerTaskData, GasKillerValidator, OrchestratorConfig, SpeculativePrebuildConfig,
     ValidatorMetrics, get_operator_states, load_key_from_file, load_orchestrator_config,
-    p2p_message_backlog, p2p_messages_per_second,
+    p2p_message_backlog, p2p_quota_period,
 };
 use governor::Quota;
 use std::collections::HashMap;
@@ -352,9 +352,8 @@ fn main() {
 
         // Create network channel
         let p2p_backlog = p2p_message_backlog();
-        let p2p_quota =
-            Quota::with_period(Duration::from_secs_f64(1.0 / p2p_messages_per_second()))
-                .expect("P2P_MESSAGES_PER_SECOND must be positive and finite");
+        let p2p_quota = Quota::with_period(p2p_quota_period())
+            .expect("p2p_quota_period always returns a non-zero duration");
         let (sender, receiver) = network.register(0, p2p_quota, p2p_backlog);
 
         // Create validator metrics and validator for the gas killer use case

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -120,6 +120,7 @@ pub async fn create_listening_creator_with_server(
     let ingress_state = IngressState::new(
         sender,
         queue_depth,
+        gas_killer_common::p2p_message_backlog(),
         metrics,
         providers,
         ingress_password,

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -58,6 +58,8 @@ pub struct AvsOperatorSetSoftware {
 pub struct IngressState {
     pub sender: TaskSender,
     pub queue_depth: TaskQueueDepth,
+    /// Maximum number of tasks allowed in the queue before the ingress starts returning 503.
+    pub max_queue_depth: usize,
     pub metrics: Option<Arc<MetricsCollector>>,
     pub providers: Arc<HashMap<ChainRole, ReadOnlyProvider>>,
     /// Bearer token password. `None` disables authentication.
@@ -69,6 +71,7 @@ impl IngressState {
     pub fn new(
         sender: TaskSender,
         queue_depth: TaskQueueDepth,
+        max_queue_depth: usize,
         metrics: Arc<MetricsCollector>,
         providers: HashMap<ChainRole, ReadOnlyProvider>,
         password: Option<String>,
@@ -77,6 +80,7 @@ impl IngressState {
         Self {
             sender,
             queue_depth,
+            max_queue_depth,
             metrics: Some(metrics),
             providers: Arc::new(providers),
             password,
@@ -88,6 +92,7 @@ impl IngressState {
         Self {
             sender,
             queue_depth,
+            max_queue_depth: gas_killer_common::p2p_message_backlog(),
             metrics: None,
             providers: Arc::new(HashMap::new()),
             password: None,
@@ -456,6 +461,25 @@ pub async fn trigger_task_handler(
             Json(GasKillerTaskResponse {
                 success: false,
                 message: client_message,
+            }),
+        );
+    }
+
+    let current_depth = state.queue_depth.load(Ordering::Relaxed);
+    if current_depth >= state.max_queue_depth {
+        warn!(
+            queue_depth = current_depth,
+            max_queue_depth = state.max_queue_depth,
+            "Task rejected: queue at capacity"
+        );
+        if let Some(m) = &state.metrics {
+            m.ingress_at_capacity.inc();
+        }
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(GasKillerTaskResponse {
+                success: false,
+                message: "Service at capacity, please try again in a few minutes".to_string(),
             }),
         );
     }

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -412,6 +412,29 @@ pub async fn trigger_task_handler(
         );
     }
 
+    // Load-shed before any validation work. Onchain validation costs multiple RPC
+    // round-trips, so rejecting at-capacity requests up front keeps an overloaded
+    // service from amplifying its own load; a request that would have failed
+    // validation gets a 503 instead of a 400 while the queue is full.
+    let current_depth = state.queue_depth.load(Ordering::Relaxed);
+    if current_depth >= state.max_queue_depth {
+        warn!(
+            queue_depth = current_depth,
+            max_queue_depth = state.max_queue_depth,
+            "Task rejected: queue at capacity"
+        );
+        if let Some(m) = &state.metrics {
+            m.ingress_at_capacity.inc();
+        }
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(GasKillerTaskResponse {
+                success: false,
+                message: "Service at capacity, please try again in a few minutes".to_string(),
+            }),
+        );
+    }
+
     if let Err(e) = request.validate() {
         warn!(
             target_address = %request.body.target_address,
@@ -461,25 +484,6 @@ pub async fn trigger_task_handler(
             Json(GasKillerTaskResponse {
                 success: false,
                 message: client_message,
-            }),
-        );
-    }
-
-    let current_depth = state.queue_depth.load(Ordering::Relaxed);
-    if current_depth >= state.max_queue_depth {
-        warn!(
-            queue_depth = current_depth,
-            max_queue_depth = state.max_queue_depth,
-            "Task rejected: queue at capacity"
-        );
-        if let Some(m) = &state.metrics {
-            m.ingress_at_capacity.inc();
-        }
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(GasKillerTaskResponse {
-                success: false,
-                message: "Service at capacity, please try again in a few minutes".to_string(),
             }),
         );
     }
@@ -1133,6 +1137,23 @@ mod tests {
             let body = response_body(resp).await;
             assert!(!body.success);
             assert!(body.message.to_lowercase().contains("capacity"));
+        }
+
+        #[tokio::test]
+        async fn test_full_queue_increments_at_capacity_metric() {
+            let (sender, _receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let metrics = Arc::new(MetricsCollector::new());
+            let mut state = IngressState::without_metrics(sender, queue_depth.clone());
+            state.metrics = Some(Arc::clone(&metrics));
+            state.max_queue_depth = 1;
+            queue_depth.store(1, std::sync::atomic::Ordering::Relaxed);
+            let app = build_app().with_state(state);
+
+            let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(metrics.ingress_at_capacity.get(), 1);
+            assert_eq!(metrics.ingress_rejected.get(), 0);
         }
 
         #[tokio::test]

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1117,6 +1117,37 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::OK);
         }
 
+        // -- queue capacity tests --
+
+        #[tokio::test]
+        async fn test_full_queue_returns_503() {
+            let (sender, _receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let mut state = IngressState::without_metrics(sender, queue_depth.clone());
+            state.max_queue_depth = 1;
+            queue_depth.store(1, std::sync::atomic::Ordering::Relaxed);
+            let app = build_app().with_state(state);
+
+            let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let body = response_body(resp).await;
+            assert!(!body.success);
+            assert!(body.message.to_lowercase().contains("capacity"));
+        }
+
+        #[tokio::test]
+        async fn test_queue_one_below_limit_still_accepts() {
+            let (sender, _receiver) = crate::creator::task_channel();
+            let queue_depth = crate::creator::task_queue_depth();
+            let mut state = IngressState::without_metrics(sender, queue_depth.clone());
+            state.max_queue_depth = 2;
+            queue_depth.store(1, std::sync::atomic::Ordering::Relaxed);
+            let app = build_app().with_state(state);
+
+            let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+
         #[tokio::test]
         async fn test_rejected_request_does_not_enqueue() {
             let (app, mut receiver) = make_app();

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -19,7 +19,7 @@ use commonware_utils::set::OrderedAssociated;
 use eigen_logging::log_level::LogLevel;
 use gas_killer_common::{
     GasKillerValidator, SpeculativePrebuildConfig, get_operator_states, load_key_from_file,
-    p2p_message_backlog, p2p_messages_per_second,
+    p2p_message_backlog, p2p_quota_period,
 };
 use gas_killer_router::GasKillerOrchestratorBuilder;
 use gas_killer_router::metrics::MetricsCollector;
@@ -274,9 +274,8 @@ fn main() {
 
         // Run as the orchestrator using the builder pattern
         let p2p_backlog = p2p_message_backlog();
-        let p2p_quota =
-            Quota::with_period(Duration::from_secs_f64(1.0 / p2p_messages_per_second()))
-                .expect("P2P_MESSAGES_PER_SECOND must be positive and finite");
+        let p2p_quota = Quota::with_period(p2p_quota_period())
+            .expect("p2p_quota_period always returns a non-zero duration");
         let (sender, receiver) = network.register(0, p2p_quota, p2p_backlog);
 
         // Custom Prometheus metrics — shared with executor, creator, and ingress via builder

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -15,11 +15,11 @@ use commonware_runtime::{
     Metrics, Runner, Spawner,
     tokio::{self},
 };
-use commonware_utils::NZU32;
 use commonware_utils::set::OrderedAssociated;
 use eigen_logging::log_level::LogLevel;
 use gas_killer_common::{
     GasKillerValidator, SpeculativePrebuildConfig, get_operator_states, load_key_from_file,
+    p2p_message_backlog, p2p_messages_per_second,
 };
 use gas_killer_router::GasKillerOrchestratorBuilder;
 use gas_killer_router::metrics::MetricsCollector;
@@ -273,10 +273,11 @@ fn main() {
         let threshold = quorum_infos[quorum_number].threshold;
 
         // Run as the orchestrator using the builder pattern
-        const DEFAULT_MESSAGE_BACKLOG: usize = 256;
-
-        let (sender, receiver) =
-            network.register(0, Quota::per_second(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
+        let p2p_backlog = p2p_message_backlog();
+        let p2p_quota =
+            Quota::with_period(Duration::from_secs_f64(1.0 / p2p_messages_per_second()))
+                .expect("P2P_MESSAGES_PER_SECOND must be positive and finite");
+        let (sender, receiver) = network.register(0, p2p_quota, p2p_backlog);
 
         // Custom Prometheus metrics — shared with executor, creator, and ingress via builder
         let metrics = Arc::new(MetricsCollector::new());

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -11,6 +11,8 @@ pub struct MetricsCollector {
     pub ingress_accepted: Counter<u64, AtomicU64>,
     /// Ingress requests rejected by validation.
     pub ingress_rejected: Counter<u64, AtomicU64>,
+    /// Ingress requests dropped because the task queue is at capacity.
+    pub ingress_at_capacity: Counter<u64, AtomicU64>,
     /// Tasks dequeued and handed to the creator for aggregation.
     pub tasks_created: Counter<u64, AtomicU64>,
     /// EVM storage-update computation duration (seconds).
@@ -60,6 +62,13 @@ impl MetricsCollector {
             "gas_killer_ingress_requests_rejected",
             "Total ingress task requests rejected by validation",
             ingress_rejected.clone(),
+        );
+
+        let ingress_at_capacity = Counter::default();
+        registry.register(
+            "gas_killer_ingress_requests_at_capacity",
+            "Total ingress task requests dropped because the queue was full",
+            ingress_at_capacity.clone(),
         );
 
         let tasks_created = Counter::default();
@@ -183,6 +192,7 @@ impl MetricsCollector {
             registry,
             ingress_accepted,
             ingress_rejected,
+            ingress_at_capacity,
             tasks_created,
             storage_computation_seconds,
             aggregation_rounds_completed,


### PR DESCRIPTION
## Summary
- Adds `P2P_MESSAGE_BACKLOG` (default 256) and `P2P_MESSAGES_PER_SECOND` (default 1.0) env vars, replacing hardcoded values in `node/src/main.rs` and `router/src/main.rs`
- Returns 503 with a human-readable message at the ingress when `queue_depth >= P2P_MESSAGE_BACKLOG`, preventing silent drops at the P2P layer
- Adds `gas_killer_ingress_requests_at_capacity` Prometheus counter for observability
- Wires both vars into `example.env` and Helm chart values/templates

## Test plan
- [ ] Deploy with defaults — verify no behavior change
- [ ] Set `P2P_MESSAGE_BACKLOG=2` and send 3 rapid requests — third should receive 503 "Service at capacity"
- [ ] Set `P2P_MESSAGES_PER_SECOND=5.0` — verify throughput increase via `gas_killer_ingress_requests_accepted` metric
- [ ] Check `gas_killer_ingress_requests_at_capacity` increments correctly under load

Closes #181