### PR TITLE
feat: add `POST /tasks` async submission returning task IDs

### DIFF
--- a/helm/gas-killer/templates/ingress.yaml
+++ b/helm/gas-killer/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
             routed here and stays reachable only in-cluster. Falls back to the router's public
             routes if publicPaths is unset, never to a catch-all "/".
           */}}
-          {{- range .Values.ingress.publicPaths | default (list "/trigger" "/avs-metadata" "/healthz") }}
+          {{- range .Values.ingress.publicPaths | default (list "/tasks" "/trigger" "/avs-metadata" "/healthz") }}
           - path: {{ . | quote }}
             pathType: Prefix
             backend:

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -670,6 +670,8 @@ ingress:
   # This keeps admin behind cluster access in addition to ADMIN_KEY. Add a path here only if it
   # genuinely needs to be internet-facing.
   publicPaths:
+    - /tasks
+    # Deprecated alias of /tasks, kept until clients migrate.
     - /trigger
     - /avs-metadata
     - /healthz

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,7 +1,7 @@
 use crate::creator::{TaskQueueDepth, TaskSender};
 use crate::error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ErrorCode};
 use crate::metrics::MetricsCollector;
-use crate::store::{ApiKeyMetadata, CreatedApiKey, SqliteStore};
+use crate::store::{ApiKeyMetadata, CreatedApiKey, SqliteStore, TaskStatus};
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use axum::{
@@ -161,14 +161,19 @@ fn check_bearer_auth(headers: &HeaderMap, expected: &str) -> bool {
         .is_some_and(|token| constant_time_eq(token.as_bytes(), expected.as_bytes()))
 }
 
-/// Authorizes a task-submission request. When a durable store is configured — always the case
-/// in production — a valid, unrevoked API key is required. With no store, the request is rejected
-/// unless `allow_unauthenticated` is set (the test/dev bare constructor), so a missing store
-/// fails closed rather than silently opening the endpoint.
-async fn authorize_task_request(state: &IngressState, headers: &HeaderMap) -> Result<(), ApiError> {
+/// Authorizes a task-submission request, returning the authenticated key's id when a store is
+/// configured. When a durable store is present — always the case in production — a valid,
+/// unrevoked API key is required and its id is returned so the submitted task can be scoped to
+/// its owner. With no store, the request is rejected unless `allow_unauthenticated` is set (the
+/// test/dev bare constructor), which yields `None`; a missing store fails closed rather than
+/// silently opening the endpoint.
+async fn authorize_task_request(
+    state: &IngressState,
+    headers: &HeaderMap,
+) -> Result<Option<String>, ApiError> {
     let Some(store) = &state.store else {
         return if state.allow_unauthenticated {
-            Ok(())
+            Ok(None)
         } else {
             Err(ApiError::unauthorized())
         };
@@ -176,7 +181,7 @@ async fn authorize_task_request(state: &IngressState, headers: &HeaderMap) -> Re
 
     if let Some(token) = bearer_token(headers) {
         match store.verify_api_key(token).await {
-            Ok(Some(_)) => return Ok(()),
+            Ok(Some(id)) => return Ok(Some(id)),
             Ok(None) => {}
             Err(e) => {
                 tracing::error!(error = %e, "api key verification failed");
@@ -540,19 +545,27 @@ impl GasKillerTaskRequest {
     }
 }
 
+/// Body returned by `POST /tasks` (and its deprecated alias `POST /trigger`) when a task is
+/// accepted: the id the client polls for status, and the task's initial state.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct GasKillerTaskResponse {
-    pub success: bool,
-    pub message: String,
+pub struct TaskAcceptedResponse {
+    pub task_id: String,
+    pub status: TaskStatus,
 }
 
-// Handler for POST /trigger
-pub async fn trigger_task_handler(
+/// Handler for `POST /tasks`, and its deprecated alias `POST /trigger`.
+///
+/// Validates the request, persists it as a `queued` task before responding — so a restart can
+/// recover work already acknowledged to the client — then enqueues it for aggregation and returns
+/// the task id for status polling. Persistence requires a configured store and an authenticated
+/// key that owns the task; validation and load-shedding stay synchronous and run first, so a
+/// malformed or at-capacity request is rejected before any task row is written.
+pub async fn submit_task_handler(
     State(state): State<IngressState>,
     headers: HeaderMap,
     ApiJson(request): ApiJson<GasKillerTaskRequest>,
-) -> Result<(StatusCode, Json<GasKillerTaskResponse>), ApiError> {
-    authorize_task_request(&state, &headers).await?;
+) -> Result<(StatusCode, Json<TaskAcceptedResponse>), ApiError> {
+    let key_id = authorize_task_request(&state, &headers).await?;
 
     // Load-shed before any validation work. Onchain validation costs multiple RPC
     // round-trips, so rejecting at-capacity requests up front keeps an overloaded
@@ -604,7 +617,22 @@ pub async fn trigger_task_handler(
         return Err(e.into());
     }
 
+    // Persistence is required to hand back a task id and to survive restarts. A configured store
+    // always authenticates (see `authorize_task_request`), so `key_id` is `Some` here; an absent
+    // id is treated as unauthorized rather than unwrapped.
+    let store = require_store(&state)?;
+    let key_id = key_id.ok_or_else(ApiError::unauthorized)?;
+
+    let task = store
+        .create_task(&key_id, &request.body)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to persist task");
+            ApiError::internal("Internal error: failed to persist task")
+        })?;
+
     info!(
+        task_id = %task.id,
         target_address = %request.body.target_address,
         from_address = %request.body.from_address,
         block_height = request.body.block_height,
@@ -614,7 +642,7 @@ pub async fn trigger_task_handler(
     let depth = state.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
     if state.sender.send(request).is_err() {
         state.queue_depth.fetch_sub(1, Ordering::Relaxed);
-        tracing::error!("task channel closed, dropping request");
+        tracing::error!(task_id = %task.id, "task channel closed, dropping request");
         return Err(ApiError::internal("Internal error: task queue unavailable"));
     }
     if let Some(m) = &state.metrics {
@@ -622,10 +650,10 @@ pub async fn trigger_task_handler(
         m.task_queue_depth.set(depth as i64);
     }
     Ok((
-        StatusCode::OK,
-        Json(GasKillerTaskResponse {
-            success: true,
-            message: "Task queued".to_string(),
+        StatusCode::ACCEPTED,
+        Json(TaskAcceptedResponse {
+            task_id: task.id,
+            status: task.status,
         }),
     ))
 }
@@ -790,7 +818,9 @@ pub fn build_app() -> Router<IngressState> {
     Router::new()
         .route("/healthz", get(healthz_handler))
         .route("/avs-metadata", get(avs_metadata_handler))
-        .route("/trigger", post(trigger_task_handler))
+        .route("/tasks", post(submit_task_handler))
+        // Deprecated alias for `/tasks`, kept to ease client migration; identical behavior.
+        .route("/trigger", post(submit_task_handler))
         .route(
             "/admin/keys",
             post(create_api_key_handler).get(list_api_keys_handler),
@@ -974,7 +1004,7 @@ mod tests {
 
     // -- HTTP handler integration tests --
     //
-    // These tests call trigger_task_handler through the real Axum router using
+    // These tests call submit_task_handler through the real Axum router using
     // tower::ServiceExt::oneshot, so they exercise JSON extraction, status codes,
     // and queue interaction end-to-end without binding a port.
 
@@ -1027,9 +1057,15 @@ mod tests {
         }
 
         fn bearer_request(body: &str, token: &str) -> Request<Body> {
+            bearer_request_to("/trigger", body, token)
+        }
+
+        /// A POST to an arbitrary submission URI with a Bearer token, so tests can exercise both
+        /// `/tasks` and its `/trigger` alias through the same helper.
+        fn bearer_request_to(uri: &str, body: &str, token: &str) -> Request<Body> {
             Request::builder()
                 .method(Method::POST)
-                .uri("/trigger")
+                .uri(uri)
                 .header("content-type", "application/json")
                 .header("Authorization", format!("Bearer {token}"))
                 .body(Body::from(body.to_string()))
@@ -1059,11 +1095,11 @@ mod tests {
             .to_string()
         }
 
-        async fn response_body(resp: axum::response::Response) -> GasKillerTaskResponse {
+        async fn accepted_body(resp: axum::response::Response) -> TaskAcceptedResponse {
             let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
                 .await
                 .unwrap();
-            serde_json::from_slice(&bytes).unwrap()
+            serde_json::from_slice(&bytes).expect("accepted response should deserialize")
         }
 
         async fn error_envelope(resp: axum::response::Response) -> crate::error::ApiErrorEnvelope {
@@ -1088,18 +1124,33 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_valid_request_returns_200_and_queues_task() {
-            let (app, mut receiver) = make_app();
-            let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
+        async fn test_valid_request_returns_202_and_queues_task() {
+            let (app, store, mut receiver) = make_app_with_store(None).await;
+            let created = store.create_api_key(None, None).await.unwrap();
 
-            assert_eq!(resp.status(), StatusCode::OK);
-            let body = response_body(resp).await;
-            assert!(body.success);
-            assert_eq!(body.message, "Task queued");
+            let resp = app
+                .oneshot(bearer_request(&valid_body(), &created.key))
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::ACCEPTED);
+            let body = accepted_body(resp).await;
+            assert_eq!(body.status, TaskStatus::Queued);
+            let id = uuid::Uuid::parse_str(&body.task_id).expect("task_id should be a UUID");
+            assert_eq!(id.get_version_num(), 4, "task ids must be UUID v4");
             assert!(
                 receiver.try_recv().is_ok(),
                 "task should have been pushed to queue"
             );
+
+            // The task is persisted before the response, scoped to the submitting key.
+            let persisted = store
+                .get_task(&body.task_id)
+                .await
+                .unwrap()
+                .expect("accepted task should be persisted");
+            assert_eq!(persisted.key_id, created.id);
+            assert_eq!(persisted.status, TaskStatus::Queued);
         }
 
         #[tokio::test]
@@ -1397,20 +1448,17 @@ mod tests {
 
         #[tokio::test]
         async fn test_valid_request_does_not_leave_extra_tasks() {
-            // Two sequential valid requests → queue should hold exactly two tasks
-            let (sender, mut receiver) = crate::creator::task_channel();
-            let queue_depth = crate::creator::task_queue_depth();
-            let app1 = build_app().with_state(IngressState::without_metrics(
-                sender.clone(),
-                queue_depth.clone(),
-            ));
-            let app2 = build_app().with_state(IngressState::without_metrics(
-                sender.clone(),
-                queue_depth.clone(),
-            ));
+            // Two sequential valid requests → queue should hold exactly two tasks.
+            let (app, store, mut receiver) = make_app_with_store(None).await;
+            let created = store.create_api_key(None, None).await.unwrap();
 
-            app1.oneshot(json_request(&valid_body())).await.unwrap();
-            app2.oneshot(json_request(&valid_body())).await.unwrap();
+            app.clone()
+                .oneshot(bearer_request(&valid_body(), &created.key))
+                .await
+                .unwrap();
+            app.oneshot(bearer_request(&valid_body(), &created.key))
+                .await
+                .unwrap();
 
             assert!(receiver.try_recv().is_ok());
             assert!(receiver.try_recv().is_ok());
@@ -1427,12 +1475,15 @@ mod tests {
         // the always-open utility endpoints.
 
         #[tokio::test]
-        async fn test_no_store_configured_accepts_unauthenticated() {
-            // The bare test/dev constructor opts into unauthenticated access, so a store-less
-            // harness can exercise /trigger.
+        async fn test_submission_without_store_returns_503() {
+            // Submission now persists before responding, so it requires a store even on the
+            // unauthenticated dev path: a valid request that clears validation is rejected as
+            // not-configured rather than silently accepted and dropped.
             let (app, _queue) = make_app();
             let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
-            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::NotConfigured);
         }
 
         #[tokio::test]
@@ -1692,8 +1743,45 @@ mod tests {
                 .oneshot(bearer_request(&valid_body(), &created.key))
                 .await
                 .unwrap();
-            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(resp.status(), StatusCode::ACCEPTED);
+            let body = accepted_body(resp).await;
+            assert_eq!(body.status, TaskStatus::Queued);
             assert!(rx.try_recv().is_ok(), "valid key should queue the task");
+        }
+
+        #[tokio::test]
+        async fn tasks_endpoint_accepts_valid_api_key_and_persists() {
+            let (app, store, mut rx) = make_app_with_store(None).await;
+            let created = store.create_api_key(None, None).await.unwrap();
+
+            let resp = app
+                .oneshot(bearer_request_to("/tasks", &valid_body(), &created.key))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::ACCEPTED);
+            let body = accepted_body(resp).await;
+            assert_eq!(body.status, TaskStatus::Queued);
+            assert!(rx.try_recv().is_ok(), "valid key should queue the task");
+
+            let persisted = store
+                .get_task(&body.task_id)
+                .await
+                .unwrap()
+                .expect("accepted task should be persisted");
+            assert_eq!(persisted.key_id, created.id);
+        }
+
+        #[tokio::test]
+        async fn tasks_endpoint_rejects_missing_token_when_store_present() {
+            let (app, _store, _rx) = make_app_with_store(None).await;
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(valid_body()))
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         }
 
         #[tokio::test]
@@ -1765,13 +1853,21 @@ mod tests {
         async fn test_queue_one_below_limit_still_accepts() {
             let (sender, _receiver) = crate::creator::task_channel();
             let queue_depth = crate::creator::task_queue_depth();
-            let mut state = IngressState::without_metrics(sender, queue_depth.clone());
+            let store = SqliteStore::connect_in_memory()
+                .await
+                .expect("in-memory store should open");
+            let created = store.create_api_key(None, None).await.unwrap();
+            let mut state =
+                IngressState::without_metrics(sender, queue_depth.clone()).with_store(store);
             state.max_queue_depth = 2;
             queue_depth.store(1, std::sync::atomic::Ordering::Relaxed);
             let app = build_app().with_state(state);
 
-            let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
-            assert_eq!(resp.status(), StatusCode::OK);
+            let resp = app
+                .oneshot(bearer_request(&valid_body(), &created.key))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::ACCEPTED);
         }
 
         #[tokio::test]

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -223,7 +223,7 @@ echo -e "${YELLOW}Step 9: Waiting briefly for services to stabilize...${NC}"
 sleep 5
 
 # Step 9b: Mint an API key so task submission is authenticated. The router requires a valid,
-# unrevoked key on /trigger; mint one via the admin API (guarded by ADMIN_KEY) and hand it to
+# unrevoked key on /tasks; mint one via the admin API (guarded by ADMIN_KEY) and hand it to
 # send_request through GAS_KILLER_API_KEY.
 echo -e "${YELLOW}Step 9b: Minting an API key via the admin endpoint...${NC}"
 CREATE_RESP=$(curl -s -X POST \

--- a/scripts/run_helm_test.sh
+++ b/scripts/run_helm_test.sh
@@ -38,7 +38,7 @@ NODE_COUNT="${NODE_COUNT:-3}"
 FORK_URL="${FORK_URL:-https://ethereum-sepolia-rpc.publicnode.com}"
 PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
 FUNDED_KEY="${FUNDED_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-# Guards the /admin/keys endpoints used to mint the API keys that authenticate /trigger. A fixed
+# Guards the /admin/keys endpoints used to mint the API keys that authenticate /tasks. A fixed
 # dev value for the local harness; override by exporting ADMIN_KEY.
 ADMIN_KEY="${ADMIN_KEY:-ci-admin-key}"
 SKIP_BUILD="${SKIP_BUILD:-false}"
@@ -288,7 +288,7 @@ echo -e "${GREEN}ArraySummation deployment completed${NC}"
 echo -e "${YELLOW}Step 12: Triggering Gas Killer task...${NC}"
 
 # Mint an API key so task submission is authenticated. The router requires a valid, unrevoked
-# key on /trigger; mint one via the admin API (guarded by ADMIN_KEY) and hand it to send_request
+# key on /tasks; mint one via the admin API (guarded by ADMIN_KEY) and hand it to send_request
 # through GAS_KILLER_API_KEY.
 CREATE_RESP=$(curl -s -X POST \
     -H "Authorization: Bearer $ADMIN_KEY" \

--- a/scripts/run_scenario.rs
+++ b/scripts/run_scenario.rs
@@ -19,7 +19,7 @@ struct Config {
     router_url: String,
     /// Required when any request uses `block_height = 0` or `verify = true`.
     http_rpc: Option<String>,
-    /// API key sent as `Authorization: Bearer <key>` on every `/trigger` request. Mint one with
+    /// API key sent as `Authorization: Bearer <key>` on every `/tasks` request. Mint one with
     /// the `create_api_key` tool. Falls back to the `GAS_KILLER_API_KEY` environment variable
     /// when unset; leave empty for a router that does not require auth.
     api_key: Option<String>,
@@ -118,7 +118,7 @@ struct RequestConfig {
     /// Set to 0 to auto-fetch the current block from `http_rpc`.
     #[serde(default)]
     block_height: u64,
-    /// When true, poll stateTransitionCount() after a 200 to confirm verifyAndUpdate ran.
+    /// When true, poll stateTransitionCount() after a 202 to confirm verifyAndUpdate ran.
     #[serde(default)]
     verify: bool,
     /// How long to wait for on-chain confirmation (seconds, default: 150).
@@ -152,10 +152,11 @@ struct ApiRequest {
     body: ApiRequestBody,
 }
 
+/// Body returned by `POST /tasks` when a task is accepted for aggregation.
 #[derive(Debug, Deserialize)]
-struct ApiResponse {
-    success: bool,
-    message: String,
+struct AcceptedResponse {
+    task_id: String,
+    status: String,
 }
 
 // ── Result types ──────────────────────────────────────────────────────────────
@@ -177,7 +178,7 @@ struct RequestResult {
 
 impl RequestResult {
     fn passed(&self) -> bool {
-        if !self.api_success || self.status != 200 {
+        if !self.api_success || self.status != 202 {
             return false;
         }
         match &self.on_chain {
@@ -333,7 +334,7 @@ async fn send_request(
         },
     };
 
-    let url = format!("{}/trigger", router_url.trim_end_matches('/'));
+    let url = format!("{}/tasks", router_url.trim_end_matches('/'));
     let start = Instant::now();
     let mut req = client.post(&url).json(&payload);
     if let Some(key) = api_key
@@ -344,30 +345,48 @@ async fn send_request(
     let resp = req.send().await;
     let elapsed = start.elapsed();
 
+    // The router acknowledges an accepted submission with `202 Accepted` and a
+    // `{ task_id, status }` body; any other status carries an error envelope, surfaced verbatim
+    // in the report.
     let (status, api_success, message) = match resp {
         Err(e) => (0u16, false, format!("connection error: {e}")),
         Ok(r) => {
             let status = r.status().as_u16();
             match r.text().await {
-                Ok(body_text) => match serde_json::from_str::<ApiResponse>(&body_text) {
-                    Ok(body) => (status, body.success, body.message),
-                    Err(e) => {
-                        let trimmed = body_text.trim();
-                        let msg = if trimmed.is_empty() {
-                            format!("non-ApiResponse body (HTTP {status}); parse error: {e}")
-                        } else {
-                            format!("{trimmed} (non-ApiResponse: {e})")
-                        };
-                        (status, false, msg)
+                Ok(body_text) if status == 202 => {
+                    match serde_json::from_str::<AcceptedResponse>(&body_text) {
+                        Ok(body) => (
+                            status,
+                            true,
+                            format!("{} (task {})", body.status, body.task_id),
+                        ),
+                        Err(e) => {
+                            let trimmed = body_text.trim();
+                            let msg = if trimmed.is_empty() {
+                                format!("202 with empty body; parse error: {e}")
+                            } else {
+                                format!("{trimmed} (unparseable 202: {e})")
+                            };
+                            (status, false, msg)
+                        }
                     }
-                },
+                }
+                Ok(body_text) => {
+                    let trimmed = body_text.trim();
+                    let msg = if trimmed.is_empty() {
+                        format!("HTTP {status} with empty body")
+                    } else {
+                        trimmed.to_string()
+                    };
+                    (status, false, msg)
+                }
                 Err(e) => (status, false, format!("failed to read response body: {e}")),
             }
         }
     };
 
     // Verify on-chain only if the API accepted the request
-    let on_chain = if cfg.verify && api_success && status == 200 {
+    let on_chain = if cfg.verify && api_success && status == 202 {
         if let (Some(p), Some(count), Ok(addr)) = (
             provider,
             on_chain_count,

--- a/scripts/scenarios/example.toml
+++ b/scripts/scenarios/example.toml
@@ -5,7 +5,7 @@
 
 router_url           = "http://localhost:8080"
 http_rpc             = "$HTTP_RPC"  # env var interpolation supported; required when block_height = 0, verify = true, or transition_index = "auto"
-# API key sent as `Authorization: Bearer <key>` on every /trigger request. Mint one with the
+# API key sent as `Authorization: Bearer <key>` on every /tasks request. Mint one with the
 # create_api_key tool. Reads the GAS_KILLER_API_KEY env var (like http_rpc above); replace with a
 # literal "gk_..." key to override, or "" to leave requests unauthenticated.
 api_key              = "$GAS_KILLER_API_KEY"

--- a/scripts/scenarios/latency_profile.toml
+++ b/scripts/scenarios/latency_profile.toml
@@ -9,7 +9,7 @@
 #
 # Requires:
 #   GNOSIS_RPC_URL    — Gnosis chain HTTP RPC endpoint
-#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /trigger (if the server requires auth)
+#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /tasks (if the server requires auth)
 #
 # After running, pull metrics from Grafana:
 #   - gas_killer_p2p_round_trip_seconds        (router)
@@ -23,7 +23,7 @@
 
 router_url           = "https://testnet.gaskiller.xyz"
 http_rpc             = "$GNOSIS_RPC_URL"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 120
 
 # ── 1. Baseline — single serial requests with 5 s breathing room between them ─

--- a/scripts/scenarios/local_profile.toml
+++ b/scripts/scenarios/local_profile.toml
@@ -1,6 +1,6 @@
 router_url           = "http://localhost:8080"
 http_rpc             = "http://localhost:8545"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 120
 
 [[scenarios]]

--- a/scripts/scenarios/testnet_load.toml
+++ b/scripts/scenarios/testnet_load.toml
@@ -5,7 +5,7 @@
 #
 # Requires:
 #   HTTP_RPC          — HTTP RPC endpoint
-#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /trigger (if the server requires auth)
+#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /tasks (if the server requires auth)
 #
 # Structure:
 #   1. smoke   — single serial request with on-chain verification; confirms the
@@ -16,7 +16,7 @@
 
 router_url           = "https://testnet.gaskiller.xyz"
 http_rpc             = "$HTTP_RPC"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 60
 
 # ── Burst test with 10 concurrent requests ──────────────────────────────────

--- a/scripts/scenarios/testnet_parallel_smoke.toml
+++ b/scripts/scenarios/testnet_parallel_smoke.toml
@@ -9,11 +9,11 @@
 #
 # Requires:
 #   HTTP_RPC          — HTTP RPC endpoint
-#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /trigger (if the server requires auth)
+#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /tasks (if the server requires auth)
 
 router_url           = "https://testnet.gaskiller.xyz"
 http_rpc             = "$HTTP_RPC"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 60
 
 [[scenarios]]

--- a/scripts/scenarios/testnet_smoke.toml
+++ b/scripts/scenarios/testnet_smoke.toml
@@ -5,7 +5,7 @@
 
 router_url = "https://testnet.gaskiller.xyz"
 http_rpc   = "$HTTP_RPC"
-api_key    = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key    = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 
 # ── Serial smoke test with on-chain verification ─────────────────
 [[scenarios]]

--- a/scripts/send_request.rs
+++ b/scripts/send_request.rs
@@ -140,7 +140,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .to::<u64>();
 
     let url = env::var("GAS_KILLER_TRIGGER_URL")
-        .unwrap_or_else(|_| "http://localhost:8080/trigger".to_string());
+        .unwrap_or_else(|_| "http://localhost:8080/tasks".to_string());
     println!("Posting GasKiller task to {}", url);
 
     let client = reqwest::Client::new();


### PR DESCRIPTION
## Summary

Switches task submission to an async, persisted model: `POST /tasks` validates a request, writes it to the store as a `queued` task **before** responding, enqueues it for aggregation, and returns `202 Accepted { "task_id": "<uuid-v4>", "status": "queued" }`. `POST /trigger` is kept as a deprecated alias routed to the same handler, so existing clients get the new shape and can migrate.

Closes gas-killer/service#193 (TASK-1). Part of the Service v1 Beta epic (gas-killer/roadmap#15).

> **Stacked on #300.** This branch builds on `bagelface/task-store-model` (the persistent task model) and targets it as its base. Retarget to `main` once #300 merges.

## What changed

- **`POST /tasks`** (new primary endpoint) and **`POST /trigger`** (deprecated alias) both route to `submit_task_handler`, which returns `202` with `{ task_id, status }`.
- Task IDs are UUID v4, generated and persisted by the store's `create_task` (from #300).
- **Persist-before-response:** the task row is written before the `202` is sent, so a restart can recover work already acknowledged to the client (satisfies the persistence ordering criterion of #192).
- **Order preserved:** auth → load-shed (`503` queue full) → validation (`400`/`422`) → onchain validation → persist → enqueue. All rejections stay synchronous and run before any row is written.
- `authorize_task_request` now returns the authenticated key's id, so the persisted task is scoped to its owning key (`key_id`).
- Submission now requires a configured store: the store-less dev path returns `503 NotConfigured` rather than silently accepting and dropping a request.
- Removed the old `{ success, message }` response shape.

## Scope

Submission layer only. The task is created as `queued`; the status lifecycle (`processing`/`ready`/`failed`) is **not** wired here — driving those transitions requires threading the task id through the aggregation channel to the orchestrator, and the terminal `ready` payload depends on the user-executable payload work (gas-killer/service#195). That lifecycle wiring lands with the status-polling endpoints (gas-killer/service#194), which also make the status observable. The channel is intentionally left carrying `GasKillerTaskRequest` unchanged in this PR.

## Testing

- Rewrote the submission happy-path tests to run against an in-memory store with a minted key, asserting `202`, a UUID-v4 `task_id`, `status: "queued"`, that the task is queued, and that it is persisted and scoped to the submitting key.
- Added `/tasks` endpoint tests (accepts a valid key + persists; rejects a missing token when a store is present).
- Existing validation (`400`/`422`), load-shed (`503`), and auth (`401`) tests are unchanged and still pass — they reject before the persist step.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), and `cargo test --all-targets --all-features` all pass (121 lib tests).
