### PR TITLE
feat: use production p2p config for deployed router and node

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -296,13 +296,18 @@ fn main() {
         const MAX_MESSAGE_SIZE: usize = 1024 * 1024; // 1 MB
         let my_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
         let my_local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-        let mut p2p_cfg = lookup::Config::local(
+        let mut p2p_cfg = lookup::Config::recommended(
             signer.clone(),
             APPLICATION_NAMESPACE,
             my_addr,
             my_local_addr,
             MAX_MESSAGE_SIZE,
         );
+
+        // recommended() sets this false, but in-cluster router<->node p2p on GKE resolves to private
+        // pod IPs; leaving it false would drop every intra-cluster connection. Keep it true until the
+        // topology uses public addresses.
+        p2p_cfg.allow_private_ips = true;
 
         // Must stay true for K8s deployments (DNAT/SNAT means source IPs at the listener are
         // always pod IPs, never the registered ClusterIP addresses) and for mixed-network topologies

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,6 +13,7 @@ use commonware_avs_node::contributor::{AggregationInput, Contribute, Contributor
 use commonware_p2p::Manager;
 use commonware_p2p::authenticated::lookup::{self, Network};
 use commonware_runtime::{Metrics, Runner, Spawner, tokio};
+use commonware_utils::NZU32;
 use commonware_utils::set::OrderedAssociated;
 use eigen_logging::log_level::LogLevel;
 use gas_killer_common::{
@@ -315,6 +316,18 @@ fn main() {
         // case; authentication relies entirely on the cryptographic handshake (peer public keys
         // checked against the registered operator set), which is secure for both topologies.
         p2p_cfg.attempt_unregistered_handshakes = true;
+
+        // recommended() throttles peer discovery for large open gossip networks where aggressive
+        // dialing is abusive. gas-killer instead runs a small, static, allowlisted operator set in a
+        // full mesh: every participant dials every other, so both ends frequently dial at once and
+        // one connection loses the reservation race. The loser must re-dial quickly, and an operator
+        // that restarts must rejoin the signing quorum in seconds rather than ~a minute. Restore fast
+        // (re)discovery while keeping recommended's abuse-resistance (concurrent-handshake cap, subnet
+        // rate limit, ping cadence).
+        p2p_cfg.dial_frequency = Duration::from_millis(500);
+        p2p_cfg.query_frequency = Duration::from_secs(30);
+        p2p_cfg.allowed_connection_rate_per_peer = Quota::per_second(NZU32!(1));
+        p2p_cfg.allowed_handshake_rate_per_ip = Quota::per_second(NZU32!(16));
 
         let (mut network, mut oracle) = Network::new(context.with_label("network"), p2p_cfg);
 

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -15,6 +15,7 @@ use commonware_runtime::{
     Metrics, Runner, Spawner,
     tokio::{self},
 };
+use commonware_utils::NZU32;
 use commonware_utils::set::OrderedAssociated;
 use eigen_logging::log_level::LogLevel;
 use gas_killer_common::{
@@ -184,6 +185,18 @@ fn main() {
     // case; authentication relies entirely on the cryptographic handshake (peer public keys
     // checked against the registered operator set), which is secure for both topologies.
     p2p_cfg.attempt_unregistered_handshakes = true;
+
+    // recommended() throttles peer discovery for large open gossip networks where aggressive
+    // dialing is abusive. gas-killer instead runs a small, static, allowlisted operator set in a
+    // full mesh: every participant dials every other, so both ends frequently dial at once and one
+    // connection loses the reservation race. The loser must re-dial quickly, and an operator that
+    // restarts must rejoin the signing quorum in seconds rather than ~a minute. Restore fast
+    // (re)discovery while keeping recommended's abuse-resistance (concurrent-handshake cap, subnet
+    // rate limit, ping cadence).
+    p2p_cfg.dial_frequency = Duration::from_millis(500);
+    p2p_cfg.query_frequency = Duration::from_secs(30);
+    p2p_cfg.allowed_connection_rate_per_peer = Quota::per_second(NZU32!(1));
+    p2p_cfg.allowed_handshake_rate_per_ip = Quota::per_second(NZU32!(16));
 
     // Start runtime
     runner.start(|context| async move {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -165,13 +165,18 @@ fn main() {
     const MAX_MESSAGE_SIZE: usize = 1024 * 1024; // 1 MB
     let my_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
     let my_local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    let mut p2p_cfg = lookup::Config::local(
+    let mut p2p_cfg = lookup::Config::recommended(
         signer.clone(),
         APPLICATION_NAMESPACE,
         my_addr,
         my_local_addr,
         MAX_MESSAGE_SIZE,
     );
+
+    // recommended() sets this false, but in-cluster router<->node p2p on GKE resolves to private
+    // pod IPs; leaving it false would drop every intra-cluster connection. Keep it true until the
+    // topology uses public addresses.
+    p2p_cfg.allow_private_ips = true;
 
     // Must stay true for K8s deployments (DNAT/SNAT means source IPs at the listener are
     // always pod IPs, never the registered ClusterIP addresses) and for mixed-network topologies


### PR DESCRIPTION
Closes #271.

## What

Switch the deployed router and node from the demo p2p profile `lookup::Config::local(...)` to the production profile `lookup::Config::recommended(...)` (commonware-p2p 0.0.63), then revert four discovery/rate fields to their `local` values (carve-out #3). `local`'s own docstring marks it unfit for production; the service runs in real GKE clusters.

The **shipped** column is the effective deployed config — not the bare `recommended` column:

| field | local | recommended | shipped (this PR) |
|---|---|---|---|
| `allowed_connection_rate_per_peer` | per_second(1) | per_minute(1) | **per_second(1)** ¹ |
| `allowed_handshake_rate_per_ip` | per_second(16) | 1 per 5s | **per_second(16)** ¹ |
| `allowed_handshake_rate_per_subnet` | per_second(128) | per_second(64) | per_second(64) |
| `max_concurrent_handshakes` | 1024 | 512 | 512 |
| `ping_frequency` | 5s | 50s | 50s |
| `allowed_ping_rate` | per_second(2) | per_minute(2) | per_minute(2) |
| `dial_frequency` | 500ms | 1s | **500ms** ¹ |
| `query_frequency` | 30s | 60s | **30s** ¹ |

¹ reverted to `local` — see carve-out #3.

Net effect: `recommended`'s abuse-resistance (`max_concurrent_handshakes` 512, `allowed_handshake_rate_per_subnet` 64/s, ping cadence 50s / per_minute(2)) **plus** `local`'s discovery aggressiveness for the per-peer / per-ip / dial / query fields.

**No silent off-table adoption.** The only fields that differ between `local` and `recommended` are the eight above plus `allow_private_ips`. Every other `Config` field — `mailbox_size`, `synchrony_bound`, `max_handshake_age`, `handshake_timeout`, `tracked_peer_sets`, `max_message_size` — is identical in both profiles, so the `local`→`recommended` swap changes nothing beyond these tabled deltas.

## Carve-outs

1. **`allow_private_ips = true`** — `recommended` defaults it to `false`, but in-cluster router↔node p2p on GKE resolves to private pod IPs, so leaving it false would drop every intra-cluster connection. Set back to `true` after construction.
2. **`attempt_unregistered_handshakes` unchanged** — registered-handshakes is out of scope per team decision.
3. **Fast peer (re)discovery — `dial_frequency`, `query_frequency`, `allowed_connection_rate_per_peer`, `allowed_handshake_rate_per_ip` reverted to `local` values.** gas-killer is a small, static, allowlisted full mesh: every participant dials every other, so dual-dial reservation collisions are routine and the loser must re-dial fast, and an operator pod restart must rejoin the signing quorum in seconds. `recommended`'s discovery throttling (tuned for large open gossip networks) stretched mesh (re)convergence to ~60–110s — long enough that the round timed out before any node was reachable. This is what failed CI (E2E + Helm both timed out with `currentSum` unchanged) and would, in prod, drop a restarted operator out of the quorum for ~a minute and throttle NAT'd external operators that share an egress IP. Reverting these four restores fast convergence while keeping the abuse-resistance above.

## Files

- `router/src/main.rs` — constructor swap + carve-outs 1–3
- `node/src/main.rs` — constructor swap + carve-outs 1–3 (symmetric with the router so both ends agree on the dial/handshake rates)

## Validation

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check`, and `cargo test` pass for the affected crates. CI is green on the latest commit, including **E2E Test** and **Helm Integration Test** (both regressed on the bare-swap commit and pass after carve-out #3).

The change lives inside `fn main()` (network config construction) with no extractable pure function, so there is no unit-test hook. Per the issue's acceptance criteria, **verify cluster connectivity on a testnet soak before mainnet** — confirm round formation has no regression, and explicitly test the disruption path (`kubectl delete pod` on one operator → it should rejoin the quorum in seconds without stalling round formation).

Part of gas-killer/roadmap#15.
