### PR TITLE
fix: clean up spurious CI diagnostics in e2e and helm tests

### DIFF
--- a/.github/workflows/helm-integration-tests.yml
+++ b/.github/workflows/helm-integration-tests.yml
@@ -412,6 +412,9 @@ jobs:
           INITIAL_COUNT=$(cast call "$ARRAY_SUMMATION_ADDRESS" "stateTransitionCount()(uint256)" --rpc-url http://localhost:8545 | tr -d '[:space:]')
           echo "Initial stateTransitionCount: $INITIAL_COUNT"
 
+          # Block height before triggering, used to bound the SumCalculated event query below.
+          START_BLOCK=$(cast block-number --rpc-url http://localhost:8545)
+
           NUM_TRIGGERS=3
           SUCCESSFUL=0
 
@@ -447,9 +450,10 @@ jobs:
             exit 1
           fi
 
-          # Check for SumCalculated events
+          # Count SumCalculated events emitted since the triggers began.
           EVENT_TOPIC=$(cast keccak 'SumCalculated(uint256,uint256)')
-          EVENT_COUNT=$(cast logs --from-block 0 --address "$ARRAY_SUMMATION_ADDRESS" --topic $EVENT_TOPIC --rpc-url http://localhost:8545 2>/dev/null | grep -c "blockNumber" || echo "0")
+          EVENT_JSON=$(cast logs --from-block "$START_BLOCK" --address "$ARRAY_SUMMATION_ADDRESS" "$EVENT_TOPIC" --rpc-url http://localhost:8545 --json 2>/dev/null || echo '[]')
+          EVENT_COUNT=$(echo "$EVENT_JSON" | jq 'length')
           echo "Found $EVENT_COUNT SumCalculated events"
 
           if [ "$EVENT_COUNT" -ge "$NUM_TRIGGERS" ]; then

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -233,6 +233,13 @@ else
     docker compose logs --tail=100 router || true
     echo -e "${YELLOW}Recent node logs:${NC}"
     docker compose logs --tail=50 node-1 node-2 node-3 || true
+    # Trace the verifyAndUpdate transaction, if one was submitted, to surface a revert reason.
+    # cast run re-simulates the transaction, so this is best-effort diagnostic output.
+    TX_HASH=$(docker compose logs router 2>/dev/null | grep "Contract execution result" | grep -o "transaction_hash=0x[a-fA-F0-9]*" | sed 's/transaction_hash=//' | tail -1)
+    if [ -n "$TX_HASH" ] && command -v cast >/dev/null 2>&1; then
+        echo -e "${YELLOW}Execution trace for $TX_HASH:${NC}"
+        cast run "$TX_HASH" --rpc-url http://localhost:8545 || true
+    fi
     exit 1
 fi
 
@@ -240,22 +247,12 @@ fi
 echo -e "${YELLOW}Recent router logs:${NC}"
 docker compose logs --tail=50 router || true
 
-# Extract transaction hash from router logs and show execution trace
-echo -e "${YELLOW}Extracting transaction hash and showing execution trace...${NC}"
+# Print the execution trace of the successful verifyAndUpdate for inspection.
+# debug_traceTransaction reflects the real mined execution, not a re-simulation.
 TX_HASH=$(docker compose logs router 2>/dev/null | grep "Contract execution result" | grep -o "transaction_hash=0x[a-fA-F0-9]*" | sed 's/transaction_hash=//' | tail -1)
-
-if [ -n "$TX_HASH" ]; then
-    echo -e "${GREEN}Found transaction hash: $TX_HASH${NC}"
-    echo -e "${YELLOW}Running cast trace...${NC}"
-
-    # Check if cast is available
-    if command -v cast >/dev/null 2>&1; then
-        cast run "$TX_HASH" --rpc-url http://localhost:8545 || echo -e "${YELLOW}Cast trace failed, transaction may still be pending${NC}"
-    else
-        echo -e "${YELLOW}Warning: cast (Foundry) not found. Install with: curl -L https://foundry.paradigm.xyz | bash && foundryup${NC}"
-    fi
-else
-    echo -e "${YELLOW}Warning: Could not find transaction hash in router logs${NC}"
+if [ -n "$TX_HASH" ] && command -v cast >/dev/null 2>&1; then
+    echo -e "${YELLOW}Execution trace for $TX_HASH:${NC}"
+    cast rpc debug_traceTransaction "$TX_HASH" '{"tracer":"callTracer"}' --rpc-url http://localhost:8545 | jq '.' || true
 fi
 
 echo -e "${GREEN}✅ Test passed - Stack is up and array summation completed successfully!${NC}"


### PR DESCRIPTION
Two CI test workflows produced misleading output that didn't reflect any real problem with the service. Both fixes are CI-only — no changes to router/executor behavior.

## e2e-test: spurious `cast run` OutOfGas
The post-success diagnostic ran `cast run <tx>` to print a trace. `cast run` re-simulates the transaction using its recorded gas limit, and the router submits `verifyAndUpdate` with alloy's bare `eth_estimateGas` result — which on the anvil fork equals the exact gas consumed (`gas_used == gas_limit`, zero headroom). The re-simulation needs a hair more than the live execution, so it always reported `OutOfGas` / `Error: Transaction failed` for a transaction that actually succeeded (`status=true`).

- **On success**, the trace now comes from `cast rpc debug_traceTransaction <tx> '{"tracer":"callTracer"}'`, which reflects the real mined execution instead of re-simulating it — so it shows the true (successful) call tree with no spurious OutOfGas.
- **On failure**, `cast run` runs in the failure branch, where a genuinely reverted transaction traces faithfully and surfaces the real revert reason.

## helm-integration-tests: SumCalculated events always counted as 0
The event check reported `Found 0` and threw `integer expression expected`, from three compounding bugs (confirmed against a Sepolia-fork anvil):

- `--topic` is not a valid `cast logs` flag in the current foundry (topic is positional), so the command errored out entirely and was swallowed by `2>/dev/null`.
- `--from-block 0` on a fork is forwarded to the upstream RPC, which rejects `getLogs` over more than 50000 blocks. Now bounded to the block captured just before the triggers.
- `grep -c … || echo "0"` produced `"0\n0"` on zero matches. Counting now uses `cast logs --json | jq 'length'` with an empty-array guard.

Verified end to end: 3 emitted events → count 3; zero matches → 0; RPC error → 0.