### PR TITLE
fix: migrate client tooling and ingress allowlist to POST /tasks

### DIFF
--- a/helm/gas-killer/templates/ingress.yaml
+++ b/helm/gas-killer/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
             routed here and stays reachable only in-cluster. Falls back to the router's public
             routes if publicPaths is unset, never to a catch-all "/".
           */}}
-          {{- range .Values.ingress.publicPaths | default (list "/trigger" "/avs-metadata" "/healthz") }}
+          {{- range .Values.ingress.publicPaths | default (list "/tasks" "/trigger" "/avs-metadata" "/healthz") }}
           - path: {{ . | quote }}
             pathType: Prefix
             backend:

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -670,6 +670,8 @@ ingress:
   # This keeps admin behind cluster access in addition to ADMIN_KEY. Add a path here only if it
   # genuinely needs to be internet-facing.
   publicPaths:
+    - /tasks
+    # Deprecated alias of /tasks, kept until clients migrate.
     - /trigger
     - /avs-metadata
     - /healthz

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -223,7 +223,7 @@ echo -e "${YELLOW}Step 9: Waiting briefly for services to stabilize...${NC}"
 sleep 5
 
 # Step 9b: Mint an API key so task submission is authenticated. The router requires a valid,
-# unrevoked key on /trigger; mint one via the admin API (guarded by ADMIN_KEY) and hand it to
+# unrevoked key on /tasks; mint one via the admin API (guarded by ADMIN_KEY) and hand it to
 # send_request through GAS_KILLER_API_KEY.
 echo -e "${YELLOW}Step 9b: Minting an API key via the admin endpoint...${NC}"
 CREATE_RESP=$(curl -s -X POST \

--- a/scripts/run_helm_test.sh
+++ b/scripts/run_helm_test.sh
@@ -38,7 +38,7 @@ NODE_COUNT="${NODE_COUNT:-3}"
 FORK_URL="${FORK_URL:-https://ethereum-sepolia-rpc.publicnode.com}"
 PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
 FUNDED_KEY="${FUNDED_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-# Guards the /admin/keys endpoints used to mint the API keys that authenticate /trigger. A fixed
+# Guards the /admin/keys endpoints used to mint the API keys that authenticate /tasks. A fixed
 # dev value for the local harness; override by exporting ADMIN_KEY.
 ADMIN_KEY="${ADMIN_KEY:-ci-admin-key}"
 SKIP_BUILD="${SKIP_BUILD:-false}"
@@ -288,7 +288,7 @@ echo -e "${GREEN}ArraySummation deployment completed${NC}"
 echo -e "${YELLOW}Step 12: Triggering Gas Killer task...${NC}"
 
 # Mint an API key so task submission is authenticated. The router requires a valid, unrevoked
-# key on /trigger; mint one via the admin API (guarded by ADMIN_KEY) and hand it to send_request
+# key on /tasks; mint one via the admin API (guarded by ADMIN_KEY) and hand it to send_request
 # through GAS_KILLER_API_KEY.
 CREATE_RESP=$(curl -s -X POST \
     -H "Authorization: Bearer $ADMIN_KEY" \

--- a/scripts/run_scenario.rs
+++ b/scripts/run_scenario.rs
@@ -19,7 +19,7 @@ struct Config {
     router_url: String,
     /// Required when any request uses `block_height = 0` or `verify = true`.
     http_rpc: Option<String>,
-    /// API key sent as `Authorization: Bearer <key>` on every `/trigger` request. Mint one with
+    /// API key sent as `Authorization: Bearer <key>` on every `/tasks` request. Mint one with
     /// the `create_api_key` tool. Falls back to the `GAS_KILLER_API_KEY` environment variable
     /// when unset; leave empty for a router that does not require auth.
     api_key: Option<String>,
@@ -118,7 +118,7 @@ struct RequestConfig {
     /// Set to 0 to auto-fetch the current block from `http_rpc`.
     #[serde(default)]
     block_height: u64,
-    /// When true, poll stateTransitionCount() after a 200 to confirm verifyAndUpdate ran.
+    /// When true, poll stateTransitionCount() after a 202 to confirm verifyAndUpdate ran.
     #[serde(default)]
     verify: bool,
     /// How long to wait for on-chain confirmation (seconds, default: 150).
@@ -152,10 +152,11 @@ struct ApiRequest {
     body: ApiRequestBody,
 }
 
+/// Body returned by `POST /tasks` when a task is accepted for aggregation.
 #[derive(Debug, Deserialize)]
-struct ApiResponse {
-    success: bool,
-    message: String,
+struct AcceptedResponse {
+    task_id: String,
+    status: String,
 }
 
 // ── Result types ──────────────────────────────────────────────────────────────
@@ -177,7 +178,7 @@ struct RequestResult {
 
 impl RequestResult {
     fn passed(&self) -> bool {
-        if !self.api_success || self.status != 200 {
+        if !self.api_success || self.status != 202 {
             return false;
         }
         match &self.on_chain {
@@ -333,7 +334,7 @@ async fn send_request(
         },
     };
 
-    let url = format!("{}/trigger", router_url.trim_end_matches('/'));
+    let url = format!("{}/tasks", router_url.trim_end_matches('/'));
     let start = Instant::now();
     let mut req = client.post(&url).json(&payload);
     if let Some(key) = api_key
@@ -344,30 +345,48 @@ async fn send_request(
     let resp = req.send().await;
     let elapsed = start.elapsed();
 
+    // The router acknowledges an accepted submission with `202 Accepted` and a
+    // `{ task_id, status }` body; any other status carries an error envelope, surfaced verbatim
+    // in the report.
     let (status, api_success, message) = match resp {
         Err(e) => (0u16, false, format!("connection error: {e}")),
         Ok(r) => {
             let status = r.status().as_u16();
             match r.text().await {
-                Ok(body_text) => match serde_json::from_str::<ApiResponse>(&body_text) {
-                    Ok(body) => (status, body.success, body.message),
-                    Err(e) => {
-                        let trimmed = body_text.trim();
-                        let msg = if trimmed.is_empty() {
-                            format!("non-ApiResponse body (HTTP {status}); parse error: {e}")
-                        } else {
-                            format!("{trimmed} (non-ApiResponse: {e})")
-                        };
-                        (status, false, msg)
+                Ok(body_text) if status == 202 => {
+                    match serde_json::from_str::<AcceptedResponse>(&body_text) {
+                        Ok(body) => (
+                            status,
+                            true,
+                            format!("{} (task {})", body.status, body.task_id),
+                        ),
+                        Err(e) => {
+                            let trimmed = body_text.trim();
+                            let msg = if trimmed.is_empty() {
+                                format!("202 with empty body; parse error: {e}")
+                            } else {
+                                format!("{trimmed} (unparseable 202: {e})")
+                            };
+                            (status, false, msg)
+                        }
                     }
-                },
+                }
+                Ok(body_text) => {
+                    let trimmed = body_text.trim();
+                    let msg = if trimmed.is_empty() {
+                        format!("HTTP {status} with empty body")
+                    } else {
+                        trimmed.to_string()
+                    };
+                    (status, false, msg)
+                }
                 Err(e) => (status, false, format!("failed to read response body: {e}")),
             }
         }
     };
 
     // Verify on-chain only if the API accepted the request
-    let on_chain = if cfg.verify && api_success && status == 200 {
+    let on_chain = if cfg.verify && api_success && status == 202 {
         if let (Some(p), Some(count), Ok(addr)) = (
             provider,
             on_chain_count,

--- a/scripts/scenarios/example.toml
+++ b/scripts/scenarios/example.toml
@@ -5,7 +5,7 @@
 
 router_url           = "http://localhost:8080"
 http_rpc             = "$HTTP_RPC"  # env var interpolation supported; required when block_height = 0, verify = true, or transition_index = "auto"
-# API key sent as `Authorization: Bearer <key>` on every /trigger request. Mint one with the
+# API key sent as `Authorization: Bearer <key>` on every /tasks request. Mint one with the
 # create_api_key tool. Reads the GAS_KILLER_API_KEY env var (like http_rpc above); replace with a
 # literal "gk_..." key to override, or "" to leave requests unauthenticated.
 api_key              = "$GAS_KILLER_API_KEY"

--- a/scripts/scenarios/latency_profile.toml
+++ b/scripts/scenarios/latency_profile.toml
@@ -9,7 +9,7 @@
 #
 # Requires:
 #   GNOSIS_RPC_URL    — Gnosis chain HTTP RPC endpoint
-#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /trigger (if the server requires auth)
+#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /tasks (if the server requires auth)
 #
 # After running, pull metrics from Grafana:
 #   - gas_killer_p2p_round_trip_seconds        (router)
@@ -23,7 +23,7 @@
 
 router_url           = "https://testnet.gaskiller.xyz"
 http_rpc             = "$GNOSIS_RPC_URL"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 120
 
 # ── 1. Baseline — single serial requests with 5 s breathing room between them ─

--- a/scripts/scenarios/local_profile.toml
+++ b/scripts/scenarios/local_profile.toml
@@ -1,6 +1,6 @@
 router_url           = "http://localhost:8080"
 http_rpc             = "http://localhost:8545"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 120
 
 [[scenarios]]

--- a/scripts/scenarios/testnet_load.toml
+++ b/scripts/scenarios/testnet_load.toml
@@ -5,7 +5,7 @@
 #
 # Requires:
 #   HTTP_RPC          — HTTP RPC endpoint
-#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /trigger (if the server requires auth)
+#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /tasks (if the server requires auth)
 #
 # Structure:
 #   1. smoke   — single serial request with on-chain verification; confirms the
@@ -16,7 +16,7 @@
 
 router_url           = "https://testnet.gaskiller.xyz"
 http_rpc             = "$HTTP_RPC"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 60
 
 # ── Burst test with 10 concurrent requests ──────────────────────────────────

--- a/scripts/scenarios/testnet_parallel_smoke.toml
+++ b/scripts/scenarios/testnet_parallel_smoke.toml
@@ -9,11 +9,11 @@
 #
 # Requires:
 #   HTTP_RPC          — HTTP RPC endpoint
-#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /trigger (if the server requires auth)
+#   GAS_KILLER_API_KEY  — API key sent as `Authorization: Bearer <key>` on /tasks (if the server requires auth)
 
 router_url           = "https://testnet.gaskiller.xyz"
 http_rpc             = "$HTTP_RPC"
-api_key              = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key              = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 ingress_timeout_secs = 60
 
 [[scenarios]]

--- a/scripts/scenarios/testnet_smoke.toml
+++ b/scripts/scenarios/testnet_smoke.toml
@@ -5,7 +5,7 @@
 
 router_url = "https://testnet.gaskiller.xyz"
 http_rpc   = "$HTTP_RPC"
-api_key    = "$GAS_KILLER_API_KEY"   # /trigger auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
+api_key    = "$GAS_KILLER_API_KEY"   # /tasks auth: set $GAS_KILLER_API_KEY in env, or paste a literal gk_ key
 
 # ── Serial smoke test with on-chain verification ─────────────────
 [[scenarios]]

--- a/scripts/send_request.rs
+++ b/scripts/send_request.rs
@@ -140,7 +140,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .to::<u64>();
 
     let url = env::var("GAS_KILLER_TRIGGER_URL")
-        .unwrap_or_else(|_| "http://localhost:8080/trigger".to_string());
+        .unwrap_or_else(|_| "http://localhost:8080/tasks".to_string());
     println!("Posting GasKiller task to {}", url);
 
     let client = reqwest::Client::new();


### PR DESCRIPTION
## Summary

Sibling of #302 (async `POST /tasks`). Updates the client tooling and the ingress allowlist to the new endpoint and response shape so the scenario/load runs don't go red the moment the router returns `202 { task_id, status }` instead of `200 { success, message }`.

**Stacked on #302.** Base is `bagelface/async-task-submission` so these changes travel to `main` together with the response-shape change — they must not merge independently, or a scenario run against the new router would score every accepted task as failed.

## What actually breaks vs. what doesn't

- **`scripts/run_scenario.rs` — real break (fixed here).** It deserialized the response into `{ success, message }` and gated success on HTTP `200`. Against the new router every accepted task would fail to parse and be scored as a failed request. Now it parses `{ task_id, status }`, treats `202` as accepted, surfaces the error-envelope body verbatim on non-`202`, and submits to `/tasks`.
- **`scripts/send_request.rs` — not a parse break.** It only checks `status.is_success()` (`202` qualifies) and verifies via on-chain `currentSum`, so it would not have gone red. Repointed its default URL to `/tasks` for consistency.
- **e2e / helm suites — not a break.** Both drive `send_request` and only parse `.key` from the admin endpoint; `run_helm_test.sh` reaches the router via `kubectl port-forward` (bypassing the ingress). Comments updated to `/tasks`.

## Also included

- **Ingress allowlist** (`helm/gas-killer/values.yaml`, `templates/ingress.yaml`): added `/tasks` to `publicPaths`. Without it, `/tasks` — the new primary endpoint — would be unreachable through the public ingress once #302 deploys. `/trigger` is kept in the list until it is removed (gas-killer/service#303).
- Scenario TOML comments repointed to `/tasks`.

Docs still referencing `/trigger` (README, `example.env`, `docker-compose.yml`, helm README) are non-breaking — `/trigger` remains a working alias — and are tracked as part of the `/trigger` removal in gas-killer/service#303.

## Testing

- `cargo fmt`, `cargo clippy -p scripts --all-targets --all-features -- -D warnings` (clean), and `cargo check -p scripts` all pass.
- Shell/helm/TOML changes are endpoint-string and comment updates; behavior of the e2e/helm suites is unchanged (they were already tolerant).
