### PR TITLE
docs: rename AGGREGATION_TIMEOUT to ROUND_TIMEOUT in README, fix rebroadcast comment, add round-advance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ LOCAL-mode-only:
 - `FORK_URL`: Sepolia RPC URL to fork from (Anvil uses this)
 
 Optional environment variables:
-- `AGGREGATION_TIMEOUT`: Max seconds the router waits for operator signatures on a round before abandoning it and moving to the next task (accepts fractional seconds). The orchestrator submits immediately once the signature threshold is reached, so this only affects rounds that fail to reach quorum. Library default: 30; Helm deployments set 300. Must exceed worst-case node compute + sign time.
+- `ROUND_TIMEOUT`: Max seconds the router waits for operator signatures on a round before abandoning it and moving to the next task (accepts fractional seconds). The orchestrator submits immediately once the signature threshold is reached, so this only affects rounds that fail to reach quorum. Library default: 30; Helm deployments set 300. Must exceed worst-case node compute + sign time.
+- `REBROADCAST_INTERVAL`: How often (in seconds) the router re-sends the `Start` broadcast for an in-flight round while waiting for signatures (accepts fractional seconds). Set longer than `ROUND_TIMEOUT` to disable intra-round rebroadcasting. Library default: 30; Helm deployments set 300.
 - `THRESHOLD`: Minimum signatures required for aggregation
 - `INGRESS`: Enable HTTP ingress mode (true/false)
 - `INGRESS_ADDRESS`: Address for ingress server (default: 0.0.0.0:8080)

--- a/example.env
+++ b/example.env
@@ -52,8 +52,8 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # ROUND_TIMEOUT=300
 
 # How often (in seconds) the router re-sends the Start broadcast for an in-flight round
-# while waiting for signatures (accepts fractional seconds; default: 30). Setting this
-# longer than ROUND_TIMEOUT disables intra-round rebroadcasting entirely.
+# while waiting for signatures (accepts fractional seconds; default: 30). When equal to
+# or longer than ROUND_TIMEOUT the biased select ensures no intra-round rebroadcast fires.
 # REBROADCAST_INTERVAL=300
 
 # =============================================================================

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -296,8 +296,8 @@ router:
   # round-timeout panel in the Grafana dashboard.
   roundTimeout: "300"
   # How often (in seconds) the router re-sends the Start broadcast for an in-flight round
-  # while waiting for signatures. Set longer than roundTimeout to disable intra-round
-  # rebroadcasting entirely.
+  # while waiting for signatures. When equal to or longer than roundTimeout the biased
+  # select ensures no intra-round rebroadcast fires.
   rebroadcastInterval: "300"
   # Max seconds the executor waits for a verifyAndUpdate transaction receipt before
   # timing out the round and proceeding to the next one. Prevents an indefinite stall

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -447,6 +447,16 @@ mod tests {
         assert_eq!(round, 0); // Default round is 0
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_for_new_round_strictly_advances() {
+        let creator = GasKillerCreator::new();
+        let (_, round0) = creator.get_payload_and_round().await.unwrap();
+        let (_, round1) = creator.wait_for_new_round(round0).await.unwrap();
+        assert!(round1 > round0);
+        let (_, round2) = creator.wait_for_new_round(round1).await.unwrap();
+        assert!(round2 > round1);
+    }
+
     #[test]
     fn test_dispatch_time_evicts_failed_rounds_and_isolates_measurements() {
         let times: DispatchTime = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
## Summary

Follow-up to #279. Addresses review feedback on that PR — stacked on top of it so the diff is clean; merge #279 first.

- **README.md**: renames `AGGREGATION_TIMEOUT` → `ROUND_TIMEOUT` and adds `REBROADCAST_INTERVAL` to the optional-env-vars list so the docs match the deployed knobs
- **example.env / values.yaml**: tightens the rebroadcast comment from "set longer than ROUND_TIMEOUT to disable" to "equal to or longer than" — the shipped default of 300/300 disables rebroadcasting via the biased select tie, so the old wording was imprecise
- **creator.rs**: adds `test_wait_for_new_round_strictly_advances` — uses `start_paused = true` so the 2-second sleep is instant; asserts each successive `wait_for_new_round` call returns a strictly greater round

## Test plan

- [ ] `cargo test --all-targets --all-features` passes (98 tests)
- [ ] README optional-env-vars block lists `ROUND_TIMEOUT` and `REBROADCAST_INTERVAL`, no mention of `AGGREGATION_TIMEOUT`