### PR TITLE
feat: wire task status transitions and startup re-queue

### DIFF
--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -1,4 +1,6 @@
 use crate::metrics::MetricsCollector;
+use crate::sequencer::{InFlightTask, in_flight_task, set_task_failed, set_task_ready};
+use crate::store::SqliteStore;
 use crate::task_data::GasKillerTaskData;
 use alloy::network::Ethereum;
 use alloy_primitives::{Address, Bytes, FixedBytes, U256};
@@ -42,6 +44,13 @@ pub struct GasKillerHandler<P> {
     /// applied to every chain. When unset, per-chain defaults apply. Sourced from
     /// `EXECUTOR_RECEIPT_TIMEOUT_SECS`.
     receipt_timeout_override: Option<u64>,
+    /// Durable store used to settle a task's terminal status once its height
+    /// executes. `None` in store-less test/dev harnesses, where the transition is
+    /// skipped.
+    store: Option<SqliteStore>,
+    /// Shared with [`crate::sequencer::GasKillerTaskSource`]; see
+    /// [`crate::sequencer::InFlightTask`].
+    in_flight: InFlightTask,
 }
 
 impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> {
@@ -56,6 +65,8 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             dispatch_time: Default::default(),
             interface_cache: Arc::new(RwLock::new(HashMap::new())),
             receipt_timeout_override: None,
+            store: None,
+            in_flight: in_flight_task(),
         }
     }
 
@@ -68,6 +79,8 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             dispatch_time: Default::default(),
             interface_cache: Arc::new(RwLock::new(HashMap::new())),
             receipt_timeout_override: None,
+            store: None,
+            in_flight: in_flight_task(),
         }
     }
 
@@ -92,6 +105,21 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
     /// the per-chain defaults.
     pub fn with_receipt_timeout(mut self, timeout_secs: Option<u64>) -> Self {
         self.receipt_timeout_override = timeout_secs;
+        self
+    }
+
+    /// Attaches the durable store so a settled height advances its task's terminal
+    /// status.
+    pub fn with_store(mut self, store: SqliteStore) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    /// Shares the in-flight task slot with [`crate::sequencer::GasKillerTaskSource`].
+    /// Must be the same handle the task source is built with, or a settled height
+    /// won't map back to its task.
+    pub fn with_in_flight_task(mut self, in_flight: InFlightTask) -> Self {
+        self.in_flight = in_flight;
         self
     }
 
@@ -412,6 +440,23 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
             }
         }
 
+        // Settle the task this height was executing. `GasKillerTaskSource::next_task`
+        // set the in-flight slot when it dispatched this task; taking it here both
+        // records the outcome and clears the slot so a later skipped height is not
+        // mistaken for this one. The task carries no user-executable payload yet
+        // (that arrives with the payload-delivery work), so a successful execution
+        // is recorded as `ready` with the status transition alone.
+        if let Some(store) = &self.store
+            && let Some(task_id) = self.in_flight.lock().ok().and_then(|mut slot| slot.take())
+        {
+            match &result {
+                Ok(_) => set_task_ready(store, &task_id).await,
+                Err(e) => {
+                    set_task_failed(store, &task_id, &format!("verification failed: {e}")).await
+                }
+            }
+        }
+
         result
     }
 }
@@ -549,5 +594,129 @@ mod tests {
             handler.receipt_timeout(ChainRole::L2),
             Duration::from_secs(45)
         );
+    }
+
+    // -- task lifecycle settlement --
+
+    use crate::store::TaskStatus;
+    use gas_killer_common::bindings::bls_sig_check_operator_state_retriever::BN254 as RetrieverBN254;
+
+    fn empty_non_signer_data() -> RetrieverIBLSTypes::NonSignerStakesAndSignature {
+        RetrieverIBLSTypes::NonSignerStakesAndSignature {
+            nonSignerQuorumBitmapIndices: vec![],
+            nonSignerPubkeys: vec![],
+            quorumApks: vec![],
+            apkG2: RetrieverBN254::G2Point {
+                X: [U256::ZERO, U256::ZERO],
+                Y: [U256::ZERO, U256::ZERO],
+            },
+            sigma: RetrieverBN254::G1Point {
+                X: U256::ZERO,
+                Y: U256::ZERO,
+            },
+            quorumApkIndices: vec![],
+            totalStakeIndices: vec![],
+            nonSignerStakeIndices: vec![],
+        }
+    }
+
+    async fn store() -> SqliteStore {
+        SqliteStore::connect_in_memory()
+            .await
+            .expect("in-memory store should open and migrate")
+    }
+
+    async fn key_id(store: &SqliteStore) -> String {
+        store
+            .create_api_key(None, None)
+            .await
+            .expect("key creation should succeed")
+            .id
+    }
+
+    fn request_body() -> crate::ingress::GasKillerTaskRequestBody {
+        crate::ingress::GasKillerTaskRequestBody {
+            target_address: Address::from([0x11; 20]),
+            call_data: vec![0x12, 0x34, 0x56, 0x78],
+            transition_index: Some(0),
+            from_address: Address::from([0x22; 20]),
+            value: U256::ZERO,
+            block_height: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_verification_settles_task_failed_when_task_data_missing() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store
+            .create_task(&key, &request_body())
+            .await
+            .expect("task creation should succeed");
+
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let in_flight = in_flight_task();
+        *in_flight.lock().unwrap() = Some(task.id.clone());
+
+        let mut handler = GasKillerHandler::new(1, provider)
+            .with_store(store.clone())
+            .with_in_flight_task(in_flight.clone());
+
+        // `task_data: None` makes `execute_verification` fail immediately (before any
+        // provider call), exercising the settlement wiring without needing a real
+        // chain, ABI-encoded certificate, or registered operator set.
+        let result = handler
+            .handle_verification(
+                0,
+                FixedBytes::<32>::ZERO,
+                Bytes::new(),
+                0,
+                empty_non_signer_data(),
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            in_flight.lock().unwrap().is_none(),
+            "the slot must be cleared once the task settles"
+        );
+        let settled = store
+            .get_task(&task.id)
+            .await
+            .unwrap()
+            .expect("task should still exist");
+        assert_eq!(settled.status, TaskStatus::Failed);
+        assert!(
+            settled
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("verification failed"))
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_verification_is_noop_on_store_when_slot_empty() {
+        let store = store().await;
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let mut handler = GasKillerHandler::new(1, provider).with_store(store);
+
+        // No task was recorded as in flight (e.g. a certificate for an unassigned
+        // height); settlement must not panic when there is nothing to settle.
+        let result = handler
+            .handle_verification(
+                0,
+                FixedBytes::<32>::ZERO,
+                Bytes::new(),
+                0,
+                empty_non_signer_data(),
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
     }
 }

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -198,18 +198,6 @@ pub async fn create_ingress(metrics: Arc<MetricsCollector>) -> Result<IngressHan
 /// Each task is rebuilt from its persisted request and pushed through the same
 /// channel a fresh `POST /tasks` submission uses, so it flows through the normal
 /// dequeue → processing → ready/failed pipeline indistinguishably from new work.
-///
-/// This is at-least-once, not exactly-once: a task whose on-chain transition
-/// already landed just before the crash — the router died between a successful
-/// `verifyAndUpdate` and the `set_task_ready` write, or that write itself failed —
-/// is still `processing` and gets re-run. The contract's transition-index
-/// ordering makes the re-run's on-chain effect a no-op (the stale index is
-/// rejected, never double-applied), so there is no on-chain safety issue, but the
-/// rejection then surfaces as an execution error and the task is recorded
-/// `failed` even though its transition already succeeded — a false-negative
-/// status, not a false-positive one. Tightening this (an on-chain state check
-/// before re-running, or request dedup) is out of scope here; tracked in
-/// gas-killer/service#325.
 pub async fn requeue_incomplete_tasks(
     store: &SqliteStore,
     sender: &TaskSender,

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -3,11 +3,14 @@
 
 use crate::GasKillerHandler;
 use crate::ingress::{
-    AvsMetadata, AvsOperatorSetMetadata, AvsOperatorSetSoftware, IngressState,
-    start_gas_killer_http_server,
+    AvsMetadata, AvsOperatorSetMetadata, AvsOperatorSetSoftware, GasKillerTaskRequest,
+    IngressState, start_gas_killer_http_server,
 };
 use crate::metrics::MetricsCollector;
-use crate::sequencer::{TaskQueueDepth, TaskReceiver, TaskSender, task_channel, task_queue_depth};
+use crate::sequencer::{
+    InFlightTask, QueuedTask, TaskQueueDepth, TaskReceiver, TaskSender, task_channel,
+    task_queue_depth,
+};
 use crate::store::SqliteStore;
 use alloy::network::{Ethereum, EthereumWallet};
 use alloy_primitives::Bytes;
@@ -30,9 +33,10 @@ use gas_killer_common::bindings::bls_apk_registry::BLSApkRegistry;
 use gas_killer_common::bindings::bls_sig_check_operator_state_retriever::BLSSigCheckOperatorStateRetriever;
 use gas_killer_common::task_data::GasKillerTaskData;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::{env, str::FromStr, sync::Arc};
-use tracing::info;
+use tracing::{error, info};
 
 /// Quorum 0 — the only quorum this deployment operates on.
 const QUORUM_NUMBERS: &[u8] = &[0x00];
@@ -68,6 +72,10 @@ pub struct IngressHandles {
     pub sender: TaskSender,
     pub receiver: TaskReceiver,
     pub queue_depth: TaskQueueDepth,
+    /// The durable store opened for the HTTP ingress, shared with the task source
+    /// and executor so they can drive task status transitions. `None` when
+    /// `INGRESS != true` (no store is opened without the HTTP server).
+    pub store: Option<SqliteStore>,
 }
 
 /// Creates the ingress task channel and, when `INGRESS=true`, spawns the HTTP
@@ -85,6 +93,7 @@ pub async fn create_ingress(metrics: Arc<MetricsCollector>) -> Result<IngressHan
             sender,
             receiver,
             queue_depth,
+            store: None,
         });
     }
 
@@ -157,6 +166,7 @@ pub async fn create_ingress(metrics: Arc<MetricsCollector>) -> Result<IngressHan
         });
     }
 
+    let store_for_return = store.clone();
     let ingress_state = IngressState::new(
         sender.clone(),
         queue_depth.clone(),
@@ -177,7 +187,47 @@ pub async fn create_ingress(metrics: Arc<MetricsCollector>) -> Result<IngressHan
         sender,
         receiver,
         queue_depth,
+        store: Some(store_for_return),
     })
+}
+
+/// Re-enqueues every task left `queued` or `processing` by a previous router life,
+/// so a restart resumes work already acknowledged to a client rather than losing
+/// it. Called once at startup, before the sequencer starts pulling from `sender`.
+///
+/// Each task is rebuilt from its persisted request and pushed through the same
+/// channel a fresh `POST /tasks` submission uses, so it flows through the normal
+/// dequeue → processing → ready/failed pipeline indistinguishably from new work.
+pub async fn requeue_incomplete_tasks(
+    store: &SqliteStore,
+    sender: &TaskSender,
+    queue_depth: &TaskQueueDepth,
+) -> Result<()> {
+    let tasks = store.incomplete_tasks().await?;
+    if tasks.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        count = tasks.len(),
+        "re-enqueuing incomplete tasks from a previous router life"
+    );
+    for task in tasks {
+        let task_id = task.id;
+        let queued = QueuedTask {
+            task_id: task_id.clone(),
+            request: GasKillerTaskRequest { body: task.request },
+        };
+        if sender.send(queued).is_err() {
+            error!(
+                task_id,
+                "failed to re-enqueue incomplete task: channel closed"
+            );
+            continue;
+        }
+        queue_depth.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(())
 }
 
 fn build_ingress_providers()
@@ -245,6 +295,8 @@ pub async fn create_submitter(
     metrics: Arc<MetricsCollector>,
     dispatch_time: DispatchTime,
     namespace: Vec<u8>,
+    store: Option<SqliteStore>,
+    in_flight: InFlightTask,
 ) -> Result<Submitter<GasKillerTaskData, GasKillerHandler<SimpleWalletProvider>>> {
     let http_rpc = env::var("HTTP_RPC").expect("HTTP_RPC must be set");
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
@@ -346,12 +398,18 @@ pub async fn create_submitter(
         .ok()
         .and_then(|v| v.parse::<u64>().ok());
 
-    // Create handler with multi-chain providers
-    let gas_killer_handler = GasKillerHandler::with_providers(providers)
+    // Create handler with multi-chain providers. The store and in-flight task slot
+    // let a settled height advance its task's terminal status; the slot is shared
+    // with the task source (see `GasKillerTaskSource`).
+    let mut gas_killer_handler = GasKillerHandler::with_providers(providers)
         .with_chain_roles(chain_roles)
         .with_metrics(metrics)
         .with_dispatch_time(dispatch_time)
-        .with_receipt_timeout(receipt_timeout_override);
+        .with_receipt_timeout(receipt_timeout_override)
+        .with_in_flight_task(in_flight);
+    if let Some(store) = store {
+        gas_killer_handler = gas_killer_handler.with_store(store);
+    }
 
     Ok(Submitter::new(
         scheme,

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -198,6 +198,18 @@ pub async fn create_ingress(metrics: Arc<MetricsCollector>) -> Result<IngressHan
 /// Each task is rebuilt from its persisted request and pushed through the same
 /// channel a fresh `POST /tasks` submission uses, so it flows through the normal
 /// dequeue → processing → ready/failed pipeline indistinguishably from new work.
+///
+/// This is at-least-once, not exactly-once: a task whose on-chain transition
+/// already landed just before the crash — the router died between a successful
+/// `verifyAndUpdate` and the `set_task_ready` write, or that write itself failed —
+/// is still `processing` and gets re-run. The contract's transition-index
+/// ordering makes the re-run's on-chain effect a no-op (the stale index is
+/// rejected, never double-applied), so there is no on-chain safety issue, but the
+/// rejection then surfaces as an execution error and the task is recorded
+/// `failed` even though its transition already succeeded — a false-negative
+/// status, not a false-positive one. Tightening this (an on-chain state check
+/// before re-running, or request dedup) is out of scope here; tracked in
+/// gas-killer/service#325.
 pub async fn requeue_incomplete_tasks(
     store: &SqliteStore,
     sender: &TaskSender,

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -1,6 +1,6 @@
 use crate::error::{ApiError, ApiErrorBody, ApiErrorEnvelope, ApiJson, ApiQuery, ErrorCode};
 use crate::metrics::MetricsCollector;
-use crate::sequencer::{TaskQueueDepth, TaskSender};
+use crate::sequencer::{QueuedTask, TaskQueueDepth, TaskSender};
 use crate::store::{ApiKeyMetadata, CreatedApiKey, SqliteStore, Task, TaskStatus};
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
@@ -640,7 +640,11 @@ pub async fn submit_task_handler(
         "Task accepted"
     );
     let depth = state.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
-    if state.sender.send(request).is_err() {
+    let queued = QueuedTask {
+        task_id: task.id.clone(),
+        request,
+    };
+    if state.sender.send(queued).is_err() {
         state.queue_depth.fetch_sub(1, Ordering::Relaxed);
         tracing::error!(task_id = %task.id, "task channel closed, dropping request");
         return Err(ApiError::internal("Internal error: task queue unavailable"));

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -44,9 +44,9 @@ use gas_killer_common::{
     agg_activity_timeout, agg_window, load_key_from_file, p2p_message_backlog, p2p_quota_period,
     rebroadcast_interval, round_timeout, storage_directory,
 };
-use gas_killer_router::factories::{create_ingress, create_submitter};
+use gas_killer_router::factories::{create_ingress, create_submitter, requeue_incomplete_tasks};
 use gas_killer_router::metrics::MetricsCollector;
-use gas_killer_router::sequencer::GasKillerTaskSource;
+use gas_killer_router::sequencer::{GasKillerTaskSource, in_flight_task};
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
@@ -445,7 +445,21 @@ fn main() {
         let ingress = create_ingress(Arc::clone(&metrics))
             .await
             .expect("Failed to create ingress");
+
+        // Resume work a previous router life acknowledged to a client but never
+        // finished: every task still `queued` or `processing` is rebuilt and
+        // pushed back through the same channel fresh submissions use.
+        if let Some(store) = &ingress.store {
+            requeue_incomplete_tasks(store, &ingress.sender, &ingress.queue_depth)
+                .await
+                .expect("Failed to re-enqueue incomplete tasks");
+        }
         let _task_sender = ingress.sender;
+
+        // Shared with the executor: the id of the task currently dispatched
+        // through the sequencer, so a certified height's execution result can be
+        // attributed back to its task. See `InFlightTask`.
+        let in_flight = in_flight_task();
 
         // On-chain submitter: consumes verified certificates, resolves heights.
         let submitter = create_submitter(
@@ -456,6 +470,8 @@ fn main() {
             Arc::clone(&metrics),
             Arc::clone(&dispatch_time),
             APPLICATION_NAMESPACE.to_vec(),
+            ingress.store.clone(),
+            in_flight.clone(),
         )
         .await
         .expect("Failed to create submitter");
@@ -486,6 +502,8 @@ fn main() {
             ingress.queue_depth,
             validator,
             Some(Arc::clone(&metrics)),
+            ingress.store,
+            in_flight,
         );
 
         // Sequencer: assigns heights, broadcasts directives to the operator set

--- a/router/src/sequencer.rs
+++ b/router/src/sequencer.rs
@@ -8,6 +8,7 @@
 
 use crate::ingress::GasKillerTaskRequest;
 use crate::metrics::MetricsCollector;
+use crate::store::{SqliteStore, TaskStatus};
 use commonware_avs_router::sequencer::{SequencedTask, TaskSource};
 use gas_killer_common::GasKillerValidator;
 use gas_killer_common::task_data::GasKillerTaskData;
@@ -15,14 +16,22 @@ use gas_killer_common::task_data::GasKillerTaskData;
 use alloy_primitives::Bytes;
 use anyhow::Result;
 use commonware_cryptography::{Hasher, Sha256};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, info};
 
-pub type TaskSender = UnboundedSender<GasKillerTaskRequest>;
-pub type TaskReceiver = UnboundedReceiver<GasKillerTaskRequest>;
+/// A task queued for the sequencer, carrying the persisted task id alongside the
+/// request so status transitions can be attributed back to the right store row.
+#[derive(Debug, Clone)]
+pub struct QueuedTask {
+    pub task_id: String,
+    pub request: GasKillerTaskRequest,
+}
+
+pub type TaskSender = UnboundedSender<QueuedTask>;
+pub type TaskReceiver = UnboundedReceiver<QueuedTask>;
 /// Shared atomic counter tracking tasks in flight between the ingress sender and
 /// the task source's receiver.
 pub type TaskQueueDepth = Arc<AtomicUsize>;
@@ -33,6 +42,54 @@ pub fn task_channel() -> (TaskSender, TaskReceiver) {
 
 pub fn task_queue_depth() -> TaskQueueDepth {
     Arc::new(AtomicUsize::new(0))
+}
+
+/// Id of the task currently dispatched through the sequencer (dequeued but not yet
+/// settled), shared between [`GasKillerTaskSource`] and [`crate::executor::GasKillerHandler`]
+/// so a certified height's execution result can be attributed back to its task.
+///
+/// Exactly one task is ever in flight: the upstream [`commonware_avs_router::sequencer::Sequencer`]
+/// drives one height at a time and only calls [`TaskSource::next_task`] again once the
+/// current task resolves, so a single slot suffices — no keying by height or round
+/// is needed.
+///
+/// `next_task` sets the slot when a task starts. `GasKillerHandler::handle_verification`
+/// takes it when execution settles (ready or failed) — the only path that calls
+/// `handle_verification` is a certificate carrying the task's own expected digest, so
+/// a settling execution always belongs to the task presently in the slot. If the slot
+/// is still occupied the next time `next_task` runs, the previous task's height was
+/// skipped by the quorum instead — the one path that resolves a height without ever
+/// calling `handle_verification` — and `next_task` settles it as failed.
+pub type InFlightTask = Arc<Mutex<Option<String>>>;
+
+pub fn in_flight_task() -> InFlightTask {
+    Arc::new(Mutex::new(None))
+}
+
+/// Best-effort task status bookkeeping shared by the task source and the executor. A
+/// store error is logged rather than propagated: failing to record a status
+/// transition must never derail aggregation, which is the real work — a missed
+/// transition is recoverable (the startup re-queue picks up anything left `queued`
+/// or `processing`), whereas aborting the pipeline is not.
+async fn set_task_processing(store: &SqliteStore, task_id: &str) {
+    if let Err(e) = store
+        .update_task_status(task_id, TaskStatus::Processing)
+        .await
+    {
+        error!(task_id, error = %e, "failed to mark task processing");
+    }
+}
+
+pub(crate) async fn set_task_ready(store: &SqliteStore, task_id: &str) {
+    if let Err(e) = store.update_task_status(task_id, TaskStatus::Ready).await {
+        error!(task_id, error = %e, "failed to mark task ready");
+    }
+}
+
+pub(crate) async fn set_task_failed(store: &SqliteStore, task_id: &str, reason: &str) {
+    if let Err(e) = store.mark_task_failed(task_id, reason).await {
+        error!(task_id, error = %e, "failed to mark task failed");
+    }
 }
 
 /// Enriched task data that includes computed storage updates and block height.
@@ -68,6 +125,11 @@ pub struct GasKillerTaskSource {
     queue_depth: TaskQueueDepth,
     validator: Arc<GasKillerValidator>,
     metrics: Option<Arc<MetricsCollector>>,
+    /// Durable store used to advance task status as work progresses. `None` in
+    /// store-less test/dev harnesses, where status transitions are simply skipped.
+    store: Option<SqliteStore>,
+    /// Shared with [`crate::executor::GasKillerHandler`]; see [`InFlightTask`].
+    in_flight: InFlightTask,
 }
 
 impl GasKillerTaskSource {
@@ -76,19 +138,23 @@ impl GasKillerTaskSource {
         queue_depth: TaskQueueDepth,
         validator: Arc<GasKillerValidator>,
         metrics: Option<Arc<MetricsCollector>>,
+        store: Option<SqliteStore>,
+        in_flight: InFlightTask,
     ) -> Self {
         Self {
             receiver,
             queue_depth,
             validator,
             metrics,
+            store,
+            in_flight,
         }
     }
 
     /// Blocks until a task arrives, maintaining the queue-depth metric.
     ///
     /// Returns `None` when the ingress side of the channel closed.
-    async fn wait_for_task(&mut self) -> Option<GasKillerTaskRequest> {
+    async fn wait_for_task(&mut self) -> Option<QueuedTask> {
         let task = self.receiver.recv().await?;
         let depth = self
             .queue_depth
@@ -235,18 +301,43 @@ impl GasKillerTaskSource {
     }
 }
 
+impl GasKillerTaskSource {
+    /// Settles the previous in-flight task as `failed` if the slot is still
+    /// occupied — the quorum skipped that task's height without ever reaching
+    /// `GasKillerHandler::handle_verification`. A no-op when the slot is already
+    /// empty (the common case: the previous task settled normally).
+    async fn settle_orphaned_task(&self) {
+        if let Some(store) = &self.store
+            && let Some(task_id) = self.in_flight.lock().ok().and_then(|mut slot| slot.take())
+        {
+            set_task_failed(store, &task_id, "aggregation height skipped by quorum").await;
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl TaskSource<GasKillerTaskData> for GasKillerTaskSource {
     /// Dequeues the next ingress task and enriches it. Enrichment failures are
-    /// logged and dropped; the loop keeps waiting for the next task rather than
-    /// shutting the sequencer down.
+    /// logged, settled as `failed`, and dropped; the loop keeps waiting for the
+    /// next task rather than shutting the sequencer down.
     async fn next_task(&mut self) -> Option<SequencedTask<GasKillerTaskData>> {
         loop {
-            let task = self.wait_for_task().await?;
-            let enriched = match self.enrich(task).await {
+            self.settle_orphaned_task().await;
+
+            let QueuedTask { task_id, request } = self.wait_for_task().await?;
+
+            if let Some(store) = &self.store {
+                set_task_processing(store, &task_id).await;
+            }
+
+            let enriched = match self.enrich(request).await {
                 Ok(enriched) => enriched,
                 Err(e) => {
-                    error!(error = %e, "failed to enrich task, dropping request");
+                    error!(error = %e, task_id, "failed to enrich task, dropping request");
+                    if let Some(store) = &self.store {
+                        set_task_failed(store, &task_id, &format!("task enrichment failed: {e}"))
+                            .await;
+                    }
                     continue;
                 }
             };
@@ -258,9 +349,14 @@ impl TaskSource<GasKillerTaskData> for GasKillerTaskSource {
             if let Err(e) = task_data.validate() {
                 error!(
                     error = %e,
+                    task_id,
                     target = %task_data.target_address,
                     "enriched task exceeds wire limits, dropping request"
                 );
+                if let Some(store) = &self.store {
+                    set_task_failed(store, &task_id, &format!("task exceeds wire limits: {e}"))
+                        .await;
+                }
                 continue;
             }
 
@@ -284,6 +380,12 @@ impl TaskSource<GasKillerTaskData> for GasKillerTaskSource {
                 ..task_data.clone()
             };
 
+            // Record this task as in flight so `GasKillerHandler::handle_verification`
+            // can settle it once its height executes.
+            if let Ok(mut slot) = self.in_flight.lock() {
+                *slot = Some(task_id);
+            }
+
             return Some(SequencedTask {
                 task: task_data,
                 announce,
@@ -298,23 +400,31 @@ mod tests {
     use super::*;
     use alloy::primitives::{Address, U256};
 
-    #[tokio::test]
-    async fn test_channel_send_recv() {
-        let (sender, mut receiver) = task_channel();
-        let task = GasKillerTaskRequest {
+    fn sample_request(transition_index: Option<u64>) -> GasKillerTaskRequest {
+        GasKillerTaskRequest {
             body: crate::ingress::GasKillerTaskRequestBody {
                 target_address: Address::from([1u8; 20]),
                 call_data: vec![0x12, 0x34, 0x56, 0x78],
-                transition_index: Some(1),
+                transition_index,
                 from_address: Address::from([2u8; 20]),
                 value: U256::from(1000),
                 block_height: 12345,
             },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_channel_send_recv() {
+        let (sender, mut receiver) = task_channel();
+        let queued = QueuedTask {
+            task_id: "task-1".to_string(),
+            request: sample_request(Some(1)),
         };
 
-        sender.send(task.clone()).unwrap();
+        sender.send(queued.clone()).unwrap();
         let received = receiver.try_recv().unwrap();
-        assert_eq!(received.body.transition_index, Some(1));
+        assert_eq!(received.task_id, "task-1");
+        assert_eq!(received.request.body.transition_index, Some(1));
         assert!(receiver.try_recv().is_err());
     }
 
@@ -343,5 +453,151 @@ mod tests {
         assert_eq!(task_data.transition_index, 42);
         assert_eq!(task_data.target_address, Address::from([1u8; 20]));
         assert_eq!(task_data.chain_id, 1);
+    }
+
+    // -- task lifecycle transitions --
+
+    async fn store() -> SqliteStore {
+        SqliteStore::connect_in_memory()
+            .await
+            .expect("in-memory store should open and migrate")
+    }
+
+    async fn key_id(store: &SqliteStore) -> String {
+        store
+            .create_api_key(None, None)
+            .await
+            .expect("key creation should succeed")
+            .id
+    }
+
+    fn request_body() -> crate::ingress::GasKillerTaskRequestBody {
+        crate::ingress::GasKillerTaskRequestBody {
+            target_address: Address::from([0x11; 20]),
+            call_data: vec![0x12, 0x34, 0x56, 0x78],
+            transition_index: Some(0),
+            from_address: Address::from([0x22; 20]),
+            value: U256::ZERO,
+            block_height: 1,
+        }
+    }
+
+    fn unreachable_validator() -> Arc<GasKillerValidator> {
+        // Nothing listens on this port; RPC calls fail fast with connection refused
+        // rather than hanging, so `enrich` errors quickly and deterministically.
+        Arc::new(GasKillerValidator::with_rpc_url("http://localhost:8545"))
+    }
+
+    #[tokio::test]
+    async fn set_helpers_persist_status_transitions() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let done = store.create_task(&key, &request_body()).await.unwrap();
+        let doomed = store.create_task(&key, &request_body()).await.unwrap();
+
+        set_task_processing(&store, &done.id).await;
+        assert_eq!(
+            store.get_task(&done.id).await.unwrap().unwrap().status,
+            TaskStatus::Processing
+        );
+
+        set_task_ready(&store, &done.id).await;
+        assert_eq!(
+            store.get_task(&done.id).await.unwrap().unwrap().status,
+            TaskStatus::Ready
+        );
+
+        set_task_failed(&store, &doomed.id, "boom").await;
+        let failed = store.get_task(&doomed.id).await.unwrap().unwrap();
+        assert_eq!(failed.status, TaskStatus::Failed);
+        assert_eq!(failed.error.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn settle_orphaned_task_marks_failed_and_clears_slot() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request_body()).await.unwrap();
+
+        let in_flight = in_flight_task();
+        *in_flight.lock().unwrap() = Some(task.id.clone());
+
+        let (_sender, receiver) = task_channel();
+        let source = GasKillerTaskSource::new(
+            receiver,
+            task_queue_depth(),
+            unreachable_validator(),
+            None,
+            Some(store.clone()),
+            in_flight.clone(),
+        );
+
+        source.settle_orphaned_task().await;
+
+        assert!(in_flight.lock().unwrap().is_none());
+        let settled = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(settled.status, TaskStatus::Failed);
+        assert_eq!(
+            settled.error.as_deref(),
+            Some("aggregation height skipped by quorum")
+        );
+    }
+
+    #[tokio::test]
+    async fn settle_orphaned_task_is_noop_when_slot_empty() {
+        let store = store().await;
+        let (_sender, receiver) = task_channel();
+        let source = GasKillerTaskSource::new(
+            receiver,
+            task_queue_depth(),
+            unreachable_validator(),
+            None,
+            Some(store),
+            in_flight_task(),
+        );
+
+        // Must not panic when there is nothing in flight to settle.
+        source.settle_orphaned_task().await;
+    }
+
+    #[tokio::test]
+    async fn next_task_marks_processing_then_failed_on_enrich_error() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request_body()).await.unwrap();
+
+        let (sender, receiver) = task_channel();
+        let mut source = GasKillerTaskSource::new(
+            receiver,
+            task_queue_depth(),
+            unreachable_validator(),
+            None,
+            Some(store.clone()),
+            in_flight_task(),
+        );
+
+        sender
+            .send(QueuedTask {
+                task_id: task.id.clone(),
+                request: GasKillerTaskRequest {
+                    body: request_body(),
+                },
+            })
+            .unwrap();
+        // Closing the sender lets `next_task` observe a closed channel (and return
+        // `None`) once the one queued task's enrichment fails and it loops back
+        // for the next task, instead of blocking forever.
+        drop(sender);
+
+        assert!(source.next_task().await.is_none());
+
+        let settled = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(settled.status, TaskStatus::Failed);
+        assert!(
+            settled
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("task enrichment failed"))
+        );
     }
 }

--- a/scripts/send_request.rs
+++ b/scripts/send_request.rs
@@ -168,48 +168,137 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             request.body.call_data.len(),
             selector_hex
         );
-        Err(format!("Trigger failed with status {}", status).into())
-    } else {
-        // Poll currentSum until it changes or timeout
-        use tokio::time::{Duration, Instant, sleep};
-        let max_wait_time = Duration::from_secs(150);
-        let check_interval = Duration::from_secs(10);
-        let start_time = Instant::now();
+        return Err(format!("Trigger failed with status {}", status).into());
+    }
 
-        loop {
-            let current_sum = array_contract
-                .currentSum()
-                .call()
-                .await
-                .map_err(|e| format!("Failed to read currentSum after trigger: {}", e))?
-                .to::<u64>();
+    let task_id = serde_json::from_str::<serde_json::Value>(&text)
+        .ok()
+        .and_then(|v| {
+            v.get("task_id")
+                .and_then(|t| t.as_str())
+                .map(str::to_string)
+        })
+        .ok_or("Accepted response did not carry a task_id")?;
+    let mut task_status_url = Url::parse(&url)?;
+    task_status_url.set_path(&format!("/tasks/{task_id}"));
+    let api_key = env::var("GAS_KILLER_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty());
 
+    // Poll currentSum until it changes or timeout
+    use tokio::time::{Duration, Instant, sleep};
+    let max_wait_time = Duration::from_secs(150);
+    let check_interval = Duration::from_secs(10);
+    let start_time = Instant::now();
+
+    loop {
+        let current_sum = array_contract
+            .currentSum()
+            .call()
+            .await
+            .map_err(|e| format!("Failed to read currentSum after trigger: {}", e))?
+            .to::<u64>();
+
+        println!(
+            "currentSum: {}, Initial: {}, Elapsed: {:.1}s",
+            current_sum,
+            initial_sum,
+            start_time.elapsed().as_secs_f64()
+        );
+
+        if current_sum != initial_sum {
             println!(
-                "currentSum: {}, Initial: {}, Elapsed: {:.1}s",
-                current_sum,
-                initial_sum,
-                start_time.elapsed().as_secs_f64()
+                "✅ currentSum changed from {} to {} — confirming task {} reaches 'ready'",
+                initial_sum, current_sum, task_id
             );
+            return confirm_task_ready(&client, &task_status_url, api_key.as_deref(), &task_id)
+                .await;
+        }
 
-            if current_sum != initial_sum {
-                println!(
-                    "✅ SUCCESS: currentSum changed from {} to {}",
-                    initial_sum, current_sum
-                );
+        if start_time.elapsed() >= max_wait_time {
+            println!(
+                "❌ TIMEOUT: currentSum unchanged ({}), waited {:.1} seconds",
+                current_sum,
+                max_wait_time.as_secs_f64()
+            );
+            return Err("Timeout waiting for currentSum to change".into());
+        }
+
+        sleep(check_interval).await;
+    }
+}
+
+/// Confirms `task_id` settles to `ready` shortly after `currentSum` moves,
+/// exercising the status-transition wiring (not just the on-chain effect).
+///
+/// The on-chain confirmation and the `ready` write happen back-to-back inside the
+/// same `handle_verification` call (see `router/src/executor.rs`), so this is a
+/// short, bounded follow-up poll — not another long wait for a fresh aggregation
+/// round.
+async fn confirm_task_ready(
+    client: &reqwest::Client,
+    task_status_url: &Url,
+    api_key: Option<&str>,
+    task_id: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use tokio::time::{Duration, Instant, sleep};
+    let max_wait_time = Duration::from_secs(60);
+    let check_interval = Duration::from_secs(5);
+    let start_time = Instant::now();
+
+    loop {
+        let mut req = client.get(task_status_url.clone());
+        if let Some(api_key) = api_key {
+            req = req.header("Authorization", format!("Bearer {api_key}"));
+        }
+        let body: serde_json::Value = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to poll task {}: {}", task_id, e))?
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse task {} response: {}", task_id, e))?;
+        let task_status = body
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        println!(
+            "task {}: status={}, elapsed={:.1}s",
+            task_id,
+            task_status,
+            start_time.elapsed().as_secs_f64()
+        );
+
+        match task_status.as_str() {
+            "ready" => {
+                println!("✅ SUCCESS: task {} reached 'ready'", task_id);
                 return Ok(());
             }
-
-            if start_time.elapsed() >= max_wait_time {
-                println!(
-                    "❌ TIMEOUT: currentSum unchanged ({}), waited {:.1} seconds",
-                    current_sum,
-                    max_wait_time.as_secs_f64()
+            "failed" | "expired" => {
+                let error = body
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("<no error recorded>");
+                return Err(
+                    format!("Task {} settled as '{}': {}", task_id, task_status, error).into(),
                 );
-                return Err("Timeout waiting for currentSum to change".into());
             }
-
-            sleep(check_interval).await;
+            _ => {}
         }
+
+        if start_time.elapsed() >= max_wait_time {
+            return Err(format!(
+                "Task {} did not reach 'ready' within {:.0}s of currentSum changing (last status: {})",
+                task_id,
+                max_wait_time.as_secs_f64(),
+                task_status
+            )
+            .into());
+        }
+
+        sleep(check_interval).await;
     }
 }
 


### PR DESCRIPTION
## Summary

Closes gas-killer/service#308. Progresses gas-killer/service#194 — until now, an accepted task stayed `queued` forever, since nothing threaded the task id into the aggregation pipeline or reported back how it settled.

**Not a straight rebase of #308's original branch.** `bagelface/task-lifecycle-transitions` (the branch #308 was originally scoped against) targeted the pre-migration `Creator`/`ListeningGasKillerCreator`/`BlsEigenlayerExecutor` pattern, which `task-lifecycle-refactor` has since replaced with the `commonware-consensus` aggregation engine (`sequencer.rs` + a rewritten `executor.rs`; `creator.rs`/`builder.rs` are gone). This PR re-implements the same intent — thread a task id through dispatch, mark `processing` on dequeue, settle `ready`/`failed` when the work resolves — against the new sequencer/engine model instead.

## What changed

- **`QueuedTask { task_id, request }`** replaces the bare `GasKillerTaskRequest` on the ingress channel, so `submit_task_handler` hands the task id all the way down to the sequencer.
- **`InFlightTask`** (`router/src/sequencer.rs`) — a single shared slot holding the currently-dispatched task's id, in place of the old round-keyed `HashMap`. The new `Sequencer` (in `commonware-avs-router`) drives exactly one height at a time and only calls `TaskSource::next_task` again once the current task resolves, so a single slot suffices:
  - `next_task` sets the slot when a task starts.
  - `GasKillerHandler::handle_verification` takes it when a certified height executes, settling `ready` (success) or `failed` (with the execution error).
  - If the slot is still occupied the *next* time `next_task` runs, the previous task's height was skipped by the quorum — the one path that resolves a height without ever calling `handle_verification` — so `next_task` settles it as `failed` before starting the next task.
- Enrichment failures (`enrich` erroring, or the enriched task failing `validate()`) now settle the task `failed` with the specific reason instead of just logging and dropping it.
- **Startup re-queue** (`factories::requeue_incomplete_tasks`) — `IngressHandles` now exposes the opened store; on boot, before the sequencer starts, every task left `queued`/`processing` by a previous router life is rebuilt from its persisted request and pushed back through the same channel a fresh `POST /tasks` uses, so it's indistinguishable from new work.

## Scope

Status transitions and restart recovery only. A `ready` task's `payload` stays `null` — the interactive tier submits on-chain itself and carries no user-executable payload yet, which is gas-killer/service#195's job. `expired` is intentionally untouched; that's TTL/sweep work tracked separately in gas-killer/service#196.

## Testing

- `sequencer.rs`: helper persistence (`processing`/`ready`/`failed`), orphaned-slot detection (settles failed, clears slot, no-ops when empty), and an end-to-end `next_task` case (dequeue → mark processing → enrichment fails against an unreachable RPC → mark failed).
- `executor.rs`: `handle_verification` settles the in-flight task failed when execution errors (forced via `task_data: None`, which fails before touching any provider) and clears the slot; no-ops safely when nothing is in flight.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), and `cargo test --all-targets --all-features` all pass across the workspace (136 router tests, full workspace green).