### PR TITLE
feat: add task status polling endpoints (GET /tasks, GET /tasks/{id})

### DIFF
--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -11,9 +11,10 @@
 //! any time. Status codes are carried alongside the code internally and are unchanged
 //! from the per-endpoint behaviour they replace.
 
-use axum::extract::rejection::JsonRejection;
-use axum::extract::{FromRequest, Request};
+use axum::extract::rejection::{JsonRejection, QueryRejection};
+use axum::extract::{FromRequest, FromRequestParts, Query, Request};
 use axum::http::StatusCode;
+use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use axum::{Json, async_trait};
 use serde::{Deserialize, Serialize};
@@ -41,6 +42,9 @@ pub enum ErrorCode {
     QueueFull,
     /// The request is missing valid authentication credentials.
     Unauthorized,
+    /// The caller is authenticated but not permitted to access the requested resource (e.g. a
+    /// task owned by a different API key).
+    Forbidden,
     /// An upstream RPC endpoint failed or is unreachable.
     RpcUnavailable,
     /// No contract is deployed at the requested target address on any supported chain.
@@ -101,6 +105,16 @@ impl ApiError {
         )
     }
 
+    /// 403 with [`ErrorCode::Forbidden`].
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::FORBIDDEN, ErrorCode::Forbidden, message)
+    }
+
+    /// 404 with [`ErrorCode::NotFound`].
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_FOUND, ErrorCode::NotFound, message)
+    }
+
     /// 503 with [`ErrorCode::QueueFull`].
     pub fn queue_full(message: impl Into<String>) -> Self {
         Self::new(
@@ -158,6 +172,32 @@ where
     }
 }
 
+/// A `Query<T>` extractor that emits the [`ApiErrorEnvelope`] on failure instead of axum's
+/// default plain-text body, so a malformed query string (an unknown `?status=` value, a
+/// non-integer `?limit=`) shares the same error contract as the rest of the API. The status
+/// from the underlying [`QueryRejection`] is preserved (400).
+pub struct ApiQuery<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for ApiQuery<T>
+where
+    Query<T>: FromRequestParts<S, Rejection = QueryRejection>,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match Query::<T>::from_request_parts(parts, state).await {
+            Ok(Query(value)) => Ok(ApiQuery(value)),
+            Err(rejection) => Err(ApiError::new(
+                rejection.status(),
+                ErrorCode::InvalidRequest,
+                rejection.body_text(),
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,6 +213,7 @@ mod tests {
             (ErrorCode::RateLimited, "RATE_LIMITED"),
             (ErrorCode::QueueFull, "QUEUE_FULL"),
             (ErrorCode::Unauthorized, "UNAUTHORIZED"),
+            (ErrorCode::Forbidden, "FORBIDDEN"),
             (ErrorCode::RpcUnavailable, "RPC_UNAVAILABLE"),
             (ErrorCode::ContractNotFound, "CONTRACT_NOT_FOUND"),
             (ErrorCode::InvalidRequest, "INVALID_REQUEST"),

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -691,6 +691,22 @@ const DEFAULT_TASK_PAGE_SIZE: i64 = 50;
 /// Largest page size `GET /tasks` will serve; larger `limit` values are clamped down to it.
 const MAX_TASK_PAGE_SIZE: i64 = 200;
 
+/// Resolves the effective page size from the caller's optional `limit`: defaulted to
+/// [`DEFAULT_TASK_PAGE_SIZE`] and clamped to `[1, MAX_TASK_PAGE_SIZE]`, so a request can never
+/// ask for a zero, negative, or unbounded page.
+fn clamp_page_limit(limit: Option<i64>) -> i64 {
+    limit
+        .unwrap_or(DEFAULT_TASK_PAGE_SIZE)
+        .clamp(1, MAX_TASK_PAGE_SIZE)
+}
+
+/// Resolves the effective offset from the caller's optional `offset`: defaulted to 0 with
+/// negatives floored to 0. SQLite treats a negative OFFSET as 0 anyway; normalizing here keeps
+/// the bound explicit and independent of the backing store.
+fn clamp_offset(offset: Option<i64>) -> i64 {
+    offset.unwrap_or(0).max(0)
+}
+
 /// Query parameters for `GET /tasks`: an optional status filter and pagination bounds.
 #[derive(Debug, Deserialize)]
 pub struct ListTasksQuery {
@@ -746,11 +762,8 @@ pub async fn list_tasks_handler(
     let store = require_store(&state)?;
     let key_id = key_id.ok_or_else(ApiError::unauthorized)?;
 
-    let limit = params
-        .limit
-        .unwrap_or(DEFAULT_TASK_PAGE_SIZE)
-        .clamp(1, MAX_TASK_PAGE_SIZE);
-    let offset = params.offset.unwrap_or(0).max(0);
+    let limit = clamp_page_limit(params.limit);
+    let offset = clamp_offset(params.offset);
 
     let tasks = store
         .list_tasks_for_key(&key_id, params.status, limit, offset)
@@ -1106,6 +1119,39 @@ mod tests {
             req.validate().unwrap_err(),
             ValidationError::ZeroTargetAddress
         );
+    }
+
+    // -- pagination bound tests --
+
+    #[test]
+    fn page_limit_defaults_when_unset() {
+        assert_eq!(clamp_page_limit(None), DEFAULT_TASK_PAGE_SIZE);
+    }
+
+    #[test]
+    fn page_limit_clamps_to_bounds() {
+        // Above the cap is clamped down; below 1 (zero or negative) is floored to 1.
+        assert_eq!(
+            clamp_page_limit(Some(MAX_TASK_PAGE_SIZE + 1)),
+            MAX_TASK_PAGE_SIZE
+        );
+        assert_eq!(clamp_page_limit(Some(10_000)), MAX_TASK_PAGE_SIZE);
+        assert_eq!(clamp_page_limit(Some(0)), 1);
+        assert_eq!(clamp_page_limit(Some(-5)), 1);
+        // A value already within range passes through unchanged.
+        assert_eq!(clamp_page_limit(Some(25)), 25);
+        assert_eq!(
+            clamp_page_limit(Some(MAX_TASK_PAGE_SIZE)),
+            MAX_TASK_PAGE_SIZE
+        );
+    }
+
+    #[test]
+    fn offset_defaults_and_floors_negatives() {
+        assert_eq!(clamp_offset(None), 0);
+        assert_eq!(clamp_offset(Some(-1)), 0);
+        assert_eq!(clamp_offset(Some(0)), 0);
+        assert_eq!(clamp_offset(Some(42)), 42);
     }
 
     // -- HTTP handler integration tests --

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,7 +1,7 @@
 use crate::creator::{TaskQueueDepth, TaskSender};
-use crate::error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ErrorCode};
+use crate::error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ApiQuery, ErrorCode};
 use crate::metrics::MetricsCollector;
-use crate::store::{ApiKeyMetadata, CreatedApiKey, SqliteStore, TaskStatus};
+use crate::store::{ApiKeyMetadata, CreatedApiKey, SqliteStore, Task, TaskStatus};
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use axum::{
@@ -161,13 +161,13 @@ fn check_bearer_auth(headers: &HeaderMap, expected: &str) -> bool {
         .is_some_and(|token| constant_time_eq(token.as_bytes(), expected.as_bytes()))
 }
 
-/// Authorizes a task-submission request, returning the authenticated key's id when a store is
-/// configured. When a durable store is present — always the case in production — a valid,
-/// unrevoked API key is required and its id is returned so the submitted task can be scoped to
-/// its owner. With no store, the request is rejected unless `allow_unauthenticated` is set (the
-/// test/dev bare constructor), which yields `None`; a missing store fails closed rather than
-/// silently opening the endpoint.
-async fn authorize_task_request(
+/// Authenticates the caller against the durable store, returning the API key's id. Used by
+/// every task endpoint (submission and status) to identify — and scope work to — the calling
+/// key. When a store is present — always the case in production — a valid, unrevoked API key is
+/// required and its id is returned. With no store, the request is rejected unless
+/// `allow_unauthenticated` is set (the test/dev bare constructor), which yields `None`; a missing
+/// store fails closed rather than silently opening the endpoint.
+async fn authenticate_caller(
     state: &IngressState,
     headers: &HeaderMap,
 ) -> Result<Option<String>, ApiError> {
@@ -565,7 +565,7 @@ pub async fn submit_task_handler(
     headers: HeaderMap,
     ApiJson(request): ApiJson<GasKillerTaskRequest>,
 ) -> Result<(StatusCode, Json<TaskAcceptedResponse>), ApiError> {
-    let key_id = authorize_task_request(&state, &headers).await?;
+    let key_id = authenticate_caller(&state, &headers).await?;
 
     // Load-shed before any validation work. Onchain validation costs multiple RPC
     // round-trips, so rejecting at-capacity requests up front keeps an overloaded
@@ -618,7 +618,7 @@ pub async fn submit_task_handler(
     }
 
     // Persistence is required to hand back a task id and to survive restarts. A configured store
-    // always authenticates (see `authorize_task_request`), so `key_id` is `Some` here; an absent
+    // always authenticates (see `authenticate_caller`), so `key_id` is `Some` here; an absent
     // id is treated as unauthorized rather than unwrapped.
     let store = require_store(&state)?;
     let key_id = key_id.ok_or_else(ApiError::unauthorized)?;
@@ -656,6 +656,111 @@ pub async fn submit_task_handler(
             status: task.status,
         }),
     ))
+}
+
+/// Full task state returned by the status endpoints (`GET /tasks/{id}` and `GET /tasks`).
+///
+/// `created_at`/`updated_at` are unix timestamps in seconds, matching the timestamp convention
+/// used elsewhere in the API (e.g. the admin key listing). `payload` is populated once the task
+/// reaches `ready`; `error` once it is `failed` or `expired`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TaskView {
+    pub task_id: String,
+    pub status: TaskStatus,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub error: Option<String>,
+    pub payload: Option<String>,
+}
+
+impl From<Task> for TaskView {
+    fn from(task: Task) -> Self {
+        Self {
+            task_id: task.id,
+            status: task.status,
+            created_at: task.created_at,
+            updated_at: task.updated_at,
+            error: task.error,
+            payload: task.payload,
+        }
+    }
+}
+
+/// Page size used by `GET /tasks` when the caller does not specify `limit`.
+const DEFAULT_TASK_PAGE_SIZE: i64 = 50;
+/// Largest page size `GET /tasks` will serve; larger `limit` values are clamped down to it.
+const MAX_TASK_PAGE_SIZE: i64 = 200;
+
+/// Query parameters for `GET /tasks`: an optional status filter and pagination bounds.
+#[derive(Debug, Deserialize)]
+pub struct ListTasksQuery {
+    #[serde(default)]
+    status: Option<TaskStatus>,
+    #[serde(default)]
+    limit: Option<i64>,
+    #[serde(default)]
+    offset: Option<i64>,
+}
+
+/// Handler for `GET /tasks/{task_id}` — returns the full state of a single task.
+///
+/// A task is visible only to the API key that created it: an unknown id yields `404`, and a task
+/// owned by a different key yields `403` (kept distinct from `404` so a caller can tell "no such
+/// task" from "not yours").
+pub async fn get_task_handler(
+    State(state): State<IngressState>,
+    headers: HeaderMap,
+    Path(task_id): Path<String>,
+) -> Result<Json<TaskView>, ApiError> {
+    let key_id = authenticate_caller(&state, &headers).await?;
+    let store = require_store(&state)?;
+    let key_id = key_id.ok_or_else(ApiError::unauthorized)?;
+
+    let task = store
+        .get_task(&task_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to fetch task");
+            ApiError::internal("Internal error: failed to fetch task")
+        })?
+        .ok_or_else(|| ApiError::not_found("Task not found"))?;
+
+    if task.key_id != key_id {
+        return Err(ApiError::forbidden("Task belongs to a different API key"));
+    }
+
+    Ok(Json(task.into()))
+}
+
+/// Handler for `GET /tasks` — lists the calling key's tasks, newest first.
+///
+/// Scoped to the caller's API key; supports an optional `?status=` filter and `?limit=`/`?offset=`
+/// pagination. `limit` defaults to [`DEFAULT_TASK_PAGE_SIZE`] and is clamped to
+/// `[1, MAX_TASK_PAGE_SIZE]`; a negative `offset` is treated as `0`.
+pub async fn list_tasks_handler(
+    State(state): State<IngressState>,
+    headers: HeaderMap,
+    ApiQuery(params): ApiQuery<ListTasksQuery>,
+) -> Result<Json<Vec<TaskView>>, ApiError> {
+    let key_id = authenticate_caller(&state, &headers).await?;
+    let store = require_store(&state)?;
+    let key_id = key_id.ok_or_else(ApiError::unauthorized)?;
+
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_TASK_PAGE_SIZE)
+        .clamp(1, MAX_TASK_PAGE_SIZE);
+    let offset = params.offset.unwrap_or(0).max(0);
+
+    let tasks = store
+        .list_tasks_for_key(&key_id, params.status, limit, offset)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to list tasks");
+            ApiError::internal("Internal error: failed to list tasks")
+        })?;
+
+    Ok(Json(tasks.into_iter().map(TaskView::from).collect()))
 }
 
 /// Request body for `POST /admin/keys`. The whole body is optional; an empty body creates an
@@ -818,8 +923,9 @@ pub fn build_app() -> Router<IngressState> {
     Router::new()
         .route("/healthz", get(healthz_handler))
         .route("/avs-metadata", get(avs_metadata_handler))
-        .route("/tasks", post(submit_task_handler))
-        // Deprecated alias for `/tasks`, kept to ease client migration; identical behavior.
+        .route("/tasks", post(submit_task_handler).get(list_tasks_handler))
+        .route("/tasks/:task_id", get(get_task_handler))
+        // Deprecated alias for `POST /tasks`, kept to ease client migration; identical behavior.
         .route("/trigger", post(submit_task_handler))
         .route(
             "/admin/keys",
@@ -1890,6 +1996,223 @@ mod tests {
                 receiver.try_recv().is_err(),
                 "invalid task must not be pushed to queue"
             );
+        }
+
+        // -- status polling tests (GET /tasks/{id}, GET /tasks) --
+
+        fn get_request(uri: &str, token: Option<&str>) -> Request<Body> {
+            let mut builder = Request::builder().method(Method::GET).uri(uri);
+            if let Some(token) = token {
+                builder = builder.header("Authorization", format!("Bearer {token}"));
+            }
+            builder.body(Body::empty()).unwrap()
+        }
+
+        async fn task_view(resp: axum::response::Response) -> TaskView {
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice(&bytes).expect("task view should deserialize")
+        }
+
+        async fn task_views(resp: axum::response::Response) -> Vec<TaskView> {
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice(&bytes).expect("task list should deserialize")
+        }
+
+        /// Persists a task for `key_id` directly through the store, returning its id.
+        async fn seed_task(store: &SqliteStore, key_id: &str) -> String {
+            store
+                .create_task(key_id, &valid_request().body)
+                .await
+                .expect("seeding a task should succeed")
+                .id
+        }
+
+        #[tokio::test]
+        async fn get_task_returns_owner_task() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let id = seed_task(&store, &key.id).await;
+
+            let resp = app
+                .oneshot(get_request(&format!("/tasks/{id}"), Some(&key.key)))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let view = task_view(resp).await;
+            assert_eq!(view.task_id, id);
+            assert_eq!(view.status, TaskStatus::Queued);
+            assert!(view.payload.is_none());
+            assert!(view.error.is_none());
+            assert!(view.created_at > 0);
+        }
+
+        #[tokio::test]
+        async fn get_task_ready_includes_payload() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let id = seed_task(&store, &key.id).await;
+            store.mark_task_ready(&id, "0xdeadbeef").await.unwrap();
+
+            let view = task_view(
+                app.oneshot(get_request(&format!("/tasks/{id}"), Some(&key.key)))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(view.status, TaskStatus::Ready);
+            assert_eq!(view.payload.as_deref(), Some("0xdeadbeef"));
+        }
+
+        #[tokio::test]
+        async fn get_task_failed_includes_error() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let id = seed_task(&store, &key.id).await;
+            store
+                .mark_task_failed(&id, "aggregation timed out")
+                .await
+                .unwrap();
+
+            let view = task_view(
+                app.oneshot(get_request(&format!("/tasks/{id}"), Some(&key.key)))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(view.status, TaskStatus::Failed);
+            assert_eq!(view.error.as_deref(), Some("aggregation timed out"));
+        }
+
+        #[tokio::test]
+        async fn get_unknown_task_returns_404() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let resp = app
+                .oneshot(get_request("/tasks/does-not-exist", Some(&key.key)))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::NotFound);
+        }
+
+        #[tokio::test]
+        async fn get_task_owned_by_other_key_returns_403() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let owner = store.create_api_key(None, None).await.unwrap();
+            let other = store.create_api_key(None, None).await.unwrap();
+            let id = seed_task(&store, &owner.id).await;
+
+            let resp = app
+                .oneshot(get_request(&format!("/tasks/{id}"), Some(&other.key)))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::Forbidden);
+        }
+
+        #[tokio::test]
+        async fn get_task_without_token_returns_401() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let id = seed_task(&store, &key.id).await;
+            let resp = app
+                .oneshot(get_request(&format!("/tasks/{id}"), None))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        }
+
+        #[tokio::test]
+        async fn list_tasks_is_scoped_to_key_newest_first() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key_a = store.create_api_key(None, None).await.unwrap();
+            let key_b = store.create_api_key(None, None).await.unwrap();
+            seed_task(&store, &key_a.id).await;
+            seed_task(&store, &key_a.id).await;
+            seed_task(&store, &key_b.id).await;
+
+            let resp = app
+                .oneshot(get_request("/tasks", Some(&key_a.key)))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let views = task_views(resp).await;
+            assert_eq!(views.len(), 2, "list must be scoped to the calling key");
+            assert!(
+                views.windows(2).all(|w| w[0].created_at >= w[1].created_at),
+                "tasks must be newest first"
+            );
+        }
+
+        #[tokio::test]
+        async fn list_tasks_filters_by_status() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let ready = seed_task(&store, &key.id).await;
+            seed_task(&store, &key.id).await;
+            store.mark_task_ready(&ready, "0x00").await.unwrap();
+
+            let views = task_views(
+                app.oneshot(get_request("/tasks?status=ready", Some(&key.key)))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(views.len(), 1);
+            assert_eq!(views[0].task_id, ready);
+            assert_eq!(views[0].status, TaskStatus::Ready);
+        }
+
+        #[tokio::test]
+        async fn list_tasks_paginates() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            for _ in 0..3 {
+                seed_task(&store, &key.id).await;
+            }
+
+            let first = task_views(
+                app.clone()
+                    .oneshot(get_request("/tasks?limit=2", Some(&key.key)))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(first.len(), 2);
+
+            let second = task_views(
+                app.oneshot(get_request("/tasks?limit=2&offset=2", Some(&key.key)))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(second.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn list_tasks_rejects_bad_status_with_envelope() {
+            let (app, store, _rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+            let resp = app
+                .oneshot(get_request("/tasks?status=bogus", Some(&key.key)))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+            let body = error_envelope(resp).await;
+            assert_eq!(body.error.code, crate::error::ErrorCode::InvalidRequest);
+        }
+
+        #[tokio::test]
+        async fn list_tasks_without_token_returns_401() {
+            let (app, _store, _rx) = make_app_with_store(None).await;
+            let resp = app.oneshot(get_request("/tasks", None)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         }
     }
 


### PR DESCRIPTION
## Summary

Adds the status-polling API from #194 (TASK-2): `GET /tasks/{task_id}` for a single task and `GET /tasks` for the calling key's list, both scoped to the authenticated API key.

Closes gas-killer/service#194. Part of the Service v1 Beta epic (gas-killer/roadmap#15). Targets the `task-lifecycle-refactor` aggregation branch (built on #300/#302/#304).

## Endpoints

- **`GET /tasks/{task_id}`** → full task state; `404` for an unknown id, `403` for a task owned by a different key, `401` without a valid key.
- **`GET /tasks`** → the calling key's tasks, newest first; `?status=` filter and `?limit=`/`?offset=` pagination (`limit` defaults to 50, clamped to 200; negative `offset` treated as 0).
- Response shape: `{ task_id, status, created_at, updated_at, error, payload }` — `payload` populated when `ready`, `error` when `failed`/`expired`.

Both read straight through the store methods added in #300 (`get_task`, `list_tasks_for_key`). Supporting bits: a new `Forbidden` error code (403) + `ApiQuery` extractor (so a bad `?status=` returns the JSON error envelope, not axum's plaintext 400), and the auth helper renamed `authorize_task_request` → `authenticate_caller` since it now serves both submit and read paths.

## Two decisions worth a look

1. **Timestamps as unix seconds (`i64`), not RFC3339.** The #194 spec example shows `"2026-04-27T12:00:00Z"`, but the rest of the API already returns unix seconds (the admin key listing's `created_at`/`last_used`/`invalid_at`), and there's no date crate in the workspace. I went with `i64` for consistency and to avoid adding a dependency. Easy to switch to RFC3339 if you'd rather match the example — say the word.
2. **`403` vs `404` for a task you don't own.** Per the spec, an unknown id is `404` and a task owned by another key is `403`. That does reveal that *some* task exists at that id to a non-owner. If you'd prefer not to leak existence, I can collapse non-owner to `404`.

## Scope — read endpoints only

The status lifecycle is **not** wired here: accepted tasks are persisted `queued` and no code transitions them yet, so polling reflects whatever is in the store (today, `queued`). The handlers fully support every state — tests drive `ready`/`failed` by transitioning tasks directly through the store and assert the payload/error surface correctly — so #194's contract is met.

Making transitions actually happen (thread the `task_id` through the aggregation channel → orchestrator drives `processing`/`ready`/`failed`) plus the startup re-queue is the next PR, tracked separately. **Hard ordering constraint carried over:** the re-queue (`incomplete_tasks`) must not be wired before those transitions, or a restart re-runs completed work.

## Testing

- 11 new integration tests through the real axum router: owner fetch, `ready`→payload, `failed`→error, `404`, `403` (other key), `401`; list scoping + newest-first, `?status=` filter, pagination, bad-status→enveloped `400`, `401`.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` (0 warnings), `cargo test --all-targets --all-features` all pass (132 lib tests).
