### PR TITLE
feat: scaffold sqlite persistence layer for the router

### DIFF
--- a/.github/workflows/helm-integration-tests.yml
+++ b/.github/workflows/helm-integration-tests.yml
@@ -316,6 +316,20 @@ jobs:
 
           echo "All pods are ready!"
 
+      - name: Verify router persistence
+        run: |
+          # The router opens its SQLite store under DATA_DIR (/data) at startup and aborts if
+          # the volume is missing or not writable by the non-root user. Assert the database
+          # file exists so a persistence regression surfaces here instead of as a generic
+          # readiness timeout or a downstream task failure.
+          ROUTER_POD=$(kubectl get pods -l app.kubernetes.io/component=router -o jsonpath='{.items[0].metadata.name}')
+          echo "Router pod: $ROUTER_POD"
+          echo "=== Contents of /data ==="
+          kubectl exec "$ROUTER_POD" -- ls -l /data
+          echo "=== Asserting /data/router.db exists ==="
+          kubectl exec "$ROUTER_POD" -- test -f /data/router.db
+          echo "router.db is present and the persistent volume is writable"
+
       - name: Setup port forwarding for testing
         run: |
           # Find actual service names (they include the chart name)

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ terraform.tfstate
 terraform.tfstate.*
 *.tfstate
 *.tfstate.*
+
+# Router SQLite store — created at runtime under DATA_DIR; never committed.
+# Matches the database file and its WAL/SHM sidecars in any directory.
+router.db
+router.db-*
+/data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,6 +2629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,6 +3570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,7 +3695,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -5938,6 +5958,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +2934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -3017,6 +3036,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -3348,6 +3373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
 source = "git+https://github.com/succinctlabs/ethereum-consensus?branch=dev#b5ad46a41ba1866992c9d7dc068f18dc00fdb251"
@@ -3540,6 +3576,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,6 +3674,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3866,6 +3924,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
+ "sqlx",
+ "tempfile",
  "tokio",
  "tower 0.4.13",
  "tower-http 0.5.2",
@@ -4080,6 +4140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4122,6 +4191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4702,6 +4780,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.8.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4789,6 +4890,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -4982,6 +5093,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -5740,7 +5867,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -5810,6 +5937,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5924,6 +6060,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5948,6 +6095,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -6449,6 +6602,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags",
 ]
@@ -7355,6 +7517,26 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8404,6 +8586,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinning_top"
@@ -8432,6 +8617,191 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.10",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -8467,6 +8837,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -9189,6 +9570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9202,6 +9589,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9376,6 +9769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9521,6 +9920,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9647,6 +10056,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -9670,6 +10088,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -9707,6 +10140,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -9719,6 +10158,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -9728,6 +10173,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9755,6 +10206,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -9764,6 +10221,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9779,6 +10242,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -9788,6 +10257,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
+tempfile = "3"
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["cors"] }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,9 @@ services:
       - HTTP_RPC=http://ethereum:8545
       - WS_RPC=ws://ethereum:8545
       - AVS_DEPLOYMENT_PATH=/app/.nodes/avs_deploy.json
+      # /app is owned by the non-root container user; /data is reserved for the Kubernetes
+      # PVC mount and is not writable here.
+      - DATA_DIR=/app/data
     volumes:
       - ./config/.nodes:/app/.nodes:ro
       - ./config/router_orchestrator.dev.json:/app/router_orchestrator.json:ro

--- a/example.env
+++ b/example.env
@@ -171,6 +171,13 @@ INGRESS_TIMEOUT_MS=0
 # INGRESS_PASSWORD=  # Required for TESTNET mode
 
 # =============================================================================
+# Persistence
+# =============================================================================
+# Directory for the router's SQLite database (router.db lives here). Created on startup if
+# absent; must be writable by the process. In Kubernetes this is a PVC-backed mount.
+DATA_DIR=/data
+
+# =============================================================================
 # AVS Metadata (served at GET /avs-metadata; set this URL as metadata.uri in config.json)
 # =============================================================================
 # AVS_METADATA_NAME=Gas Killer

--- a/helm/gas-killer/templates/_helpers.tpl
+++ b/helm/gas-killer/templates/_helpers.tpl
@@ -91,6 +91,13 @@ Shared data PVC name
 {{- end }}
 
 {{/*
+Router persistent data PVC name
+*/}}
+{{- define "gas-killer.routerdata.fullname" -}}
+{{- printf "%s-router-data" (include "gas-killer.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Config ConfigMap name
 */}}
 {{- define "gas-killer.config.fullname" -}}

--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -101,6 +101,30 @@ data:
           }
         },
         {
+          "id": 5,
+          "type": "stat",
+          "title": "Database",
+          "description": "Router SQLite store liveness — gas_killer_db_up, set by the router's periodic SELECT 1 health check.",
+          "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+          "targets": [{
+            "expr": "gas_killer_db_up",
+            "legendFormat": "db"
+          }],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "orientation": "auto",
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+              ]
+            }
+          }
+        },
+        {
           "id": 10,
           "type": "text",
           "title": "Resource Usage",

--- a/helm/gas-killer/templates/router-data-pvc.yaml
+++ b/helm/gas-killer/templates/router-data-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.router.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gas-killer.routerdata.fullname" . }}
+  labels:
+    {{- include "gas-killer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: router
+spec:
+  accessModes:
+    - {{ .Values.router.persistence.accessMode }}
+  {{- if .Values.router.persistence.storageClass }}
+  storageClassName: {{ .Values.router.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.router.persistence.size }}
+{{- end }}

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -7,6 +7,14 @@ metadata:
     app.kubernetes.io/component: router
 spec:
   replicas: 1
+  {{- if .Values.router.persistence.enabled }}
+  # The data volume is ReadWriteOnce. A RollingUpdate surges a new pod before the old one
+  # terminates; if it schedules on a different node it hits a Multi-Attach error and the
+  # rollout wedges. Recreate tears down the old pod (releasing the volume) before starting
+  # the replacement — brief upgrade downtime, but correct for an RWO-backed singleton.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "gas-killer.selectorLabels" . | nindent 6 }}

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -18,6 +18,11 @@ spec:
         app.kubernetes.io/component: router
     spec:
       terminationGracePeriodSeconds: {{ .Values.router.terminationGracePeriodSeconds }}
+      # fsGroup makes the mounted data volume writable by the non-root container user so the
+      # router can create its SQLite database under DATA_DIR. Applies whether the volume is
+      # PVC-backed or an emptyDir.
+      securityContext:
+        fsGroup: {{ .Values.router.persistence.fsGroup }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -276,6 +281,8 @@ spec:
               value: "{{ .Values.router.ingressBindHost }}:{{ .Values.router.ingressPort }}"
             - name: RUST_BACKTRACE
               value: "1"
+            - name: DATA_DIR
+              value: {{ .Values.router.persistence.mountPath | quote }}
             - name: INGRESS_TIMEOUT_MS
               value: {{ .Values.router.ingress.timeoutMs | quote }}
             {{- if or (and (eq .Values.global.environment "TESTNET") .Values.router.ingress.enabled) .Values.secrets.ingressPassword }}
@@ -364,6 +371,8 @@ spec:
             - name: shared-data
               mountPath: /app/.nodes
               readOnly: true
+            - name: router-data
+              mountPath: {{ .Values.router.persistence.mountPath }}
             {{- if and (eq .Values.global.environment "TESTNET") .Values.secretManager.enabled }}
             - name: router-secrets
               mountPath: /app/secrets
@@ -382,6 +391,13 @@ spec:
         - name: shared-data
           persistentVolumeClaim:
             claimName: {{ include "gas-killer.shareddata.fullname" . }}
+        - name: router-data
+          {{- if .Values.router.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "gas-killer.routerdata.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- if and (eq .Values.global.environment "TESTNET") .Values.secretManager.enabled }}
         - name: router-secrets
           emptyDir: {}

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -336,6 +336,19 @@ router:
     type: ClusterIP
     port: 3000
     ingressPort: 8080
+  # Durable SQLite store for the router (API keys, task state). The store path is exposed
+  # to the binary via the DATA_DIR env var. When enabled, a PersistentVolumeClaim keeps the
+  # data across pod restarts; when disabled, an emptyDir is used and data is lost on restart
+  # (acceptable for ephemeral or dev clusters).
+  persistence:
+    enabled: true
+    mountPath: /data
+    storageClass: ""
+    size: 1Gi
+    accessMode: ReadWriteOnce
+    # Applied as the pod's securityContext.fsGroup so the non-root container user can write
+    # to the mounted volume. The router image runs as 'appuser' (uid/gid 1000).
+    fsGroup: 1000
   resources:
     requests:
       memory: "512Mi"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -78,12 +78,16 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sqlx = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [build-dependencies]
 prost-build = "0.13.5"

--- a/router/migrations/README.md
+++ b/router/migrations/README.md
@@ -1,0 +1,3 @@
+# Schema migrations for the router SQLite store, embedded via sqlx::migrate!.
+# Files are named <version>_<description>.sql and applied in version order.
+# Consuming features add their own migrations here (e.g. keys, tasks).

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -8,6 +8,7 @@ use crate::ingress::{
     start_gas_killer_http_server,
 };
 use crate::metrics::MetricsCollector;
+use crate::store::SqliteStore;
 use alloy::network::{Ethereum, EthereumWallet};
 use alloy_provider::{
     Identity, Provider, ProviderBuilder, RootProvider,
@@ -117,6 +118,9 @@ pub async fn create_listening_creator_with_server(
             .filter(|s| !s.is_empty()),
         operator_sets,
     };
+    // Open the durable store and apply migrations before serving traffic. A failure here
+    // aborts router startup rather than running against an unmigrated or unwritable store.
+    let store = SqliteStore::connect().await?;
     let ingress_state = IngressState::new(
         sender,
         queue_depth,
@@ -125,7 +129,8 @@ pub async fn create_listening_creator_with_server(
         providers,
         ingress_password,
         avs_metadata,
-    );
+    )
+    .with_store(store);
     tokio::spawn(async move {
         start_gas_killer_http_server(ingress_state, &addr).await;
     });

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -26,8 +26,13 @@ use commonware_avs_router::executor::bls::BlsEigenlayerExecutor;
 use commonware_runtime::Metrics;
 use gas_killer_common::{ChainRole, GasKillerValidator};
 use std::collections::HashMap;
+use std::time::Duration;
 use std::{env, str::FromStr, sync::Arc};
 use tracing::info;
+
+/// How often the background loop re-checks SQLite store liveness for the `gas_killer_db_up`
+/// metric. Aligned with a typical Prometheus scrape interval so the gauge stays fresh.
+const DB_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Wallet provider that uses SimpleNonceManager to always fetch the pending nonce from the
 /// chain rather than caching it locally. This prevents nonce corruption when a transaction
@@ -121,6 +126,23 @@ pub async fn create_listening_creator_with_server(
     // Open the durable store and apply migrations before serving traffic. A failure here
     // aborts router startup rather than running against an unmigrated or unwritable store.
     let store = SqliteStore::connect().await?;
+
+    // Publish store liveness as `gas_killer_db_up`. connect() already proved the store
+    // answers, so seed the gauge to 1; a background loop then re-checks so a later volume
+    // loss (detached PVC, full or read-only disk) surfaces as db_up=0 on the dashboard.
+    metrics.db_up.set(1);
+    {
+        let store = store.clone();
+        let metrics = Arc::clone(&metrics);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(DB_HEALTH_CHECK_INTERVAL);
+            loop {
+                ticker.tick().await;
+                metrics.db_up.set(store.health_check().await.is_ok() as i64);
+            }
+        });
+    }
+
     let ingress_state = IngressState::new(
         sender,
         queue_depth,

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,6 +1,7 @@
 use crate::creator::{TaskQueueDepth, TaskSender};
 use crate::error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ErrorCode};
 use crate::metrics::MetricsCollector;
+use crate::store::SqliteStore;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use axum::{
@@ -67,6 +68,9 @@ pub struct IngressState {
     /// Bearer token password. `None` disables authentication.
     pub password: Option<String>,
     pub avs_metadata: AvsMetadata,
+    /// Durable SQLite store shared with the orchestrator. `None` when persistence is not
+    /// configured (e.g. in tests); persistent features fall back to in-memory behaviour.
+    pub store: Option<SqliteStore>,
 }
 
 impl IngressState {
@@ -87,6 +91,7 @@ impl IngressState {
             providers: Arc::new(providers),
             password,
             avs_metadata,
+            store: None,
         }
     }
 
@@ -99,7 +104,14 @@ impl IngressState {
             providers: Arc::new(HashMap::new()),
             password: None,
             avs_metadata: AvsMetadata::default(),
+            store: None,
         }
+    }
+
+    /// Attaches the durable SQLite store, returning the updated state for chained construction.
+    pub fn with_store(mut self, store: SqliteStore) -> Self {
+        self.store = Some(store);
+        self
     }
 }
 

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -7,6 +7,7 @@ pub mod factories;
 pub mod ingress;
 pub mod metrics;
 pub mod orchestrator;
+pub mod store;
 
 // Re-export task_data from common crate
 pub mod task_data {
@@ -27,3 +28,4 @@ pub use gas_killer_common::GasKillerTaskData;
 pub use gas_killer_common::GasKillerValidator;
 pub use ingress::{GasKillerTaskRequest, GasKillerTaskRequestBody, ValidationError};
 pub use orchestrator::GasKillerOrchestrator;
+pub use store::SqliteStore;

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -34,6 +34,8 @@ pub struct MetricsCollector {
     pub round_latency_seconds: Histogram,
     /// Current number of tasks sitting in the ingress queue waiting to be processed.
     pub task_queue_depth: Gauge<i64, AtomicI64>,
+    /// Whether the SQLite store answered its most recent health check (1 = up, 0 = down).
+    pub db_up: Gauge<i64, AtomicI64>,
     /// Time to detect which chain a target contract is deployed on (seconds).
     pub executor_chain_detection_seconds: Histogram,
     /// Time for the payload-hash preflight computation (seconds).
@@ -142,6 +144,13 @@ impl MetricsCollector {
             task_queue_depth.clone(),
         );
 
+        let db_up = Gauge::default();
+        registry.register(
+            "gas_killer_db_up",
+            "Whether the SQLite store answered its most recent health check (1 = up, 0 = down)",
+            db_up.clone(),
+        );
+
         // Single same-RPC round-trips (~5-150ms); fine low-end buckets so p50/p95 resolve.
         let rpc_buckets = [
             0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.15, 0.25, 0.5, 1.0, 2.5,
@@ -201,6 +210,7 @@ impl MetricsCollector {
             p2p_round_trip_seconds,
             round_latency_seconds,
             task_queue_depth,
+            db_up,
             executor_chain_detection_seconds,
             executor_hash_preflight_seconds,
             executor_supports_interface_seconds,
@@ -237,5 +247,18 @@ mod tests {
         ));
         assert!(output.contains("gas_killer_round_latency_seconds_count 1"));
         assert!(output.contains("gas_killer_round_latency_seconds_sum 12.5"));
+    }
+
+    #[test]
+    fn test_db_up_gauge_registered_and_reports_status() {
+        let metrics = MetricsCollector::new();
+        metrics.db_up.set(1);
+
+        let output = metrics.encode();
+        assert!(output.contains("Whether the SQLite store answered its most recent health check"));
+        assert!(output.contains("gas_killer_db_up 1"));
+
+        metrics.db_up.set(0);
+        assert!(metrics.encode().contains("gas_killer_db_up 0"));
     }
 }

--- a/router/src/store/mod.rs
+++ b/router/src/store/mod.rs
@@ -1,0 +1,197 @@
+//! SQLite persistence layer for the router.
+//!
+//! [`SqliteStore`] owns the single durable store behind the ingress: API keys and task
+//! state both live in this one database. The store opens a connection pool, applies its
+//! embedded schema migrations on startup, and hands the pool to components that need it.
+//!
+//! Schema is defined by migration files under `router/migrations/`, embedded into the
+//! binary at compile time so no migration files need to ship in the runtime image. Each
+//! feature that needs a table adds its own migration; this module owns only connection
+//! setup and the migration runner.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::Context;
+use sqlx::sqlite::{
+    SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteSynchronous,
+};
+
+/// Directory holding the router's persistent data when `DATA_DIR` is unset.
+///
+/// In production this is a mounted PVC (see the Helm chart); the path must be writable by
+/// the container's user.
+const DEFAULT_DATA_DIR: &str = "/data";
+
+/// Filename of the SQLite database within the data directory.
+const DATABASE_FILENAME: &str = "router.db";
+
+/// How long a write waits for a competing writer's lock before erroring. SQLite serializes
+/// writers, so a brief contention window is expected under concurrent ingress load.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Embedded schema migrations, applied in order on startup.
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+/// A handle to the router's SQLite connection pool.
+///
+/// Cheap to clone — the inner pool is reference-counted — so it can be shared across the
+/// ingress and orchestrator and every clone reads and writes the same database.
+#[derive(Clone)]
+pub struct SqliteStore {
+    pool: SqlitePool,
+}
+
+impl SqliteStore {
+    /// Opens the database under `DATA_DIR` (default `/data`), creating it if absent, and
+    /// applies all pending migrations.
+    ///
+    /// Returns an error if the data directory cannot be created, the database cannot be
+    /// opened, or a migration fails. Callers must abort startup on error so the router
+    /// never serves traffic against an unmigrated store.
+    pub async fn connect() -> anyhow::Result<Self> {
+        Self::connect_at(&resolve_db_path()).await
+    }
+
+    /// Opens the database at an explicit filesystem path, creating the parent directory and
+    /// the database file if needed, then applies pending migrations.
+    pub async fn connect_at(path: &Path) -> anyhow::Result<Self> {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating data directory {}", parent.display()))?;
+        }
+
+        let options = SqliteConnectOptions::new()
+            .filename(path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .foreign_keys(true)
+            .busy_timeout(BUSY_TIMEOUT);
+
+        let pool = SqlitePoolOptions::new()
+            .connect_with(options)
+            .await
+            .with_context(|| format!("opening sqlite database at {}", path.display()))?;
+
+        Self::migrate(pool, &path.display().to_string()).await
+    }
+
+    /// Opens a transient in-memory database for tests.
+    ///
+    /// Each new connection to a bare in-memory database gets its own empty schema, so the
+    /// pool is capped at a single connection to keep one migrated database alive for the
+    /// store's lifetime.
+    #[cfg(test)]
+    pub async fn connect_in_memory() -> anyhow::Result<Self> {
+        let options = "sqlite::memory:"
+            .parse::<SqliteConnectOptions>()
+            .context("building in-memory sqlite options")?
+            .foreign_keys(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .context("opening in-memory sqlite database")?;
+
+        Self::migrate(pool, ":memory:").await
+    }
+
+    /// Applies pending migrations against `pool` and wraps it in a [`SqliteStore`].
+    async fn migrate(pool: SqlitePool, path: &str) -> anyhow::Result<Self> {
+        MIGRATOR
+            .run(&pool)
+            .await
+            .context("applying database migrations")?;
+
+        tracing::info!(
+            path,
+            migrations = MIGRATOR.iter().count(),
+            "sqlite store ready"
+        );
+
+        Ok(Self { pool })
+    }
+
+    /// Borrows the connection pool for issuing queries.
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+}
+
+/// Resolves the database path from `DATA_DIR` (default [`DEFAULT_DATA_DIR`]) as
+/// `<DATA_DIR>/router.db`.
+fn resolve_db_path() -> PathBuf {
+    let dir = std::env::var("DATA_DIR").unwrap_or_else(|_| DEFAULT_DATA_DIR.to_string());
+    Path::new(&dir).join(DATABASE_FILENAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn in_memory_store_migrates_and_serves_queries() {
+        let store = SqliteStore::connect_in_memory()
+            .await
+            .expect("in-memory store should open and migrate");
+
+        let one: i64 = sqlx::query_scalar("SELECT 1")
+            .fetch_one(store.pool())
+            .await
+            .expect("a trivial query should round-trip through the pool");
+        assert_eq!(one, 1);
+
+        // The migration runner always provisions its bookkeeping table, even with no
+        // migrations of our own yet.
+        let tracking_table: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM sqlite_master WHERE name = '_sqlx_migrations'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .expect("migration bookkeeping table should exist");
+        assert_eq!(tracking_table, 1);
+    }
+
+    #[tokio::test]
+    async fn file_store_is_durable_and_idempotent_across_reopen() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("router.db");
+
+        // First open creates and migrates the database.
+        {
+            let store = SqliteStore::connect_at(&path)
+                .await
+                .expect("first open should create and migrate");
+
+            let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+                .fetch_one(store.pool())
+                .await
+                .expect("journal_mode pragma should be readable");
+            assert_eq!(journal_mode.to_lowercase(), "wal");
+        }
+
+        assert!(
+            path.exists(),
+            "database file should persist after the pool is dropped"
+        );
+
+        // Reopening the same database re-runs migrations as a no-op rather than failing.
+        let store = SqliteStore::connect_at(&path)
+            .await
+            .expect("reopening an existing database should succeed");
+        let one: i64 = sqlx::query_scalar("SELECT 1")
+            .fetch_one(store.pool())
+            .await
+            .expect("reopened store should serve queries");
+        assert_eq!(one, 1);
+    }
+
+    #[test]
+    fn db_path_defaults_to_data_dir() {
+        // Exercised without mutating process env: the default branch is what ships in prod.
+        let path = Path::new(DEFAULT_DATA_DIR).join(DATABASE_FILENAME);
+        assert_eq!(path, Path::new("/data/router.db"));
+    }
+}

--- a/router/src/store/mod.rs
+++ b/router/src/store/mod.rs
@@ -118,6 +118,17 @@ impl SqliteStore {
     pub fn pool(&self) -> &SqlitePool {
         &self.pool
     }
+
+    /// Runs a trivial liveness query against the store, returning an error if the pool
+    /// cannot serve it — e.g. the backing volume was detached, filled, or went read-only.
+    /// Drives the `gas_killer_db_up` metric.
+    pub async fn health_check(&self) -> anyhow::Result<()> {
+        sqlx::query("SELECT 1")
+            .execute(&self.pool)
+            .await
+            .context("sqlite health check")?;
+        Ok(())
+    }
 }
 
 /// Resolves the database path from the `DATA_DIR` environment variable.
@@ -192,6 +203,17 @@ mod tests {
             .await
             .expect("reopened store should serve queries");
         assert_eq!(one, 1);
+    }
+
+    #[tokio::test]
+    async fn health_check_succeeds_on_open_store() {
+        let store = SqliteStore::connect_in_memory()
+            .await
+            .expect("in-memory store should open");
+        store
+            .health_check()
+            .await
+            .expect("health check should pass against an open store");
     }
 
     #[test]

--- a/router/src/store/mod.rs
+++ b/router/src/store/mod.rs
@@ -120,10 +120,16 @@ impl SqliteStore {
     }
 }
 
-/// Resolves the database path from `DATA_DIR` (default [`DEFAULT_DATA_DIR`]) as
-/// `<DATA_DIR>/router.db`.
+/// Resolves the database path from the `DATA_DIR` environment variable.
 fn resolve_db_path() -> PathBuf {
-    let dir = std::env::var("DATA_DIR").unwrap_or_else(|_| DEFAULT_DATA_DIR.to_string());
+    db_path_from_dir(std::env::var("DATA_DIR").ok())
+}
+
+/// Builds the database path from an optional data directory, applying [`DEFAULT_DATA_DIR`]
+/// when unset, as `<dir>/router.db`. Split from [`resolve_db_path`] so both the default and
+/// override branches are testable without mutating process-wide environment state.
+fn db_path_from_dir(dir: Option<String>) -> PathBuf {
+    let dir = dir.unwrap_or_else(|| DEFAULT_DATA_DIR.to_string());
     Path::new(&dir).join(DATABASE_FILENAME)
 }
 
@@ -189,9 +195,15 @@ mod tests {
     }
 
     #[test]
-    fn db_path_defaults_to_data_dir() {
-        // Exercised without mutating process env: the default branch is what ships in prod.
-        let path = Path::new(DEFAULT_DATA_DIR).join(DATABASE_FILENAME);
-        assert_eq!(path, Path::new("/data/router.db"));
+    fn db_path_defaults_to_data_dir_when_unset() {
+        assert_eq!(db_path_from_dir(None), Path::new("/data/router.db"));
+    }
+
+    #[test]
+    fn db_path_honors_data_dir_override() {
+        assert_eq!(
+            db_path_from_dir(Some("/app/data".to_string())),
+            Path::new("/app/data/router.db")
+        );
     }
 }


### PR DESCRIPTION
Closes #293.

Scaffolds the shared SQLite persistence layer the router lacked entirely, so the API-key (#188) and task-store (#192) features each add only their own table on top of it instead of introducing the DB layer inside a feature PR.

## What's here

**Persistence layer** — `router/src/store/mod.rs`
- `SqliteStore` opens a `SqlitePool` via `SqliteConnectOptions` with `journal_mode=WAL`, `foreign_keys=ON`, and a 5s `busy_timeout`.
- `connect()` resolves `DATA_DIR` (default `/data`) → `<DATA_DIR>/router.db`, creates the parent dir, then runs the embedded `sqlx::migrate!("./migrations")` runner. Migrations are compiled into the binary, so nothing migration-related ships in the runtime image.
- Uses the **runtime-checked** `sqlx::query`/`query_scalar` API (not the compile-time `query!` macros), so CI needs no `DATABASE_URL` or `.sqlx` offline cache.

**Wiring**
- `IngressState` gains `store: Option<SqliteStore>` + a `with_store()` builder (existing test constructors default to `None`).
- `create_listening_creator_with_server` opens the store **before** serving traffic; a migration/open failure propagates to `.expect("Failed to build orchestrator")` and aborts startup loudly rather than serving against an unmigrated store.

**Deployment**
- New `router-data-pvc.yaml` + `router.persistence` values; PVC mounted RW at `/data`, `DATA_DIR` wired through. `fsGroup: 1000` so the non-root `appuser` can write — applied in both PVC and `emptyDir` (disabled) modes.
- `docker-compose.yml` overrides `DATA_DIR=/app/data` (an `appuser`-writable path) so e2e/local don't hit the unwritable `/data`.
- Documented in `example.env`; runtime DB files ignored in `.gitignore`.

**CI** — `helm-integration-tests.yml` gains a *Verify router persistence* step asserting `/data/router.db` exists in-cluster, so a persistence regression surfaces as a named failure instead of a generic readiness timeout.

## Testing
- `cargo fmt` · `clippy --all-targets --all-features -D warnings` · `cargo test` (**81 router tests**, +3 new store tests covering migrate + `SELECT 1`, WAL assertion + idempotent reopen, and the default-path resolution).
- `helm lint` + `helm template` verified in both `persistence.enabled` true/false modes.

No Dockerfile change needed: the builder already links binaries (C toolchain present for the bundled `libsqlite3-sys` compile) and bundled SQLite is statically linked, so the runtime stage needs no system lib.

## Out of scope (owned by consumers)
- `keys` table + `/admin/keys` CRUD → #188 (AUTH-1)
- `tasks` table + re-queue-on-startup → #192 (RELY-1)

## Related
- gas-killer/infra#4 — tracks the zonal-PD/regional-cluster zone-failover gap for this volume (no infra change required to ship).
