### PR TITLE
feat: update to "commonware-restaking" orchestrator latency improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commonware-avs-bindings"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#623d4231123dfa7853c08d6e6ec8c624d64dc9b3"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#8f3c32773dfa07af8b8f25cc6f445a79bde2ec4f"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-core"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#623d4231123dfa7853c08d6e6ec8c624d64dc9b3"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#8f3c32773dfa07af8b8f25cc6f445a79bde2ec4f"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#623d4231123dfa7853c08d6e6ec8c624d64dc9b3"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#8f3c32773dfa07af8b8f25cc6f445a79bde2ec4f"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-node"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#623d4231123dfa7853c08d6e6ec8c624d64dc9b3"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#8f3c32773dfa07af8b8f25cc6f445a79bde2ec4f"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "commonware-avs-router"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-restaking#623d4231123dfa7853c08d6e6ec8c624d64dc9b3"
+source = "git+https://github.com/BreadchainCoop/commonware-restaking#8f3c32773dfa07af8b8f25cc6f445a79bde2ec4f"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5066,7 +5066,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6181,7 +6181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6201,7 +6201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ LOCAL-mode-only:
 - `FORK_URL`: Sepolia RPC URL to fork from (Anvil uses this)
 
 Optional environment variables:
-- `AGGREGATION_TIMEOUT`: Max seconds the router waits for operator signatures on a round before abandoning it and moving to the next task (accepts fractional seconds). The orchestrator submits immediately once the signature threshold is reached, so this only affects rounds that fail to reach quorum. Library default: 30; Helm deployments set 300. Must exceed worst-case node compute + sign time.
+- `ROUND_TIMEOUT`: Max seconds the router waits for operator signatures on a round before abandoning it and moving to the next task (accepts fractional seconds). The orchestrator submits immediately once the signature threshold is reached, so this only affects rounds that fail to reach quorum. Library default: 30; Helm deployments set 300. Must exceed worst-case node compute + sign time.
+- `REBROADCAST_INTERVAL`: How often (in seconds) the router re-sends the `Start` broadcast for an in-flight round while waiting for signatures (accepts fractional seconds). Set longer than `ROUND_TIMEOUT` to disable intra-round rebroadcasting. Library default: 30; Helm deployments set 300.
 - `THRESHOLD`: Minimum signatures required for aggregation
 - `INGRESS`: Enable HTTP ingress mode (true/false)
 - `INGRESS_ADDRESS`: Address for ingress server (default: 0.0.0.0:8080)

--- a/example.env
+++ b/example.env
@@ -49,7 +49,12 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # time out before operators finish, but every stalled round (operators offline,
 # threshold unreachable) blocks the queue for the full window. Tune against the
 # gas_killer_p2p_round_trip_seconds and round-timeout metrics.
-# AGGREGATION_TIMEOUT=300
+# ROUND_TIMEOUT=300
+
+# How often (in seconds) the router re-sends the Start broadcast for an in-flight round
+# while waiting for signatures (accepts fractional seconds; default: 30). Setting this
+# longer than ROUND_TIMEOUT disables intra-round rebroadcasting entirely.
+# REBROADCAST_INTERVAL=300
 
 # =============================================================================
 # P2P Channel Configuration

--- a/example.env
+++ b/example.env
@@ -52,8 +52,8 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # ROUND_TIMEOUT=300
 
 # How often (in seconds) the router re-sends the Start broadcast for an in-flight round
-# while waiting for signatures (accepts fractional seconds; default: 30). Setting this
-# longer than ROUND_TIMEOUT disables intra-round rebroadcasting entirely.
+# while waiting for signatures (accepts fractional seconds; default: 30). When equal to
+# or longer than ROUND_TIMEOUT the biased select ensures no intra-round rebroadcast fires.
 # REBROADCAST_INTERVAL=300
 
 # =============================================================================

--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -292,7 +292,7 @@ data:
           "type": "text",
           "title": "Orchestrator Internals",
           "gridPos": { "x": 0, "y": 32, "w": 24, "h": 1 },
-          "options": { "mode": "markdown", "content": "## Orchestrator Internals\n\nRound-internal metrics from the commonware orchestrator and BLS executor registries, surfaced via the runtime context on the same `/metrics` endpoint.\n\nTime to quorum = round broadcast → signature threshold reached (isolates aggregation from EigenLayer reads). Round timeouts = aggregation windows that expired before the round completed — the primary signal for tuning `AGGREGATION_TIMEOUT`. EigenLayer state retrieval = operator resolution + non-signer stakes/signature reads between quorum and `handle_verification`; subtract it and time-to-quorum from P2P round-trip to estimate pure transport+signing overhead." }
+          "options": { "mode": "markdown", "content": "## Orchestrator Internals\n\nRound-internal metrics from the commonware orchestrator and BLS executor registries, surfaced via the runtime context on the same `/metrics` endpoint.\n\nTime to quorum = round broadcast → signature threshold reached (isolates aggregation from EigenLayer reads). Round timeouts = aggregation windows that expired before the round completed — the primary signal for tuning `ROUND_TIMEOUT`. EigenLayer state retrieval = operator resolution + non-signer stakes/signature reads between quorum and `handle_verification`; subtract it and time-to-quorum from P2P round-trip to estimate pure transport+signing overhead." }
         },
         {
           "id": 61,
@@ -333,7 +333,7 @@ data:
           "id": 63,
           "type": "timeseries",
           "title": "Round Outcomes / min",
-          "description": "A timed-out round is abandoned and the orchestrator moves to the next queued task; sustained timeouts mean AGGREGATION_TIMEOUT is shorter than time-to-quorum.",
+          "description": "A timed-out round is abandoned and the orchestrator moves to the next queued task; sustained timeouts mean ROUND_TIMEOUT is shorter than time-to-quorum.",
           "gridPos": { "x": 12, "y": 33, "w": 6, "h": 8 },
           "targets": [
             {

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -315,8 +315,10 @@ spec:
             - name: AVS_OPSET_SLASHING_CONDITIONS
               value: {{ .Values.router.avsMetadata.operatorSet.slashingConditions | quote }}
             {{- end }}
-            - name: AGGREGATION_TIMEOUT
-              value: {{ .Values.router.aggregationTimeout | quote }}
+            - name: ROUND_TIMEOUT
+              value: {{ .Values.router.roundTimeout | quote }}
+            - name: REBROADCAST_INTERVAL
+              value: {{ .Values.router.rebroadcastInterval | quote }}
             {{- if .Values.router.receiptTimeoutSecs }}
             - name: EXECUTOR_RECEIPT_TIMEOUT_SECS
               value: {{ .Values.router.receiptTimeoutSecs | quote }}

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -296,8 +296,8 @@ router:
   # round-timeout panel in the Grafana dashboard.
   roundTimeout: "300"
   # How often (in seconds) the router re-sends the Start broadcast for an in-flight round
-  # while waiting for signatures. Set longer than roundTimeout to disable intra-round
-  # rebroadcasting entirely.
+  # while waiting for signatures. When equal to or longer than roundTimeout the biased
+  # select ensures no intra-round rebroadcast fires.
   rebroadcastInterval: "300"
   # Max seconds the executor waits for a verifyAndUpdate transaction receipt before
   # timing out the round and proceeding to the next one. Prevents an indefinite stall

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -244,7 +244,7 @@ node:
   # How long Kubernetes waits for a node to finish in-flight work after SIGTERM.
   # Must be >= the time needed to complete a validation + sign cycle. Production
   # transactions can take several minutes of EVMSketch compute (see the
-  # aggregationTimeout comment), so 360s covers a full round plus buffer.
+  # roundTimeout comment), so 360s covers a full round plus buffer.
   terminationGracePeriodSeconds: 360
   # Stagger EigenSDK eth_getLogs backfill sweeps across nodes so at most one runs at a time.
   # node-1 starts immediately; node-N waits (N-1) * startupDelaySecsPerNode before launching.
@@ -284,7 +284,7 @@ router:
   healthzPort: 8081
   # How long Kubernetes waits for a router to finish in-flight work after SIGTERM.
   # Must be >= the time needed to complete an aggregation round, which is bounded by
-  # aggregationTimeout (300s), so 360s lets an in-flight round finish plus buffer.
+  # roundTimeout (300s), so 360s lets an in-flight round finish plus buffer.
   terminationGracePeriodSeconds: 360
   # Max seconds the router waits for operator signatures on a round before abandoning
   # it and moving to the next queued task. The orchestrator submits immediately once
@@ -294,7 +294,11 @@ router:
   # of a larger value is that a round that never reaches quorum blocks the task queue
   # for the full window. Tune against gas_killer_p2p_round_trip_seconds and the
   # round-timeout panel in the Grafana dashboard.
-  aggregationTimeout: "300"
+  roundTimeout: "300"
+  # How often (in seconds) the router re-sends the Start broadcast for an in-flight round
+  # while waiting for signatures. Set longer than roundTimeout to disable intra-round
+  # rebroadcasting entirely.
+  rebroadcastInterval: "300"
   # Max seconds the executor waits for a verifyAndUpdate transaction receipt before
   # timing out the round and proceeding to the next one. Prevents an indefinite stall
   # under L1 mempool congestion or RPC degradation. Leave empty to use the per-chain

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -447,6 +447,16 @@ mod tests {
         assert_eq!(round, 0); // Default round is 0
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_for_new_round_strictly_advances() {
+        let creator = GasKillerCreator::new();
+        let (_, round0) = creator.get_payload_and_round().await.unwrap();
+        let (_, round1) = creator.wait_for_new_round(round0).await.unwrap();
+        assert!(round1 > round0);
+        let (_, round2) = creator.wait_for_new_round(round1).await.unwrap();
+        assert!(round2 > round1);
+    }
+
     #[test]
     fn test_dispatch_time_evicts_failed_rounds_and_isolates_measurements() {
         let times: DispatchTime = Arc::new(Mutex::new(HashMap::new()));

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -96,6 +96,13 @@ impl Creator for GasKillerCreator {
         Ok((raw_payload, 0)) // set default "round" to 0
     }
 
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let payload = self.get_task_metadata();
+        let raw_payload = payload.encode().to_vec();
+        Ok((raw_payload, current + 1))
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         GasKillerTaskData::default()
     }
@@ -185,6 +192,15 @@ impl ListeningGasKillerCreator {
 #[async_trait]
 impl Creator for ListeningGasKillerCreator {
     type TaskData = GasKillerTaskData;
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        loop {
+            let result = self.get_payload_and_round().await?;
+            if result.1 > current {
+                return Ok(result);
+            }
+        }
+    }
 
     async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
         let task = self.wait_for_task().await?;
@@ -397,6 +413,13 @@ impl Creator for GasKillerCreatorType {
         match self {
             GasKillerCreatorType::Basic(creator) => creator.get_payload_and_round().await,
             GasKillerCreatorType::Listening(creator) => creator.get_payload_and_round().await,
+        }
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        match self {
+            GasKillerCreatorType::Basic(creator) => creator.wait_for_new_round(current).await,
+            GasKillerCreatorType::Listening(creator) => creator.wait_for_new_round(current).await,
         }
     }
 


### PR DESCRIPTION
## Summary

Updates the service to be compatible with the breaking changes introduced by [BreadchainCoop/commonware-restaking#175](https://github.com/BreadchainCoop/commonware-restaking/pull/175), bumping the dependency to the current `main` tip.

- **`Creator` trait**: implements the new required `wait_for_new_round(current: u64)` method on all three creator types (`GasKillerCreator`, `ListeningGasKillerCreator`, `GasKillerCreatorType`)
- **Env var rename**: `AGGREGATION_TIMEOUT` → `ROUND_TIMEOUT` + new `REBROADCAST_INTERVAL` (updated in `example.env`, Helm values, deployment template, and Grafana dashboard copy)
- **Cargo.lock**: bumps all `commonware-avs-*` crates from `623d4231` → `8f3c3277`

## Test plan

- [ ] `cargo check --all-targets --all-features` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [ ] `cargo test --all-targets --all-features` passes (97 tests, 0 failures)
- [ ] Helm: `ROUND_TIMEOUT` and `REBROADCAST_INTERVAL` injected correctly into router pod via `values.yaml` → `router-deployment.yaml`