### PR TITLE
feat: make inter-round poll interval configurable via POLLING_INTERVAL_MS

### DIFF
--- a/example.env
+++ b/example.env
@@ -163,6 +163,9 @@ SIGNER_ENDPOINT=http://signer:50051
 INGRESS=true
 INGRESS_ADDRESS=0.0.0.0:8080
 INGRESS_TIMEOUT_MS=0
+
+# How often (in milliseconds) to poll for a new round between task cycles.
+POLLING_INTERVAL_MS=2000
 # INGRESS_PASSWORD=  # Required for TESTNET mode
 
 # =============================================================================

--- a/example.env
+++ b/example.env
@@ -165,6 +165,8 @@ INGRESS_ADDRESS=0.0.0.0:8080
 INGRESS_TIMEOUT_MS=0
 
 # How often (in milliseconds) to poll for a new round between task cycles.
+# Only applies when INGRESS=false (Basic creator). When INGRESS=true the creator
+# blocks on an event-driven channel and this value has no effect.
 POLLING_INTERVAL_MS=2000
 # INGRESS_PASSWORD=  # Required for TESTNET mode
 

--- a/example.env
+++ b/example.env
@@ -56,6 +56,11 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # or longer than ROUND_TIMEOUT the biased select ensures no intra-round rebroadcast fires.
 # REBROADCAST_INTERVAL=300
 
+# How often (in milliseconds) to poll for a new round between task cycles (default: 2000).
+# Only applies when INGRESS=false; when INGRESS=true the creator blocks on an event-driven
+# channel and this value has no effect. Must be > 0 to avoid a busy-loop.
+# POLLING_INTERVAL_MS=2000
+
 # =============================================================================
 # P2P Channel Configuration
 # =============================================================================
@@ -163,11 +168,6 @@ SIGNER_ENDPOINT=http://signer:50051
 INGRESS=true
 INGRESS_ADDRESS=0.0.0.0:8080
 INGRESS_TIMEOUT_MS=0
-
-# How often (in milliseconds) to poll for a new round between task cycles.
-# Only applies when INGRESS=false (Basic creator). When INGRESS=true the creator
-# blocks on an event-driven channel and this value has no effect.
-POLLING_INTERVAL_MS=2000
 # INGRESS_PASSWORD=  # Required for TESTNET mode
 
 # =============================================================================

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -315,6 +315,8 @@ spec:
             - name: AVS_OPSET_SLASHING_CONDITIONS
               value: {{ .Values.router.avsMetadata.operatorSet.slashingConditions | quote }}
             {{- end }}
+            - name: POLLING_INTERVAL_MS
+              value: {{ .Values.router.pollingIntervalMs | quote }}
             - name: ROUND_TIMEOUT
               value: {{ .Values.router.roundTimeout | quote }}
             - name: REBROADCAST_INTERVAL

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -287,6 +287,8 @@ router:
   # roundTimeout (300s), so 360s lets an in-flight round finish plus buffer.
   terminationGracePeriodSeconds: 360
   # How often (in milliseconds) to poll for a new round between task cycles.
+  # Only applies when INGRESS=false (Basic creator). When INGRESS=true the creator
+  # blocks on an event-driven channel and this value has no effect.
   pollingIntervalMs: "2000"
   # Max seconds the router waits for operator signatures on a round before abandoning
   # it and moving to the next queued task. The orchestrator submits immediately once

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -286,6 +286,8 @@ router:
   # Must be >= the time needed to complete an aggregation round, which is bounded by
   # roundTimeout (300s), so 360s lets an in-flight round finish plus buffer.
   terminationGracePeriodSeconds: 360
+  # How often (in milliseconds) to poll for a new round between task cycles.
+  pollingIntervalMs: "2000"
   # Max seconds the router waits for operator signatures on a round before abandoning
   # it and moving to the next queued task. The orchestrator submits immediately once
   # the signature threshold is reached, so this is a stalled-round recovery window,

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -91,6 +91,7 @@ impl GasKillerCreator {
         let polling_interval_ms: u64 = env::var("POLLING_INTERVAL_MS")
             .ok()
             .and_then(|v| v.parse().ok())
+            .filter(|&ms| ms > 0)
             .unwrap_or(2_000);
         Self {
             polling_interval: Duration::from_millis(polling_interval_ms),

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -80,6 +80,12 @@ pub struct GasKillerCreator {
     polling_interval: Duration,
 }
 
+impl Default for GasKillerCreator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GasKillerCreator {
     pub fn new() -> Self {
         let polling_interval_ms: u64 = env::var("POLLING_INTERVAL_MS")

--- a/router/src/creator.rs
+++ b/router/src/creator.rs
@@ -76,12 +76,19 @@ impl Default for GasKillerConfig {
 }
 
 /// Creator for the gas killer usecase without ingress
-#[derive(Default)]
-pub struct GasKillerCreator {}
+pub struct GasKillerCreator {
+    polling_interval: Duration,
+}
 
 impl GasKillerCreator {
     pub fn new() -> Self {
-        Self {}
+        let polling_interval_ms: u64 = env::var("POLLING_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(2_000);
+        Self {
+            polling_interval: Duration::from_millis(polling_interval_ms),
+        }
     }
 }
 
@@ -97,7 +104,7 @@ impl Creator for GasKillerCreator {
     }
 
     async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(self.polling_interval).await;
         let payload = self.get_task_metadata();
         let raw_payload = payload.encode().to_vec();
         Ok((raw_payload, current + 1))


### PR DESCRIPTION
## Summary
- Adds a `polling_interval: Duration` field to `GasKillerCreator`, replacing the hardcoded 2-second sleep in `wait_for_new_round`
- `GasKillerCreator::new()` reads `POLLING_INTERVAL_MS` from the environment (default: 2000ms), consistent with how other config is loaded in the same file
- Documents `POLLING_INTERVAL_MS` in `example.env`

## Test plan
- [ ] Existing behaviour unchanged when `POLLING_INTERVAL_MS` is unset (defaults to 2000ms)
- [ ] Setting `POLLING_INTERVAL_MS` to a different value changes the poll cadence