### PR TITLE
feat: structured machine-readable error codes (OPS-2)

### DIFF
--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -47,6 +47,10 @@ pub enum ErrorCode {
     ContractNotFound,
     /// The request body is malformed or fails field-level validation.
     InvalidRequest,
+    /// The requested path does not exist.
+    NotFound,
+    /// The HTTP method is not supported for the requested path.
+    MethodNotAllowed,
     /// An unexpected server-side error occurred.
     Internal,
 }
@@ -169,6 +173,8 @@ mod tests {
             (ErrorCode::RpcUnavailable, "RPC_UNAVAILABLE"),
             (ErrorCode::ContractNotFound, "CONTRACT_NOT_FOUND"),
             (ErrorCode::InvalidRequest, "INVALID_REQUEST"),
+            (ErrorCode::NotFound, "NOT_FOUND"),
+            (ErrorCode::MethodNotAllowed, "METHOD_NOT_ALLOWED"),
             (ErrorCode::Internal, "INTERNAL"),
         ];
         for (code, wire) in cases {

--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -1,0 +1,211 @@
+//! Machine-readable error envelope for the ingress HTTP API.
+//!
+//! Every error response the API returns has the shape:
+//!
+//! ```json
+//! { "error": { "code": "TRANSITION_MISMATCH", "message": "..." } }
+//! ```
+//!
+//! The `code` is a stable, uppercase snake-case identifier that integrators match on
+//! programmatically; the `message` is a human-readable explanation that may change at
+//! any time. Status codes are carried alongside the code internally and are unchanged
+//! from the per-endpoint behaviour they replace.
+
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{FromRequest, Request};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{Json, async_trait};
+use serde::{Deserialize, Serialize};
+
+/// Stable, machine-readable error code returned in every API error response.
+///
+/// These identifiers are a public API contract: integrators branch on them, so a variant
+/// must never be renamed or repurposed once shipped. Add a new variant rather than changing
+/// the meaning of an existing one. The wire form is uppercase snake-case (e.g.
+/// `TRANSITION_MISMATCH`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    /// A required address field is zero or otherwise not a usable address.
+    InvalidAddress,
+    /// `block_height` is older than the accepted staleness window.
+    StaleBlock,
+    /// The provided `transition_index` does not match the contract's current state.
+    TransitionMismatch,
+    /// `call_data` exceeds the maximum accepted size.
+    CalldataTooLarge,
+    /// The client exceeded its allotted request rate.
+    RateLimited,
+    /// The ingress queue is at capacity and cannot accept more work right now.
+    QueueFull,
+    /// The request is missing valid authentication credentials.
+    Unauthorized,
+    /// An upstream RPC endpoint failed or is unreachable.
+    RpcUnavailable,
+    /// No contract is deployed at the requested target address on any supported chain.
+    ContractNotFound,
+    /// The request body is malformed or fails field-level validation.
+    InvalidRequest,
+    /// An unexpected server-side error occurred.
+    Internal,
+}
+
+/// The `error` object nested inside [`ApiErrorEnvelope`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorBody {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+/// The full wire shape of an error response: `{ "error": { "code", "message" } }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorEnvelope {
+    pub error: ApiErrorBody,
+}
+
+/// An API error in flight: the HTTP status to return plus the [`ErrorCode`] and message
+/// that are serialized into the [`ApiErrorEnvelope`] body.
+///
+/// Implements [`IntoResponse`], so handlers return `Result<T, ApiError>` and `?`/`Err`
+/// produce a correctly-shaped response with the carried status.
+#[derive(Debug, Clone)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(status: StatusCode, code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// 401 with [`ErrorCode::Unauthorized`].
+    pub fn unauthorized() -> Self {
+        Self::new(
+            StatusCode::UNAUTHORIZED,
+            ErrorCode::Unauthorized,
+            "Unauthorized",
+        )
+    }
+
+    /// 503 with [`ErrorCode::QueueFull`].
+    pub fn queue_full(message: impl Into<String>) -> Self {
+        Self::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ErrorCode::QueueFull,
+            message,
+        )
+    }
+
+    /// 500 with [`ErrorCode::Internal`].
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorCode::Internal,
+            message,
+        )
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ApiErrorEnvelope {
+            error: ApiErrorBody {
+                code: self.code,
+                message: self.message,
+            },
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+/// A `Json<T>` extractor that emits the [`ApiErrorEnvelope`] on failure instead of axum's
+/// default plain-text body, so body-parse and schema-validation failures share the same
+/// error contract as handler-level errors. The status code from the underlying
+/// [`JsonRejection`] is preserved (400 for malformed JSON, 422 for shape mismatch, etc.).
+pub struct ApiJson<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequest<S> for ApiJson<T>
+where
+    Json<T>: FromRequest<S, Rejection = JsonRejection>,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(ApiJson(value)),
+            Err(rejection) => Err(ApiError::new(
+                rejection.status(),
+                ErrorCode::InvalidRequest,
+                rejection.body_text(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[test]
+    fn error_codes_serialize_as_screaming_snake_case() {
+        let cases = [
+            (ErrorCode::InvalidAddress, "INVALID_ADDRESS"),
+            (ErrorCode::StaleBlock, "STALE_BLOCK"),
+            (ErrorCode::TransitionMismatch, "TRANSITION_MISMATCH"),
+            (ErrorCode::CalldataTooLarge, "CALLDATA_TOO_LARGE"),
+            (ErrorCode::RateLimited, "RATE_LIMITED"),
+            (ErrorCode::QueueFull, "QUEUE_FULL"),
+            (ErrorCode::Unauthorized, "UNAUTHORIZED"),
+            (ErrorCode::RpcUnavailable, "RPC_UNAVAILABLE"),
+            (ErrorCode::ContractNotFound, "CONTRACT_NOT_FOUND"),
+            (ErrorCode::InvalidRequest, "INVALID_REQUEST"),
+            (ErrorCode::Internal, "INTERNAL"),
+        ];
+        for (code, wire) in cases {
+            assert_eq!(serde_json::to_value(code).unwrap(), serde_json::json!(wire));
+        }
+    }
+
+    #[tokio::test]
+    async fn into_response_carries_status_and_envelope() {
+        let err = ApiError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::TransitionMismatch,
+            "expected transition_index 42, contract reports 43",
+        );
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let parsed: ApiErrorEnvelope = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.error.code, ErrorCode::TransitionMismatch);
+        assert_eq!(
+            parsed.error.message,
+            "expected transition_index 42, contract reports 43"
+        );
+    }
+
+    #[test]
+    fn envelope_has_no_extra_top_level_fields() {
+        let json = serde_json::to_value(ApiErrorEnvelope {
+            error: ApiErrorBody {
+                code: ErrorCode::QueueFull,
+                message: "full".to_string(),
+            },
+        })
+        .unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert!(obj.contains_key("error"));
+    }
+}

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -535,11 +535,29 @@ async fn avs_metadata_handler(State(state): State<IngressState>) -> Json<AvsMeta
     Json(state.avs_metadata.clone())
 }
 
+/// Fallback for requests whose path matches no route. Returns the error envelope with a 404
+/// rather than axum's default empty-body response, so unknown paths share the API error contract.
+async fn not_found_handler() -> ApiError {
+    ApiError::new(StatusCode::NOT_FOUND, ErrorCode::NotFound, "Not found")
+}
+
+/// Fallback for requests to a known path with an unsupported HTTP method. Returns the error
+/// envelope with a 405 rather than axum's default empty-body response.
+async fn method_not_allowed_handler() -> ApiError {
+    ApiError::new(
+        StatusCode::METHOD_NOT_ALLOWED,
+        ErrorCode::MethodNotAllowed,
+        "Method not allowed",
+    )
+}
+
 pub fn build_app() -> Router<IngressState> {
     Router::new()
         .route("/healthz", get(healthz_handler))
         .route("/avs-metadata", get(avs_metadata_handler))
         .route("/trigger", post(trigger_task_handler))
+        .fallback(not_found_handler)
+        .method_not_allowed_fallback(method_not_allowed_handler)
 }
 
 // Start the HTTP server in a background task
@@ -1015,6 +1033,23 @@ mod tests {
 
             let resp = app.oneshot(req).await.unwrap();
             assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::MethodNotAllowed);
+        }
+
+        #[tokio::test]
+        async fn test_unknown_path_returns_404() {
+            let (app, _queue) = make_app();
+            let req = Request::builder()
+                .method(Method::GET)
+                .uri("/does-not-exist")
+                .body(Body::empty())
+                .unwrap();
+
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::NotFound);
         }
 
         #[tokio::test]

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,4 +1,5 @@
 use crate::creator::{TaskQueueDepth, TaskSender};
+use crate::error::{ApiError, ApiJson, ErrorCode};
 use crate::metrics::MetricsCollector;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
@@ -166,6 +167,35 @@ impl fmt::Display for OnchainValidationError {
 
 impl std::error::Error for OnchainValidationError {}
 
+impl From<OnchainValidationError> for ApiError {
+    fn from(e: OnchainValidationError) -> Self {
+        let (status, code) = match e {
+            OnchainValidationError::ContractNotFound => {
+                (StatusCode::BAD_REQUEST, ErrorCode::ContractNotFound)
+            }
+            OnchainValidationError::TransitionIndexMismatch { .. } => {
+                (StatusCode::BAD_REQUEST, ErrorCode::TransitionMismatch)
+            }
+            OnchainValidationError::BlockHeightInFuture { .. } => {
+                (StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest)
+            }
+            OnchainValidationError::BlockHeightTooStale { .. } => {
+                (StatusCode::BAD_REQUEST, ErrorCode::StaleBlock)
+            }
+            OnchainValidationError::RpcError(_) => {
+                (StatusCode::SERVICE_UNAVAILABLE, ErrorCode::RpcUnavailable)
+            }
+        };
+        // RPC failures are transient and their detail is internal; surface a generic message
+        // to clients rather than leaking the upstream error string.
+        let message = match code {
+            ErrorCode::RpcUnavailable => "Service temporarily unavailable".to_string(),
+            _ => e.to_string(),
+        };
+        ApiError::new(status, code, message)
+    }
+}
+
 async fn detect_contract_chain<P: Provider + Clone>(
     providers: &HashMap<ChainRole, P>,
     address: Address,
@@ -276,6 +306,21 @@ impl fmt::Display for ValidationError {
 }
 
 impl std::error::Error for ValidationError {}
+
+impl From<ValidationError> for ApiError {
+    fn from(e: ValidationError) -> Self {
+        let code = match e {
+            ValidationError::ZeroTargetAddress | ValidationError::ZeroFromAddress => {
+                ErrorCode::InvalidAddress
+            }
+            ValidationError::CallDataTooLarge { .. } => ErrorCode::CalldataTooLarge,
+            ValidationError::EmptyCallData
+            | ValidationError::CallDataTooShort { .. }
+            | ValidationError::ZeroBlockHeight => ErrorCode::InvalidRequest,
+        };
+        ApiError::new(StatusCode::BAD_REQUEST, code, e.to_string())
+    }
+}
 
 /// Deserializes `transition_index` from JSON.
 ///
@@ -398,18 +443,12 @@ pub struct GasKillerTaskResponse {
 pub async fn trigger_task_handler(
     State(state): State<IngressState>,
     headers: HeaderMap,
-    Json(request): Json<GasKillerTaskRequest>,
-) -> (StatusCode, Json<GasKillerTaskResponse>) {
+    ApiJson(request): ApiJson<GasKillerTaskRequest>,
+) -> Result<(StatusCode, Json<GasKillerTaskResponse>), ApiError> {
     if let Some(password) = &state.password
         && !check_bearer_auth(&headers, password)
     {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(GasKillerTaskResponse {
-                success: false,
-                message: "Unauthorized".to_string(),
-            }),
-        );
+        return Err(ApiError::unauthorized());
     }
 
     // Load-shed before any validation work. Onchain validation costs multiple RPC
@@ -426,13 +465,9 @@ pub async fn trigger_task_handler(
         if let Some(m) = &state.metrics {
             m.ingress_at_capacity.inc();
         }
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(GasKillerTaskResponse {
-                success: false,
-                message: "Service at capacity, please try again in a few minutes".to_string(),
-            }),
-        );
+        return Err(ApiError::queue_full(
+            "Service at capacity, please try again in a few minutes",
+        ));
     }
 
     if let Err(e) = request.validate() {
@@ -446,23 +481,12 @@ pub async fn trigger_task_handler(
         if let Some(m) = &state.metrics {
             m.ingress_rejected.inc();
         }
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(GasKillerTaskResponse {
-                success: false,
-                message: format!("Task rejected: {e}"),
-            }),
-        );
+        return Err(e.into());
     }
 
     if !state.providers.is_empty()
         && let Err(e) = validate_onchain(&*state.providers, &request.body).await
     {
-        let status = if matches!(e, OnchainValidationError::RpcError(_)) {
-            StatusCode::SERVICE_UNAVAILABLE
-        } else {
-            StatusCode::BAD_REQUEST
-        };
         warn!(
             target_address = %request.body.target_address,
             from_address = %request.body.from_address,
@@ -474,18 +498,7 @@ pub async fn trigger_task_handler(
         if let Some(m) = &state.metrics {
             m.ingress_rejected.inc();
         }
-        let client_message = if matches!(e, OnchainValidationError::RpcError(_)) {
-            "Service temporarily unavailable".to_string()
-        } else {
-            format!("Task rejected: {e}")
-        };
-        return (
-            status,
-            Json(GasKillerTaskResponse {
-                success: false,
-                message: client_message,
-            }),
-        );
+        return Err(e.into());
     }
 
     info!(
@@ -499,25 +512,19 @@ pub async fn trigger_task_handler(
     if state.sender.send(request).is_err() {
         state.queue_depth.fetch_sub(1, Ordering::Relaxed);
         tracing::error!("task channel closed, dropping request");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(GasKillerTaskResponse {
-                success: false,
-                message: "Internal error: task queue unavailable".to_string(),
-            }),
-        );
+        return Err(ApiError::internal("Internal error: task queue unavailable"));
     }
     if let Some(m) = &state.metrics {
         m.ingress_accepted.inc();
         m.task_queue_depth.set(depth as i64);
     }
-    (
+    Ok((
         StatusCode::OK,
         Json(GasKillerTaskResponse {
             success: true,
             message: "Task queued".to_string(),
         }),
-    )
+    ))
 }
 
 async fn healthz_handler() -> StatusCode {
@@ -767,6 +774,14 @@ mod tests {
             serde_json::from_slice(&bytes).unwrap()
         }
 
+        async fn error_envelope(resp: axum::response::Response) -> crate::error::ApiErrorEnvelope {
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice(&bytes)
+                .expect("error response should deserialize as the ApiError envelope")
+        }
+
         #[tokio::test]
         async fn test_healthz_returns_200() {
             let (app, _queue) = make_app();
@@ -812,9 +827,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.contains("target_address is zero"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidAddress);
+            assert!(body.error.message.contains("target_address is zero"));
         }
 
         #[tokio::test]
@@ -834,9 +849,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.contains("from_address is zero"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidAddress);
+            assert!(body.error.message.contains("from_address is zero"));
         }
 
         #[tokio::test]
@@ -856,9 +871,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.contains("call_data is empty"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
+            assert!(body.error.message.contains("call_data is empty"));
         }
 
         #[tokio::test]
@@ -878,9 +893,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.contains("call_data too short"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
+            assert!(body.error.message.contains("call_data too short"));
         }
 
         #[tokio::test]
@@ -901,9 +916,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.contains("call_data too large"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::CalldataTooLarge);
+            assert!(body.error.message.contains("call_data too large"));
         }
 
         #[tokio::test]
@@ -923,9 +938,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.contains("block_height is zero"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
+            assert!(body.error.message.contains("block_height is zero"));
         }
 
         #[tokio::test]
@@ -944,6 +959,8 @@ mod tests {
                 "malformed JSON should return 4xx, got {}",
                 resp.status()
             );
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
         }
 
         #[tokio::test]
@@ -963,6 +980,8 @@ mod tests {
 
             let resp = app.oneshot(json_request(&payload)).await.unwrap();
             assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
         }
 
         #[tokio::test]
@@ -981,6 +1000,8 @@ mod tests {
                 "empty body should return 4xx, got {}",
                 resp.status()
             );
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
         }
 
         #[tokio::test]
@@ -1028,6 +1049,8 @@ mod tests {
             let (app, _queue) = make_app_with_password("secret");
             let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
             assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::Unauthorized);
         }
 
         #[tokio::test]
@@ -1042,6 +1065,8 @@ mod tests {
                 .unwrap();
             let resp = app.oneshot(req).await.unwrap();
             assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::Unauthorized);
         }
 
         #[tokio::test]
@@ -1134,9 +1159,9 @@ mod tests {
 
             let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
             assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-            let body = response_body(resp).await;
-            assert!(!body.success);
-            assert!(body.message.to_lowercase().contains("capacity"));
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::QueueFull);
+            assert!(body.error.message.to_lowercase().contains("capacity"));
         }
 
         #[tokio::test]
@@ -1569,6 +1594,98 @@ mod tests {
             assert!(
                 matches!(err, OnchainValidationError::ContractNotFound),
                 "expected ContractNotFound, got {err}"
+            );
+        }
+    }
+
+    // -- error envelope mapping --
+    //
+    // Locks the status code and machine-readable ErrorCode each validation error maps to,
+    // including that transient RPC failures are sanitized so internal detail never reaches
+    // the client.
+
+    mod error_mapping {
+        use super::*;
+        use crate::error::ErrorCode;
+
+        #[test]
+        fn validation_errors_map_to_code_and_400() {
+            let cases = [
+                (
+                    ValidationError::ZeroTargetAddress,
+                    ErrorCode::InvalidAddress,
+                ),
+                (ValidationError::ZeroFromAddress, ErrorCode::InvalidAddress),
+                (ValidationError::EmptyCallData, ErrorCode::InvalidRequest),
+                (
+                    ValidationError::CallDataTooShort { len: 2 },
+                    ErrorCode::InvalidRequest,
+                ),
+                (
+                    ValidationError::CallDataTooLarge { len: 1, max: 0 },
+                    ErrorCode::CalldataTooLarge,
+                ),
+                (ValidationError::ZeroBlockHeight, ErrorCode::InvalidRequest),
+            ];
+            for (err, code) in cases {
+                let api = ApiError::from(err);
+                assert_eq!(api.status, StatusCode::BAD_REQUEST);
+                assert_eq!(api.code, code);
+            }
+        }
+
+        #[test]
+        fn onchain_errors_map_to_code_and_status() {
+            let cases = [
+                (
+                    OnchainValidationError::ContractNotFound,
+                    StatusCode::BAD_REQUEST,
+                    ErrorCode::ContractNotFound,
+                ),
+                (
+                    OnchainValidationError::TransitionIndexMismatch {
+                        provided: 5,
+                        current: 6,
+                    },
+                    StatusCode::BAD_REQUEST,
+                    ErrorCode::TransitionMismatch,
+                ),
+                (
+                    OnchainValidationError::BlockHeightInFuture {
+                        provided: 10,
+                        current: 9,
+                    },
+                    StatusCode::BAD_REQUEST,
+                    ErrorCode::InvalidRequest,
+                ),
+                (
+                    OnchainValidationError::BlockHeightTooStale {
+                        provided: 1,
+                        current: 500,
+                        max_age: 300,
+                    },
+                    StatusCode::BAD_REQUEST,
+                    ErrorCode::StaleBlock,
+                ),
+            ];
+            for (err, status, code) in cases {
+                let api = ApiError::from(err);
+                assert_eq!(api.status, status);
+                assert_eq!(api.code, code);
+            }
+        }
+
+        #[test]
+        fn rpc_error_is_503_and_message_is_sanitized() {
+            let api = ApiError::from(OnchainValidationError::RpcError(
+                "connection refused at 10.0.0.5".to_string(),
+            ));
+            assert_eq!(api.status, StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(api.code, ErrorCode::RpcUnavailable);
+            assert_eq!(api.message, "Service temporarily unavailable");
+            assert!(
+                !api.message.contains("10.0.0.5"),
+                "internal RPC detail must not leak to clients"
             );
         }
     }

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,12 +1,13 @@
 use crate::creator::{TaskQueueDepth, TaskSender};
-use crate::error::{ApiError, ApiJson, ErrorCode};
+use crate::error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ErrorCode};
 use crate::metrics::MetricsCollector;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use axum::{
     Json, Router,
     extract::State,
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::Response,
     routing::{get, post},
 };
 use gas_killer_common::ChainRole;
@@ -535,20 +536,51 @@ async fn avs_metadata_handler(State(state): State<IngressState>) -> Json<AvsMeta
     Json(state.avs_metadata.clone())
 }
 
-/// Fallback for requests whose path matches no route. Returns the error envelope with a 404
-/// rather than axum's default empty-body response, so unknown paths share the API error contract.
-async fn not_found_handler() -> ApiError {
-    ApiError::new(StatusCode::NOT_FOUND, ErrorCode::NotFound, "Not found")
-}
+/// Gives axum's built-in 404 (no matching route) and 405 (method not allowed) responses the same
+/// `{ "error": { "code", "message" } }` body as handler errors, so every error the ingress emits
+/// shares one contract.
+///
+/// Only framework-generated errors are rewritten: a 404/405 with no `Content-Type`. Handler errors
+/// and the API's own envelopes always set `application/json`, so they pass through untouched. The
+/// body is replaced in place rather than rebuilt, preserving the headers axum computed — in
+/// particular the `Allow` header that a spec-compliant 405 must carry.
+async fn wrap_framework_error(mut resp: Response) -> Response {
+    let status = resp.status();
+    let is_framework_error = matches!(
+        status,
+        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+    ) && resp.headers().get(header::CONTENT_TYPE).is_none();
+    if !is_framework_error {
+        return resp;
+    }
 
-/// Fallback for requests to a known path with an unsupported HTTP method. Returns the error
-/// envelope with a 405 rather than axum's default empty-body response.
-async fn method_not_allowed_handler() -> ApiError {
-    ApiError::new(
-        StatusCode::METHOD_NOT_ALLOWED,
-        ErrorCode::MethodNotAllowed,
-        "Method not allowed",
-    )
+    let (code, message) = if status == StatusCode::METHOD_NOT_ALLOWED {
+        (ErrorCode::MethodNotAllowed, "Method not allowed")
+    } else {
+        (ErrorCode::NotFound, "Not found")
+    };
+    let envelope = ApiErrorEnvelope {
+        error: ApiErrorBody {
+            code,
+            message: message.to_string(),
+        },
+    };
+    let body = match serde_json::to_vec(&envelope) {
+        Ok(bytes) => bytes,
+        // A fixed-shape struct cannot realistically fail to serialize; if it somehow does, leave
+        // axum's original response untouched rather than panicking.
+        Err(_) => return resp,
+    };
+
+    let len = body.len();
+    *resp.body_mut() = axum::body::Body::from(body);
+    let headers = resp.headers_mut();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    headers.insert(header::CONTENT_LENGTH, HeaderValue::from(len));
+    resp
 }
 
 pub fn build_app() -> Router<IngressState> {
@@ -556,8 +588,7 @@ pub fn build_app() -> Router<IngressState> {
         .route("/healthz", get(healthz_handler))
         .route("/avs-metadata", get(avs_metadata_handler))
         .route("/trigger", post(trigger_task_handler))
-        .fallback(not_found_handler)
-        .method_not_allowed_fallback(method_not_allowed_handler)
+        .layer(axum::middleware::map_response(wrap_framework_error))
 }
 
 // Start the HTTP server in a background task
@@ -1033,6 +1064,18 @@ mod tests {
 
             let resp = app.oneshot(req).await.unwrap();
             assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+            // A spec-compliant 405 must advertise the supported methods; rewriting the body into
+            // the error envelope must not drop the Allow header axum computes for the route.
+            let allow = resp
+                .headers()
+                .get(axum::http::header::ALLOW)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            assert!(
+                allow.contains("POST"),
+                "Allow should list POST, got {allow:?}"
+            );
             let body = error_envelope(resp).await;
             assert_eq!(body.error.code, crate::error::ErrorCode::MethodNotAllowed);
         }

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1095,6 +1095,63 @@ mod tests {
             assert_eq!(body.error.code, crate::error::ErrorCode::NotFound);
         }
 
+        // Pins the documented contract of `wrap_framework_error`: a handler that emits a bare,
+        // bodyless `StatusCode::NOT_FOUND`/`METHOD_NOT_ALLOWED` (no Content-Type) is rewritten into
+        // the error envelope, while a handler that already returns an envelope (Content-Type
+        // application/json) keeps its specific status, code, and message untouched. Guards against a
+        // future handler's error shape silently diverging from — or being clobbered by — the layer.
+        #[tokio::test]
+        async fn test_bare_status_handler_is_wrapped_but_envelope_handler_is_preserved() {
+            use crate::error::ErrorCode;
+
+            let app: Router = Router::new()
+                .route("/bare", get(|| async { StatusCode::NOT_FOUND }))
+                .route(
+                    "/typed",
+                    get(|| async {
+                        ApiError::new(
+                            StatusCode::NOT_FOUND,
+                            ErrorCode::NotFound,
+                            "widget 7 not found",
+                        )
+                    }),
+                )
+                .layer(axum::middleware::map_response(wrap_framework_error));
+
+            // Bare StatusCode from a handler → wrapped into the generic envelope.
+            let bare = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::GET)
+                        .uri("/bare")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(bare.status(), StatusCode::NOT_FOUND);
+            let bare_body = error_envelope(bare).await;
+            assert_eq!(bare_body.error.code, ErrorCode::NotFound);
+            assert_eq!(bare_body.error.message, "Not found");
+
+            // Handler-built envelope (application/json) → passed through with its specific message.
+            let typed = app
+                .oneshot(
+                    Request::builder()
+                        .method(Method::GET)
+                        .uri("/typed")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(typed.status(), StatusCode::NOT_FOUND);
+            let typed_body = error_envelope(typed).await;
+            assert_eq!(typed_body.error.code, ErrorCode::NotFound);
+            assert_eq!(typed_body.error.message, "widget 7 not found");
+        }
+
         #[tokio::test]
         async fn test_valid_request_does_not_leave_extra_tasks() {
             // Two sequential valid requests → queue should hold exactly two tasks

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1,6 +1,7 @@
 // Gas killer usecase implementations
 pub mod builder;
 pub mod creator;
+pub mod error;
 pub mod executor;
 pub mod factories;
 pub mod ingress;
@@ -20,6 +21,7 @@ pub mod validator {
 // Re-export main types for easy access
 pub use builder::GasKillerOrchestratorBuilder;
 pub use creator::GasKillerCreatorType;
+pub use error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ErrorCode};
 pub use executor::GasKillerHandler;
 pub use gas_killer_common::GasKillerTaskData;
 pub use gas_killer_common::GasKillerValidator;


### PR DESCRIPTION
Closes #199.

Replaces the ad-hoc `{ "success": false, "message": "..." }` error responses on the ingress with a consistent, machine-readable envelope so beta integrators can branch on error type without parsing free text.

## What changed

**New `router/src/error.rs`:**
- `ErrorCode` — a stable, documented enum serialized as `SCREAMING_SNAKE_CASE`. Covers all eight codes the issue requires (`INVALID_ADDRESS`, `STALE_BLOCK`, `TRANSITION_MISMATCH`, `CALLDATA_TOO_LARGE`, `RATE_LIMITED`, `QUEUE_FULL`, `UNAUTHORIZED`, `RPC_UNAVAILABLE`) plus `CONTRACT_NOT_FOUND`, `INVALID_REQUEST`, `INTERNAL` for the existing handler paths. `RATE_LIMITED`/`QUEUE_FULL` are defined ahead of their emitters (#190/#191) so the enum stays the single source of truth.
- `ApiError` (status + code + message) implements `IntoResponse`, serializing to `{ "error": { "code", "message" } }`.
- `ApiJson<T>` — a drop-in `Json<T>` extractor that routes body-parse / schema-validation rejections through the same envelope while preserving axum's status code (400 malformed, 422 shape mismatch), so *every* error response — handler-level and extractor-level — shares the contract.

**`router/src/ingress.rs`:**
- `From<ValidationError>` / `From<OnchainValidationError>` for `ApiError` centralize the status+code mapping. RPC failures keep their sanitized `"Service temporarily unavailable"` message — internal RPC detail is not leaked to clients.
- `trigger_task_handler` returns `Result<_, ApiError>` and uses `ApiJson`. All existing `warn!` logging and metric increments are preserved; only the error body shape changed.

## Acceptance criteria
- [x] Consistent `{ "error": { "code", "message" } }` envelope across all error responses (handler + extractor)
- [x] Stable, documented, uppercase snake-case code enum
- [x] HTTP status codes unchanged from prior behaviour
- [x] All eight required codes present

## Notes
- The **success** response shape is intentionally left as-is; #193 redefines it (`202 { task_id, status }`).
- This is the Phase-1 foundation the rest of the v1-beta lifecycle builds on: #188 uses `ApiError::unauthorized()`, #191 emits `QUEUE_FULL`, #190 emits `RATE_LIMITED`, and #193/#194's new endpoints get the envelope for free via `ApiJson`.

## Verification
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-targets --all-features` all pass across the workspace.
- New unit tests cover code serialization, the envelope shape, the `From` mappings (incl. RPC-detail sanitization and future-vs-stale block distinction); every error-path HTTP test now asserts on `error.code`.
- No new runtime config, so no `example.env` / Helm changes.