### PR TITLE
feat: add persistent task model and store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "url",
+ "uuid 1.22.0",
 ]
 
 [[package]]
@@ -9882,6 +9883,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,4 @@ tower-http = { version = "0.5", features = ["cors"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 url = { version = "2.5.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4"] }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -89,6 +89,7 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/router/migrations/0002_tasks.sql
+++ b/router/migrations/0002_tasks.sql
@@ -1,0 +1,38 @@
+-- Task records tracking each submitted aggregation request through its lifecycle.
+--
+-- A task enters in the `queued` state when a request is accepted, advances to `processing`
+-- while the router aggregates operator signatures, and settles in a terminal state: `ready`
+-- (carrying an executable `payload`), `failed`, or `expired` (each carrying a human-readable
+-- `error`). Persisting the request parameters alongside the state lets the router rebuild and
+-- re-enqueue tasks still `queued` or `processing` after a restart, so an in-flight request is
+-- never silently lost when the pod recycles.
+--
+-- `key_id` scopes a task to the API key that created it, both for ownership checks on the
+-- status endpoints and so a key's own tasks can be listed. The listing filters and paginates
+-- by `(key_id, created_at)`, which the index below serves.
+--
+-- Ethereum values are stored as text: addresses in their `0x` hex form and `value` as a
+-- decimal string, since a 256-bit integer does not fit SQLite's signed 64-bit INTEGER.
+-- `call_data` holds the raw request bytes. `transition_index` is NULL when the request left
+-- the slot for the server to resolve at dequeue time ("auto").
+CREATE TABLE tasks (
+    id               TEXT    PRIMARY KEY NOT NULL,
+    key_id           TEXT    NOT NULL REFERENCES api_keys(id),
+    status           TEXT    NOT NULL CHECK (status IN ('queued', 'processing', 'ready', 'failed', 'expired')),
+    target_address   TEXT    NOT NULL,
+    call_data        BLOB    NOT NULL,
+    transition_index INTEGER,
+    from_address     TEXT    NOT NULL,
+    value            TEXT    NOT NULL,
+    block_height     INTEGER NOT NULL,
+    payload          TEXT,
+    error            TEXT,
+    created_at       INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at       INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Serves the per-key task listing (newest first) and its status-filtered variant.
+CREATE INDEX idx_tasks_key_created ON tasks (key_id, created_at DESC);
+
+-- Serves the startup scan that re-enqueues tasks left unfinished by a restart.
+CREATE INDEX idx_tasks_status ON tasks (status);

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -28,4 +28,4 @@ pub use gas_killer_common::GasKillerTaskData;
 pub use gas_killer_common::GasKillerValidator;
 pub use ingress::{GasKillerTaskRequest, GasKillerTaskRequestBody, ValidationError};
 pub use orchestrator::GasKillerOrchestrator;
-pub use store::{ApiKeyMetadata, CreatedApiKey, SqliteStore};
+pub use store::{ApiKeyMetadata, CreatedApiKey, SqliteStore, Task, TaskStatus};

--- a/router/src/store/mod.rs
+++ b/router/src/store/mod.rs
@@ -10,8 +10,10 @@
 //! setup and the migration runner.
 
 mod api_keys;
+mod tasks;
 
 pub use api_keys::{ApiKeyMetadata, CreatedApiKey};
+pub use tasks::{Task, TaskStatus};
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/router/src/store/tasks.rs
+++ b/router/src/store/tasks.rs
@@ -1,0 +1,557 @@
+//! Task persistence backed by the [`SqliteStore`].
+//!
+//! A task is the durable record of one submitted aggregation request. It is created in the
+//! [`TaskStatus::Queued`] state, advances to [`TaskStatus::Processing`] while the router
+//! aggregates operator signatures, and settles in a terminal state: [`TaskStatus::Ready`]
+//! (with an executable `payload`), [`TaskStatus::Failed`], or [`TaskStatus::Expired`] (each
+//! carrying an `error`).
+//!
+//! The full request that created the task is stored alongside its state so the router can
+//! rebuild and re-enqueue any task still `queued` or `processing` after a restart — an
+//! in-flight request must never be lost when the pod recycles. Every task is scoped to the
+//! API key that created it (`key_id`), which drives both ownership checks and per-key listing.
+
+use std::str::FromStr;
+
+use alloy_primitives::{Address, U256};
+use anyhow::Context;
+use sqlx::FromRow;
+use uuid::Uuid;
+
+use super::SqliteStore;
+use crate::ingress::GasKillerTaskRequestBody;
+
+/// Columns selected for every task read, in the order the [`TaskRow`] fields expect. sqlx maps
+/// by column name, but listing them once keeps the queries consistent and self-documenting.
+const TASK_COLUMNS: &str = "id, key_id, status, target_address, call_data, transition_index, \
+     from_address, value, block_height, payload, error, created_at, updated_at";
+
+/// Lifecycle state of a task as it moves through aggregation.
+///
+/// The string forms are the on-the-wire values (via serde) and the values persisted in the
+/// `status` column; the migration's CHECK constraint pins the same set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    /// Accepted and waiting in the queue.
+    Queued,
+    /// Dequeued; the router is aggregating operator signatures.
+    Processing,
+    /// Aggregation succeeded; `payload` holds the executable calldata.
+    Ready,
+    /// Aggregation failed; `error` explains why.
+    Failed,
+    /// The task lapsed before completing; `error` explains why.
+    Expired,
+}
+
+impl TaskStatus {
+    /// The value stored in the `status` column, matching the migration's CHECK constraint.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Processing => "processing",
+            Self::Ready => "ready",
+            Self::Failed => "failed",
+            Self::Expired => "expired",
+        }
+    }
+
+    /// Parses a status read back from the store. Errors on any value outside the known set,
+    /// which the CHECK constraint should make unreachable in practice.
+    fn from_db(s: &str) -> anyhow::Result<Self> {
+        Ok(match s {
+            "queued" => Self::Queued,
+            "processing" => Self::Processing,
+            "ready" => Self::Ready,
+            "failed" => Self::Failed,
+            "expired" => Self::Expired,
+            other => anyhow::bail!("unknown task status in store: {other}"),
+        })
+    }
+}
+
+/// A persisted task: the request that created it, its current lifecycle state, and the outputs
+/// produced as it settles.
+#[derive(Debug, Clone)]
+pub struct Task {
+    /// UUID v4 identifying the task globally.
+    pub id: String,
+    /// Id of the API key that submitted the task; scopes ownership and listing.
+    pub key_id: String,
+    pub status: TaskStatus,
+    /// The original request, preserved so the task can be rebuilt and re-enqueued on restart.
+    pub request: GasKillerTaskRequestBody,
+    /// Executable payload, populated once the task is [`TaskStatus::Ready`].
+    pub payload: Option<String>,
+    /// Human-readable failure reason, populated once the task is `failed` or `expired`.
+    pub error: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Raw column values as read from SQLite, before Ethereum types are parsed back out of their
+/// text encodings. Kept private; callers only ever see [`Task`].
+#[derive(FromRow)]
+struct TaskRow {
+    id: String,
+    key_id: String,
+    status: String,
+    target_address: String,
+    call_data: Vec<u8>,
+    transition_index: Option<i64>,
+    from_address: String,
+    value: String,
+    block_height: i64,
+    payload: Option<String>,
+    error: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+impl TryFrom<TaskRow> for Task {
+    type Error = anyhow::Error;
+
+    fn try_from(row: TaskRow) -> anyhow::Result<Self> {
+        let request = GasKillerTaskRequestBody {
+            target_address: Address::from_str(&row.target_address)
+                .with_context(|| format!("parsing target_address for task {}", row.id))?,
+            call_data: row.call_data,
+            transition_index: row.transition_index.map(|i| i as u64),
+            from_address: Address::from_str(&row.from_address)
+                .with_context(|| format!("parsing from_address for task {}", row.id))?,
+            value: U256::from_str(&row.value)
+                .with_context(|| format!("parsing value for task {}", row.id))?,
+            block_height: row.block_height as u64,
+        };
+
+        Ok(Task {
+            status: TaskStatus::from_db(&row.status)
+                .with_context(|| format!("reading status for task {}", row.id))?,
+            id: row.id,
+            key_id: row.key_id,
+            request,
+            payload: row.payload,
+            error: row.error,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+impl SqliteStore {
+    /// Persists a new task in the [`TaskStatus::Queued`] state for the given API key, assigning
+    /// it a fresh UUID v4. The full request is stored so the task can be re-enqueued on restart.
+    /// Returns the created [`Task`], including the store-assigned timestamps.
+    ///
+    /// Fails if `key_id` does not reference an existing key (enforced by the foreign key).
+    pub async fn create_task(
+        &self,
+        key_id: &str,
+        request: &GasKillerTaskRequestBody,
+    ) -> anyhow::Result<Task> {
+        let id = Uuid::new_v4().to_string();
+
+        let (created_at, updated_at): (i64, i64) = sqlx::query_as(
+            "INSERT INTO tasks \
+             (id, key_id, status, target_address, call_data, transition_index, from_address, \
+              value, block_height) \
+             VALUES (?1, ?2, 'queued', ?3, ?4, ?5, ?6, ?7, ?8) \
+             RETURNING created_at, updated_at",
+        )
+        .bind(&id)
+        .bind(key_id)
+        .bind(request.target_address.to_string())
+        .bind(request.call_data.as_slice())
+        .bind(request.transition_index.map(|i| i as i64))
+        .bind(request.from_address.to_string())
+        .bind(request.value.to_string())
+        .bind(request.block_height as i64)
+        .fetch_one(self.pool())
+        .await
+        .context("inserting task")?;
+
+        Ok(Task {
+            id,
+            key_id: key_id.to_string(),
+            status: TaskStatus::Queued,
+            request: request.clone(),
+            payload: None,
+            error: None,
+            created_at,
+            updated_at,
+        })
+    }
+
+    /// Fetches a task by id, or `None` if no such task exists. The returned task carries its
+    /// `key_id`, which callers compare against the requesting key to enforce ownership.
+    pub async fn get_task(&self, id: &str) -> anyhow::Result<Option<Task>> {
+        let row: Option<TaskRow> =
+            sqlx::query_as(&format!("SELECT {TASK_COLUMNS} FROM tasks WHERE id = ?1"))
+                .bind(id)
+                .fetch_optional(self.pool())
+                .await
+                .context("fetching task")?;
+
+        row.map(Task::try_from).transpose()
+    }
+
+    /// Lists a single API key's tasks, newest first, optionally filtered to one status. `limit`
+    /// caps the page size and `offset` skips earlier rows, together paginating the listing.
+    pub async fn list_tasks_for_key(
+        &self,
+        key_id: &str,
+        status: Option<TaskStatus>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<Task>> {
+        let rows: Vec<TaskRow> = sqlx::query_as(&format!(
+            "SELECT {TASK_COLUMNS} FROM tasks \
+             WHERE key_id = ?1 AND (?2 IS NULL OR status = ?2) \
+             ORDER BY created_at DESC, id \
+             LIMIT ?3 OFFSET ?4",
+        ))
+        .bind(key_id)
+        .bind(status.map(TaskStatus::as_str))
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool())
+        .await
+        .context("listing tasks")?;
+
+        rows.into_iter().map(Task::try_from).collect()
+    }
+
+    /// Transitions a task to `status` and stamps `updated_at`. Sets only the status column, so
+    /// it suits state-only moves such as `queued → processing`; use [`Self::mark_task_ready`] or
+    /// [`Self::mark_task_failed`] when a payload or error must be recorded too. Returns `true`
+    /// if a task with that id existed.
+    pub async fn update_task_status(&self, id: &str, status: TaskStatus) -> anyhow::Result<bool> {
+        let result =
+            sqlx::query("UPDATE tasks SET status = ?2, updated_at = unixepoch() WHERE id = ?1")
+                .bind(id)
+                .bind(status.as_str())
+                .execute(self.pool())
+                .await
+                .context("updating task status")?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Settles a task as [`TaskStatus::Ready`], recording its executable payload and stamping
+    /// `updated_at`. Returns `true` if a task with that id existed.
+    pub async fn mark_task_ready(&self, id: &str, payload: &str) -> anyhow::Result<bool> {
+        let result = sqlx::query(
+            "UPDATE tasks SET status = 'ready', payload = ?2, updated_at = unixepoch() \
+             WHERE id = ?1",
+        )
+        .bind(id)
+        .bind(payload)
+        .execute(self.pool())
+        .await
+        .context("marking task ready")?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Settles a task as [`TaskStatus::Failed`], recording the failure reason and stamping
+    /// `updated_at`. Returns `true` if a task with that id existed.
+    pub async fn mark_task_failed(&self, id: &str, error: &str) -> anyhow::Result<bool> {
+        let result = sqlx::query(
+            "UPDATE tasks SET status = 'failed', error = ?2, updated_at = unixepoch() \
+             WHERE id = ?1",
+        )
+        .bind(id)
+        .bind(error)
+        .execute(self.pool())
+        .await
+        .context("marking task failed")?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Returns every task still in flight — `queued` or `processing` — oldest first. The router
+    /// calls this on startup to rebuild and re-enqueue work interrupted by a restart.
+    pub async fn incomplete_tasks(&self) -> anyhow::Result<Vec<Task>> {
+        let rows: Vec<TaskRow> = sqlx::query_as(&format!(
+            "SELECT {TASK_COLUMNS} FROM tasks \
+             WHERE status IN ('queued', 'processing') ORDER BY created_at, id",
+        ))
+        .fetch_all(self.pool())
+        .await
+        .context("loading incomplete tasks")?;
+
+        rows.into_iter().map(Task::try_from).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn store() -> SqliteStore {
+        SqliteStore::connect_in_memory()
+            .await
+            .expect("in-memory store should open and migrate")
+    }
+
+    /// Creates an API key and returns its id, satisfying the tasks table's foreign key.
+    async fn key_id(store: &SqliteStore) -> String {
+        store
+            .create_api_key(None, None)
+            .await
+            .expect("key creation should succeed")
+            .id
+    }
+
+    fn request() -> GasKillerTaskRequestBody {
+        GasKillerTaskRequestBody {
+            target_address: Address::from([0x11; 20]),
+            call_data: vec![0x12, 0x34, 0x56, 0x78, 0xab],
+            transition_index: Some(7),
+            from_address: Address::from([0x22; 20]),
+            value: U256::from(1_000_000u64),
+            block_height: 21_000_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn created_task_is_queued_with_uuid_and_timestamps() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let task = store
+            .create_task(&key, &request())
+            .await
+            .expect("task creation should succeed");
+
+        assert_eq!(task.status, TaskStatus::Queued);
+        assert_eq!(task.key_id, key);
+        assert!(task.payload.is_none());
+        assert!(task.error.is_none());
+        assert!(task.created_at > 0);
+        assert!(task.updated_at >= task.created_at);
+
+        let parsed = Uuid::parse_str(&task.id).expect("id should be a UUID");
+        assert_eq!(parsed.get_version_num(), 4, "task ids must be UUID v4");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_unknown_key() {
+        let store = store().await;
+        let result = store.create_task("no-such-key", &request()).await;
+        assert!(
+            result.is_err(),
+            "the foreign key should reject a task for a key that does not exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_round_trips_request_fields() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let created = store.create_task(&key, &request()).await.unwrap();
+
+        let fetched = store
+            .get_task(&created.id)
+            .await
+            .unwrap()
+            .expect("created task should be fetchable");
+
+        let req = request();
+        assert_eq!(fetched.request.target_address, req.target_address);
+        assert_eq!(fetched.request.from_address, req.from_address);
+        assert_eq!(fetched.request.call_data, req.call_data);
+        assert_eq!(fetched.request.transition_index, req.transition_index);
+        assert_eq!(fetched.request.value, req.value);
+        assert_eq!(fetched.request.block_height, req.block_height);
+    }
+
+    #[tokio::test]
+    async fn auto_transition_index_round_trips_as_none() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let mut req = request();
+        req.transition_index = None;
+
+        let created = store.create_task(&key, &req).await.unwrap();
+        let fetched = store.get_task(&created.id).await.unwrap().unwrap();
+        assert_eq!(fetched.request.transition_index, None);
+    }
+
+    #[tokio::test]
+    async fn get_unknown_task_is_none() {
+        let store = store().await;
+        assert!(store.get_task("does-not-exist").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_is_scoped_to_key_and_newest_first() {
+        let store = store().await;
+        let key_a = key_id(&store).await;
+        let key_b = key_id(&store).await;
+
+        store.create_task(&key_a, &request()).await.unwrap();
+        store.create_task(&key_a, &request()).await.unwrap();
+        store.create_task(&key_b, &request()).await.unwrap();
+
+        let listed = store
+            .list_tasks_for_key(&key_a, None, 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 2, "listing must be scoped to the key");
+        assert!(listed.iter().all(|t| t.key_id == key_a));
+        // created_at is non-increasing down the list (ties broken by id).
+        assert!(
+            listed
+                .windows(2)
+                .all(|w| w[0].created_at >= w[1].created_at),
+            "tasks must be ordered newest first"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_status() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let ready = store.create_task(&key, &request()).await.unwrap();
+        store.create_task(&key, &request()).await.unwrap();
+
+        store
+            .mark_task_ready(&ready.id, "0xdeadbeef")
+            .await
+            .unwrap();
+
+        let ready_only = store
+            .list_tasks_for_key(&key, Some(TaskStatus::Ready), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(ready_only.len(), 1);
+        assert_eq!(ready_only[0].id, ready.id);
+
+        let queued_only = store
+            .list_tasks_for_key(&key, Some(TaskStatus::Queued), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(queued_only.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_paginates_with_limit_and_offset() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        for _ in 0..3 {
+            store.create_task(&key, &request()).await.unwrap();
+        }
+
+        let first_page = store.list_tasks_for_key(&key, None, 2, 0).await.unwrap();
+        assert_eq!(first_page.len(), 2);
+
+        let second_page = store.list_tasks_for_key(&key, None, 2, 2).await.unwrap();
+        assert_eq!(second_page.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn update_status_transitions_and_reports_existence() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request()).await.unwrap();
+
+        assert!(
+            store
+                .update_task_status(&task.id, TaskStatus::Processing)
+                .await
+                .unwrap()
+        );
+        let fetched = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, TaskStatus::Processing);
+        assert!(fetched.updated_at >= task.updated_at);
+
+        assert!(
+            !store
+                .update_task_status("does-not-exist", TaskStatus::Processing)
+                .await
+                .unwrap(),
+            "updating an unknown task should report no change"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_ready_records_payload() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request()).await.unwrap();
+
+        assert!(store.mark_task_ready(&task.id, "0xcafe").await.unwrap());
+        let fetched = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, TaskStatus::Ready);
+        assert_eq!(fetched.payload.as_deref(), Some("0xcafe"));
+        assert!(fetched.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_failed_records_error() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request()).await.unwrap();
+
+        assert!(
+            store
+                .mark_task_failed(&task.id, "aggregation timed out")
+                .await
+                .unwrap()
+        );
+        let fetched = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, TaskStatus::Failed);
+        assert_eq!(fetched.error.as_deref(), Some("aggregation timed out"));
+        assert!(fetched.payload.is_none());
+    }
+
+    #[tokio::test]
+    async fn incomplete_tasks_returns_only_in_flight() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let queued = store.create_task(&key, &request()).await.unwrap();
+        let processing = store.create_task(&key, &request()).await.unwrap();
+        let ready = store.create_task(&key, &request()).await.unwrap();
+        let failed = store.create_task(&key, &request()).await.unwrap();
+
+        store
+            .update_task_status(&processing.id, TaskStatus::Processing)
+            .await
+            .unwrap();
+        store.mark_task_ready(&ready.id, "0x00").await.unwrap();
+        store.mark_task_failed(&failed.id, "nope").await.unwrap();
+
+        let incomplete = store.incomplete_tasks().await.unwrap();
+        let ids: Vec<&str> = incomplete.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(
+            incomplete.len(),
+            2,
+            "only queued and processing are in flight"
+        );
+        assert!(ids.contains(&queued.id.as_str()));
+        assert!(ids.contains(&processing.id.as_str()));
+    }
+
+    #[test]
+    fn status_round_trips_through_db_encoding() {
+        for status in [
+            TaskStatus::Queued,
+            TaskStatus::Processing,
+            TaskStatus::Ready,
+            TaskStatus::Failed,
+            TaskStatus::Expired,
+        ] {
+            assert_eq!(TaskStatus::from_db(status.as_str()).unwrap(), status);
+        }
+        assert!(TaskStatus::from_db("bogus").is_err());
+    }
+
+    #[test]
+    fn status_serializes_snake_case() {
+        let json = serde_json::to_string(&TaskStatus::Processing).unwrap();
+        assert_eq!(json, r#""processing""#);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the persistent task model — the SQLite schema, the `Task` record, and the store CRUD — as the foundation of the async task lifecycle. This is the data-layer slice of the persistent task store (gas-killer/service#192) and the precursor to the endpoint work: `POST /tasks` (gas-killer/service#193) and the status/polling endpoints (gas-killer/service#194), which will consume these store methods.

Part of the Service v1 Beta epic (gas-killer/roadmap#15).

## What's included

- **Migration `0002_tasks.sql`** — a `tasks` table keyed by UUID, foreign-keyed to `api_keys(id)`, with a `status` CHECK constraint (`queued | processing | ready | failed | expired`), the full submitted request (target/from addresses, call data, transition index, value, block height), `payload`/`error` outputs, and `created_at`/`updated_at`. Indexes cover the per-key listing and the startup re-queue scan.
- **`store/tasks.rs`** — `TaskStatus` enum, `Task` record, and store methods: `create_task`, `get_task`, `list_tasks_for_key` (scoped, status-filtered, paginated), `update_task_status`, `mark_task_ready`, `mark_task_failed`, and `incomplete_tasks` (for restart re-queue). The full request is persisted so a task can be rebuilt and re-enqueued after a pod restart.

## Scope

Data layer only — the store methods are not wired to any endpoint in this PR. They are re-exported from the crate root and covered by tests so they compile clean under `-D warnings` ahead of the endpoint PRs. Durability guarantees (write-before-ack, startup re-queue wiring) and the Helm PVC mount from #192 are intentionally left to follow-on work once the endpoints exist.

## Testing

- 14 new unit tests for the task store (creation, FK enforcement, request round-trip, ownership-scoped listing, status filter, pagination, status transitions, restart re-queue query, status encoding).
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), and `cargo test --all-targets --all-features` all pass.
