### PR TITLE
feat: user-executable payload output (replace on-chain execution)

### DIFF
--- a/.github/workflows/helm-integration-tests.yml
+++ b/.github/workflows/helm-integration-tests.yml
@@ -572,6 +572,9 @@ jobs:
         # The yield distributor is a BLS-interface GasKillerSDK target; the schnorr
         # router only drives SchnorrGasKillerSDK targets, so this l2 subsystem runs
         # in the bls leg only (it is disabled at helm-install time for schnorr).
+        #
+        # This step mirrors what an integrator does: poll the task to `ready`, fetch the
+        # rendered payload, submit it with a funded key, then assert the on-chain effect.
         if: matrix.signature_scheme == 'bls'
         run: |
           echo "=== Triggering Yield Distribution through router ==="
@@ -584,13 +587,12 @@ jobs:
           fi
           L2_RPC="http://localhost:8546"
           ROUTER_URL="http://localhost:8080"
+          # Anvil dev account #0 (funded on the l1 and l2 forks): the account that signs and
+          # submits the router-rendered payload.
+          SUBMIT_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
-          # Capture router state before trigger
-          echo "=== Router pod status before trigger ==="
-          kubectl get pods -l app.kubernetes.io/component=router -o wide
           ROUTER_POD=$(kubectl get pods -l app.kubernetes.io/component=router -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
           echo "Router pod: $ROUTER_POD"
-          echo "Restart count: $(kubectl get pod $ROUTER_POD -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo unknown)"
           echo "=== Router logs before trigger (last 50 lines) ==="
           kubectl logs $ROUTER_POD --tail=50 || true
 
@@ -604,11 +606,9 @@ jobs:
           RESOLVER=$(cast call --rpc-url "$L2_RPC" "$YIELD_DISTRIBUTOR" "resolveYieldDistribution()(bool,bytes)" 2>&1)
           echo "resolveYieldDistribution: $RESOLVER"
 
-          # Build distributeYieldGK() calldata
+          # Build distributeYieldGK() calldata, converted to a JSON byte array for the task request.
           CALL_DATA=$(cast calldata "distributeYieldGK()")
           echo "Calldata: $CALL_DATA"
-
-          # Convert calldata hex to JSON byte array
           CALL_DATA_HEX="${CALL_DATA#0x}"
           BYTES_ARRAY="["
           for ((i=0; i<${#CALL_DATA_HEX}; i+=2)); do
@@ -617,7 +617,7 @@ jobs:
           done
           BYTES_ARRAY+="]"
 
-          # Build and send trigger payload
+          # Submit the task to the router
           PAYLOAD="{\"body\":{\"target_address\":\"$YIELD_DISTRIBUTOR\",\"call_data\":$BYTES_ARRAY,\"transition_index\":$INITIAL_COUNT,\"from_address\":\"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\",\"value\":\"0\",\"block_height\":$BLOCK}}"
           echo "Payload: $PAYLOAD"
 
@@ -633,29 +633,52 @@ jobs:
             exit 1
           fi
 
-          # Capture logs periodically during the wait to catch crashes
-          echo "Waiting 300s for BLS aggregation and on-chain execution..."
-          for i in 30 60 90 120 150 180 210 240 270 300; do
-            sleep 30
-            echo ""
-            echo "=== ${i}s checkpoint ==="
-            RESTART_COUNT=$(kubectl get pod $ROUTER_POD -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo unknown)
-            PHASE=$(kubectl get pod $ROUTER_POD -o jsonpath='{.status.phase}' 2>/dev/null || echo unknown)
-            echo "Router pod phase: $PHASE, restart count: $RESTART_COUNT"
-            if [ "$RESTART_COUNT" != "0" ] && [ "$RESTART_COUNT" != "unknown" ]; then
-              echo "=== ROUTER RESTARTED! Previous container logs (last 200 lines): ==="
-              kubectl logs $ROUTER_POD --previous --tail=200 2>/dev/null || echo "No previous logs available"
-              echo "=== Current container logs (after restart): ==="
-              kubectl logs $ROUTER_POD --tail=100 2>/dev/null || true
-            fi
+          TASK_ID=$(echo "$BODY" | jq -r '.task_id // empty' 2>/dev/null || echo "")
+          if [ -z "$TASK_ID" ]; then
+            echo "Trigger response carried no task_id"
+            exit 1
+          fi
+          echo "Task id: $TASK_ID"
+
+          # Poll the task until the router renders its payload (or it fails), up to 300s.
+          echo "Waiting for BLS aggregation to render the payload..."
+          READY_TASK=""
+          for i in $(seq 1 60); do
+            sleep 5
+            TASK=$(curl -s -H "Authorization: Bearer $GAS_KILLER_API_KEY" "$ROUTER_URL/tasks/$TASK_ID")
+            STATUS=$(echo "$TASK" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+            echo "  [$((i * 5))s] task status: $STATUS"
+            case "$STATUS" in
+              ready)
+                READY_TASK="$TASK"
+                break
+                ;;
+              failed|expired)
+                echo "Task settled as '$STATUS': $(echo "$TASK" | jq -r '.error // "<none>"' 2>/dev/null)"
+                kubectl logs $ROUTER_POD --tail=100 2>/dev/null || true
+                exit 1
+                ;;
+            esac
           done
 
-          # Final state
-          echo ""
-          echo "=== Final router state ==="
-          kubectl get pods -l app.kubernetes.io/component=router -o wide
-          FINAL_RESTART=$(kubectl get pod $ROUTER_POD -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo unknown)
-          echo "Final restart count: $FINAL_RESTART"
+          if [ -z "$READY_TASK" ]; then
+            echo "=== YIELD DISTRIBUTION TRIGGER FAILED ==="
+            echo "Task $TASK_ID did not reach 'ready' within 300s"
+            kubectl logs $ROUTER_POD --tail=100 2>/dev/null || true
+            kubectl logs -l gas-killer/node-index=1 -c node --tail 50 || true
+            exit 1
+          fi
+
+          # Submit the rendered payload ourselves (to/data are server-controlled).
+          TO=$(echo "$READY_TASK" | jq -r '.payload.to' 2>/dev/null || echo "")
+          DATA=$(echo "$READY_TASK" | jq -r '.payload.data' 2>/dev/null || echo "")
+          echo "Submitting rendered verifyAndUpdate to $TO on L2..."
+          if ! cast send "$TO" "$DATA" --private-key "$SUBMIT_KEY" --rpc-url "$L2_RPC"; then
+            echo "=== YIELD DISTRIBUTION TRIGGER FAILED ==="
+            echo "verifyAndUpdate submission failed"
+            kubectl logs $ROUTER_POD --tail=100 2>/dev/null || true
+            exit 1
+          fi
 
           # Verify stateTransitionCount increased
           FINAL_COUNT=$(cast call --rpc-url "$L2_RPC" "$YIELD_DISTRIBUTOR" "stateTransitionCount()(uint256)" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || echo "0")
@@ -670,9 +693,6 @@ jobs:
             echo ""
             echo "=== Router logs (last 100) ==="
             kubectl logs $ROUTER_POD --tail=100 2>/dev/null || true
-            echo ""
-            echo "=== Previous container logs (if restarted, last 200) ==="
-            kubectl logs $ROUTER_POD --previous --tail=200 2>/dev/null || echo "No previous container logs"
             echo ""
             echo "=== Node-1 logs (last 50) ==="
             kubectl logs -l gas-killer/node-index=1 -c node --tail 50 || true

--- a/.github/workflows/helm-integration-tests.yml
+++ b/.github/workflows/helm-integration-tests.yml
@@ -643,11 +643,18 @@ jobs:
           # Poll the task until the router renders its payload (or it fails), up to 300s.
           echo "Waiting for BLS aggregation to render the payload..."
           READY_TASK=""
+          DUMPED_UNKNOWN=0
           for i in $(seq 1 60); do
             sleep 5
             TASK=$(curl -s -H "Authorization: Bearer $GAS_KILLER_API_KEY" "$ROUTER_URL/tasks/$TASK_ID")
             STATUS=$(echo "$TASK" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
             echo "  [$((i * 5))s] task status: $STATUS"
+            # Surface the raw response once if it isn't a recognizable task view (e.g. an error
+            # envelope), so an unexpected status query result is diagnosable from the log.
+            if [ "$STATUS" = "unknown" ] && [ "$DUMPED_UNKNOWN" = "0" ]; then
+              echo "  raw status response: $TASK"
+              DUMPED_UNKNOWN=1
+            fi
             case "$STATUS" in
               ready)
                 READY_TASK="$TASK"

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -521,19 +521,27 @@ pub const DEFAULT_PAYLOAD_BLOCK_BUFFER: u64 = 50;
 const _: () = assert!(DEFAULT_PAYLOAD_BLOCK_BUFFER <= DEFAULT_BLOCK_STALE_MEASURE);
 
 /// Reads the payload validity buffer from `PAYLOAD_BLOCK_BUFFER`, defaulting to
-/// [`DEFAULT_PAYLOAD_BLOCK_BUFFER`].
+/// [`DEFAULT_PAYLOAD_BLOCK_BUFFER`] and clamped to [`block_stale_measure`].
 ///
-/// Must stay within the contract's operator-set window: on-chain, `verifyAndUpdate` requires
-/// `referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number`, so a payload rendered against a
-/// reference block only remains submittable for `BLOCK_STALE_MEASURE` blocks. Keeping the buffer
-/// `<= block_stale_measure()` guarantees `valid_until_block` never promises a payload past the
-/// point the chain would reject it.
+/// On-chain, `verifyAndUpdate` requires `referenceBlockNumber + BLOCK_STALE_MEASURE >=
+/// block.number`, so a payload rendered against a reference block only remains submittable for
+/// `BLOCK_STALE_MEASURE` blocks. Clamping guarantees `valid_until_block` never promises a payload
+/// past the point the chain would reject it, under any env — not just the defaults the
+/// compile-time assertion covers.
 pub fn payload_block_buffer() -> u64 {
-    env::var("PAYLOAD_BLOCK_BUFFER")
+    let requested = env::var("PAYLOAD_BLOCK_BUFFER")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|&v| v > 0)
-        .unwrap_or(DEFAULT_PAYLOAD_BLOCK_BUFFER)
+        .unwrap_or(DEFAULT_PAYLOAD_BLOCK_BUFFER);
+    clamp_payload_block_buffer(requested, block_stale_measure())
+}
+
+/// Clamps a requested payload buffer to the on-chain staleness window. A buffer past
+/// `stale_measure` would set `valid_until_block` beyond the block at which `verifyAndUpdate`
+/// reverts `StaleBlockNumber`, so the freshness gate would serve a payload that cannot land.
+fn clamp_payload_block_buffer(requested: u64, stale_measure: u64) -> u64 {
+    requested.min(stale_measure)
 }
 
 /// Runtime configuration for the speculative executor pre-build loop.
@@ -758,5 +766,15 @@ mod tests {
         assert_eq!(DEFAULT_PAYLOAD_BLOCK_BUFFER, 50);
         // The buffer-within-staleness-window invariant is enforced at compile time next to the
         // constant definitions (`const _: () = assert!(...)`).
+    }
+
+    #[test]
+    fn payload_block_buffer_clamps_to_staleness_window() {
+        // A buffer within the window is returned unchanged.
+        assert_eq!(clamp_payload_block_buffer(50, 300), 50);
+        // A buffer past the window is clamped so `valid_until_block` never exceeds the block at
+        // which `verifyAndUpdate` would revert `StaleBlockNumber`.
+        assert_eq!(clamp_payload_block_buffer(500, 300), 300);
+        assert_eq!(clamp_payload_block_buffer(300, 300), 300);
     }
 }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -510,6 +510,32 @@ pub fn block_stale_measure() -> u64 {
         .unwrap_or(DEFAULT_BLOCK_STALE_MEASURE)
 }
 
+/// Grace window, in blocks past the aggregation reference block, for which a rendered
+/// user-executable payload stays valid. Used to set the payload's `valid_until_block`.
+pub const DEFAULT_PAYLOAD_BLOCK_BUFFER: u64 = 50;
+
+// A payload rendered against a reference block is only submittable while
+// `referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number`, so the default buffer must stay
+// within the default staleness window or `valid_until_block` would promise a payload the chain
+// already rejects. Enforced at compile time to keep the two defaults in lockstep.
+const _: () = assert!(DEFAULT_PAYLOAD_BLOCK_BUFFER <= DEFAULT_BLOCK_STALE_MEASURE);
+
+/// Reads the payload validity buffer from `PAYLOAD_BLOCK_BUFFER`, defaulting to
+/// [`DEFAULT_PAYLOAD_BLOCK_BUFFER`].
+///
+/// Must stay within the contract's operator-set window: on-chain, `verifyAndUpdate` requires
+/// `referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number`, so a payload rendered against a
+/// reference block only remains submittable for `BLOCK_STALE_MEASURE` blocks. Keeping the buffer
+/// `<= block_stale_measure()` guarantees `valid_until_block` never promises a payload past the
+/// point the chain would reject it.
+pub fn payload_block_buffer() -> u64 {
+    env::var("PAYLOAD_BLOCK_BUFFER")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_PAYLOAD_BLOCK_BUFFER)
+}
+
 /// Runtime configuration for the speculative executor pre-build loop.
 ///
 /// The loop watches each chain's head and pre-builds the EVMSketch executor for the
@@ -725,5 +751,12 @@ mod tests {
         assert_eq!(DEFAULT_AGG_ACTIVITY_TIMEOUT, 256);
         // The default window must construct the NonZeroU64 the engine config needs.
         assert_eq!(agg_window().get(), DEFAULT_AGG_WINDOW);
+    }
+
+    #[test]
+    fn payload_block_buffer_defaults_are_sane() {
+        assert_eq!(DEFAULT_PAYLOAD_BLOCK_BUFFER, 50);
+        // The buffer-within-staleness-window invariant is enforced at compile time next to the
+        // constant definitions (`const _: () = assert!(...)`).
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bindings;
 pub mod config;
+pub mod payload;
 pub mod providers;
 pub mod schnorr;
 pub mod task_data;
@@ -7,13 +8,14 @@ pub mod validator;
 
 // Re-export commonly used types
 pub use config::{
-    ChainRole, KeyConfig, OrchestratorConfig, SignatureScheme, SpeculativePrebuildConfig,
-    ack_messages_per_second, agg_activity_timeout, agg_window, block_stale_measure,
-    detect_chain_for_address, get_operator_states, load_key_from_file, load_orchestrator_config,
-    p2p_message_backlog, p2p_quota_period, quorum_threshold_fraction, rebroadcast_interval,
-    round_timeout, schnorr_messages_per_second, schnorr_stage_timeout, signature_scheme,
-    storage_directory,
+    ChainRole, DEFAULT_PAYLOAD_BLOCK_BUFFER, KeyConfig, OrchestratorConfig, SignatureScheme,
+    SpeculativePrebuildConfig, ack_messages_per_second, agg_activity_timeout, agg_window,
+    block_stale_measure, detect_chain_for_address, get_operator_states, load_key_from_file,
+    load_orchestrator_config, p2p_message_backlog, p2p_quota_period, payload_block_buffer,
+    quorum_threshold_fraction, rebroadcast_interval, round_timeout, schnorr_messages_per_second,
+    schnorr_stage_timeout, signature_scheme, storage_directory,
 };
+pub use payload::{BundleProof, PayloadView, TaskBundle};
 pub use providers::{build_read_providers, chain_rpc_urls_from_env};
 pub use task_data::GasKillerTaskData;
 pub use validator::{GasKillerValidator, ValidatorMetrics};

--- a/common/src/payload.rs
+++ b/common/src/payload.rs
@@ -1,0 +1,171 @@
+//! Wire types for the user-executable payload flow.
+//!
+//! When an aggregation round completes, the router persists the round as a [`TaskBundle`] — the
+//! structured `verifyAndUpdate` argument components — and renders a [`PayloadView`], a
+//! ready-to-sign transaction request the user submits themselves. The bundle is the durable
+//! unit: the payload is one rendering of it, so the retained on-chain broadcast path (future
+//! auto-execute / AA tier) can consume the same bundle to submit the transaction directly.
+
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, U256};
+use serde::{Deserialize, Serialize};
+
+/// A ready-to-sign transaction request returned by `GET /tasks/{id}` once a task is ready.
+///
+/// The caller signs and submits it as-is. `to` and `value` are server-controlled rather than
+/// bare `verifyAndUpdate` calldata, so introducing an on-chain protocol fee (a payable target or
+/// a routing entrypoint) changes the server output, never the integrator's client code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PayloadView {
+    /// Contract the transaction is sent to (the gas-killer target in beta).
+    pub to: Address,
+    /// Full ABI-encoded `verifyAndUpdate` calldata (selector + arguments).
+    pub data: Bytes,
+    /// Wei sent with the transaction. Zero in beta; `verifyAndUpdate` is not payable.
+    pub value: U256,
+    /// Numeric EVM chain id the transaction must be submitted to.
+    pub chain_id: u64,
+    /// `eth_estimateGas` result for the rendered call, provided as a submission hint.
+    pub estimated_gas: u64,
+    /// Last block for which the payload is accepted on-chain; past it the caller re-requests.
+    pub valid_until_block: u64,
+}
+
+/// Scheme-specific quorum proof carried by a [`TaskBundle`].
+///
+/// The outer transaction request is scheme-agnostic; only the encoded proof — and therefore the
+/// `verifyAndUpdate` calldata — differs between BLS and Schnorr.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "scheme", rename_all = "snake_case")]
+pub enum BundleProof {
+    /// BLS aggregate proof.
+    Bls {
+        /// Quorum numbers the certificate covers.
+        quorum_numbers: Bytes,
+        /// ABI-encoded `GasKillerSDK` `NonSignerStakesAndSignature` struct.
+        non_signer_stakes_and_signature: Bytes,
+    },
+    /// Aggregate-Schnorr proof.
+    Schnorr {
+        /// Aggregate signature scalar.
+        s: U256,
+        /// Aggregate nonce commitment address.
+        r_addr: Address,
+        /// Non-signing operator addresses, strictly ascending.
+        non_signers: Vec<Address>,
+    },
+}
+
+/// A completed aggregation round, persisted keyed by task id.
+///
+/// Holds every `verifyAndUpdate` argument component plus the chain, transition index, and
+/// validity bound needed to render a [`PayloadView`] and to check freshness on read without
+/// re-deriving anything.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBundle {
+    /// Quorum-signed payload hash.
+    pub msg_hash: B256,
+    /// Operator-set reference block the certificate is anchored to.
+    pub reference_block_number: u32,
+    /// State transition index this round advances.
+    pub transition_index: u64,
+    /// Gas-killer target contract.
+    pub target_address: Address,
+    /// Selector of the target function being optimized.
+    pub target_function: FixedBytes<4>,
+    /// EVMSketch storage updates to apply.
+    pub storage_updates: Bytes,
+    /// Numeric EVM chain id.
+    pub chain_id: u64,
+    /// Wei to send with the rendered transaction (zero in beta).
+    pub value: U256,
+    /// Last block for which the rendered payload stays valid.
+    pub valid_until_block: u64,
+    /// Scheme-specific proof material.
+    pub proof: BundleProof,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_payload() -> PayloadView {
+        PayloadView {
+            to: Address::from([0x11; 20]),
+            data: Bytes::from(vec![0x93, 0xde, 0x45, 0x31, 0x01, 0x02]),
+            value: U256::ZERO,
+            chain_id: 1,
+            estimated_gas: 234_000,
+            valid_until_block: 22_345_678,
+        }
+    }
+
+    #[test]
+    fn payload_view_serde_round_trip_and_wire_shape() {
+        let payload = sample_payload();
+        let json = serde_json::to_value(&payload).unwrap();
+
+        // `to`/`data`/`value` are 0x-hex strings; the scalars are plain JSON numbers. This is the
+        // wire contract integrators depend on (matches the issue's payload example).
+        assert_eq!(
+            json["to"].as_str().unwrap(),
+            "0x1111111111111111111111111111111111111111"
+        );
+        assert_eq!(json["data"].as_str().unwrap(), "0x93de45310102");
+        assert_eq!(json["value"].as_str().unwrap(), "0x0");
+        assert_eq!(json["chain_id"], 1);
+        assert_eq!(json["estimated_gas"], 234_000);
+        assert_eq!(json["valid_until_block"], 22_345_678u64);
+
+        let decoded: PayloadView = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn bundle_bls_round_trips_and_tags_scheme() {
+        let bundle = TaskBundle {
+            msg_hash: B256::from([0xab; 32]),
+            reference_block_number: 100,
+            transition_index: 7,
+            target_address: Address::from([0x22; 20]),
+            target_function: FixedBytes::<4>::from([0xde, 0xad, 0xbe, 0xef]),
+            storage_updates: Bytes::from(vec![0x01, 0x02, 0x03]),
+            chain_id: 31337,
+            value: U256::ZERO,
+            valid_until_block: 150,
+            proof: BundleProof::Bls {
+                quorum_numbers: Bytes::from(vec![0x00]),
+                non_signer_stakes_and_signature: Bytes::from(vec![0xff, 0xee]),
+            },
+        };
+        let json = serde_json::to_value(&bundle).unwrap();
+        assert_eq!(json["proof"]["scheme"], "bls");
+
+        let decoded: TaskBundle = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, bundle);
+    }
+
+    #[test]
+    fn bundle_schnorr_round_trips_and_tags_scheme() {
+        let bundle = TaskBundle {
+            msg_hash: B256::from([0xcd; 32]),
+            reference_block_number: 200,
+            transition_index: 3,
+            target_address: Address::from([0x33; 20]),
+            target_function: FixedBytes::<4>::from([0x01, 0x02, 0x03, 0x04]),
+            storage_updates: Bytes::from(vec![0x09]),
+            chain_id: 1,
+            value: U256::ZERO,
+            valid_until_block: 250,
+            proof: BundleProof::Schnorr {
+                s: U256::from(42u64),
+                r_addr: Address::from([0x44; 20]),
+                non_signers: vec![Address::from([0x55; 20]), Address::from([0x66; 20])],
+            },
+        };
+        let json = serde_json::to_value(&bundle).unwrap();
+        assert_eq!(json["proof"]["scheme"], "schnorr");
+
+        let decoded: TaskBundle = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, bundle);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,8 @@ services:
       # Defaults to a fixed value for the local/e2e harness; override by exporting ADMIN_KEY.
       - ADMIN_KEY=${ADMIN_KEY:-ci-admin-key}
       - SIGNATURE_SCHEME=${SIGNATURE_SCHEME:-bls}
+      # Blocks past the reference block for which a rendered task payload stays valid.
+      - PAYLOAD_BLOCK_BUFFER=${PAYLOAD_BLOCK_BUFFER:-50}
     volumes:
       - ./config/.nodes:/app/.nodes:ro
       - ./config/router_orchestrator.dev.json:/app/router_orchestrator.json:ro

--- a/example.env
+++ b/example.env
@@ -166,10 +166,15 @@ BLOCK_STALE_MEASURE=300
 
 # PAYLOAD_BLOCK_BUFFER: blocks past the aggregation reference block for which a completed task's
 # rendered, user-signable payload stays valid (its valid_until_block). Past this, GET /tasks/{id}
-# returns a PAYLOAD_EXPIRED re-request error instead of calldata that would revert on-chain. Must
-# be <= BLOCK_STALE_MEASURE (a payload is only submittable while referenceBlockNumber +
-# BLOCK_STALE_MEASURE >= block.number). Default: 50.
+# returns a PAYLOAD_EXPIRED re-request error instead of calldata that would revert on-chain. A
+# payload is only submittable while referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number, so
+# values above BLOCK_STALE_MEASURE are clamped to it. Default: 50.
 # PAYLOAD_BLOCK_BUFFER=50
+#
+# The GET /tasks/{id} block-window freshness check measures valid_until_block against the L1 chain
+# (HTTP_RPC), where the operator-set reference block lives. An L2-only deployment (no HTTP_RPC)
+# skips that check and relies on the target's stateTransitionCount plus the on-chain staleness
+# revert; configure an L1 provider so a stale payload is caught as a 409 before submission.
 
 # Speculative executor pre-build: the node/router watch each chain's head and pre-build the
 # EVMSketch executor for the latest block so a task's first validation hits the cache instead

--- a/example.env
+++ b/example.env
@@ -164,6 +164,13 @@ QUORUM_THRESHOLD=2
 THRESHOLD_DENOMINATOR=3
 BLOCK_STALE_MEASURE=300
 
+# PAYLOAD_BLOCK_BUFFER: blocks past the aggregation reference block for which a completed task's
+# rendered, user-signable payload stays valid (its valid_until_block). Past this, GET /tasks/{id}
+# returns a PAYLOAD_EXPIRED re-request error instead of calldata that would revert on-chain. Must
+# be <= BLOCK_STALE_MEASURE (a payload is only submittable while referenceBlockNumber +
+# BLOCK_STALE_MEASURE >= block.number). Default: 50.
+# PAYLOAD_BLOCK_BUFFER=50
+
 # Speculative executor pre-build: the node/router watch each chain's head and pre-build the
 # EVMSketch executor for the latest block so a task's first validation hits the cache instead
 # of paying the ~80-120 ms build() on the critical path. The cached executor only feeds the

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -341,6 +341,8 @@ spec:
             - name: EXECUTOR_RECEIPT_TIMEOUT_SECS
               value: {{ .Values.router.receiptTimeoutSecs | quote }}
             {{- end }}
+            - name: PAYLOAD_BLOCK_BUFFER
+              value: {{ .Values.router.payloadBlockBuffer | quote }}
             - name: HEALTHZ_PORT
               value: {{ .Values.router.healthzPort | quote }}
             - name: P2P_MESSAGE_BACKLOG

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -326,6 +326,10 @@ router:
   # under L1 mempool congestion or RPC degradation. Leave empty to use the per-chain
   # defaults baked into the router (L1: 120s, L2: 30s).
   receiptTimeoutSecs: ""
+  # Blocks past the aggregation reference block for which a completed task's rendered,
+  # user-signable payload stays valid (its valid_until_block). Must be <= BLOCK_STALE_MEASURE
+  # so a payload never outlives the contract's operator-set window.
+  payloadBlockBuffer: "50"
   ingress:
     enabled: true
     # IMPORTANT: Must be quoted string to prevent YAML from converting to scientific notation.

--- a/router/migrations/0003_task_bundle.sql
+++ b/router/migrations/0003_task_bundle.sql
@@ -1,0 +1,10 @@
+-- Structured record of a completed aggregation round, stored as JSON alongside the rendered
+-- transaction-request `payload`.
+--
+-- The `payload` column holds the ready-to-sign transaction request the user submits; `bundle`
+-- holds the underlying `verifyAndUpdate` argument components (msg hash, quorum/proof material,
+-- reference block, storage updates, transition index, chain id, validity bound). Keeping the
+-- bundle as the durable unit lets the read path check freshness without re-deriving anything and
+-- lets the retained broadcast path (future auto-execute / AA tier) submit the same round directly.
+-- NULL until the task settles `ready`.
+ALTER TABLE tasks ADD COLUMN bundle TEXT;

--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -34,6 +34,9 @@ pub enum ErrorCode {
     StaleBlock,
     /// The provided `transition_index` does not match the contract's current state.
     TransitionMismatch,
+    /// A previously rendered `ready` payload is no longer submittable — its `valid_until_block`
+    /// has passed or the on-chain transition index has advanced — so the caller must re-request.
+    PayloadExpired,
     /// `call_data` exceeds the maximum accepted size.
     CalldataTooLarge,
     /// The client exceeded its allotted request rate.
@@ -113,6 +116,13 @@ impl ApiError {
     /// 404 with [`ErrorCode::NotFound`].
     pub fn not_found(message: impl Into<String>) -> Self {
         Self::new(StatusCode::NOT_FOUND, ErrorCode::NotFound, message)
+    }
+
+    /// 409 with [`ErrorCode::PayloadExpired`]. Signals that a `ready` payload has gone stale and
+    /// the caller must re-request; 409 (not 410) because the task still exists and the resolution
+    /// is to submit a fresh request, not that the resource is permanently gone.
+    pub fn payload_expired(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::CONFLICT, ErrorCode::PayloadExpired, message)
     }
 
     /// 503 with [`ErrorCode::QueueFull`].
@@ -209,6 +219,7 @@ mod tests {
             (ErrorCode::InvalidAddress, "INVALID_ADDRESS"),
             (ErrorCode::StaleBlock, "STALE_BLOCK"),
             (ErrorCode::TransitionMismatch, "TRANSITION_MISMATCH"),
+            (ErrorCode::PayloadExpired, "PAYLOAD_EXPIRED"),
             (ErrorCode::CalldataTooLarge, "CALLDATA_TOO_LARGE"),
             (ErrorCode::RateLimited, "RATE_LIMITED"),
             (ErrorCode::QueueFull, "QUEUE_FULL"),
@@ -244,6 +255,13 @@ mod tests {
             parsed.error.message,
             "expected transition_index 42, contract reports 43"
         );
+    }
+
+    #[test]
+    fn payload_expired_carries_conflict_status() {
+        let err = ApiError::payload_expired("valid_until_block 100 passed; re-request");
+        assert_eq!(err.status, StatusCode::CONFLICT);
+        assert_eq!(err.code, ErrorCode::PayloadExpired);
     }
 
     #[test]

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -31,8 +31,12 @@ const DEFAULT_RECEIPT_TIMEOUT_L2_SECS: u64 = 30;
 
 /// Gas estimate recorded in a rendered payload when `eth_estimateGas` fails. It is advisory —
 /// the user re-fills gas when submitting — so a transient RPC failure still yields a submittable
-/// payload rather than failing an already-completed round.
-const PAYLOAD_GAS_ESTIMATE_FALLBACK: u64 = 3_000_000;
+/// payload rather than failing an already-completed round. Sized as a generous ceiling that clears
+/// a real `verifyAndUpdate` (signature verification plus a large batched state transition) so a
+/// caller that submits it verbatim as the gas limit does not run out of gas; it stays well under
+/// the block gas limit, and unused gas is refunded, so over-provisioning costs the submitter
+/// nothing.
+const PAYLOAD_GAS_ESTIMATE_FALLBACK: u64 = 10_000_000;
 
 /// Rebuilds the operator-state-retriever `NonSignerStakesAndSignature` into the distinct
 /// `GasKillerSDK` binding type. Each `sol!` invocation mints its own Rust type, so the fields

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -68,8 +68,8 @@ fn reshape_non_signer(
 
 /// The [`ExecutionResult`] a completion handler returns for a rendered (non-broadcast) round.
 ///
-/// The v1-beta completion path persists the payload/bundle rather than submitting a transaction,
-/// so there is no receipt to report; the submitter only needs an `Ok` to mark the height settled.
+/// A rendered round persists the payload/bundle and submits no transaction, so there is no
+/// receipt to report; the submitter only needs an `Ok` to mark the height settled.
 fn rendered_execution_result() -> ExecutionResult {
     ExecutionResult {
         transaction_hash: String::new(),
@@ -408,11 +408,11 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
     /// Broadcasts a BLS `verifyAndUpdate` on-chain from the router's funded wallet and waits for
     /// the receipt.
     ///
-    /// This is the **auto-execute** path, retained as the entry point for the future
-    /// per-API-key auto-execute / account-abstraction tier that submits the round on the user's
-    /// behalf. The v1-beta completion path renders a user-signed payload via
-    /// [`Self::render_bls_payload`] instead of calling this; both share [`Self::prepare_bls`], so
-    /// switching between them later is a localized branch.
+    /// This is the **auto-execute** path: the entry point for the per-API-key auto-execute /
+    /// account-abstraction tier that submits the round on the user's behalf. The completion
+    /// handler renders a user-signed payload via [`Self::render_bls_payload`]; both share
+    /// [`Self::prepare_bls`], so a per-key branch between rendering and broadcasting stays
+    /// localized.
     pub async fn execute_verification(
         &mut self,
         msg_hash: FixedBytes<32>,
@@ -736,10 +736,10 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         })
     }
 
-    /// Schnorr twin of [`Self::execute_verification`] — the **auto-execute** broadcast path,
-    /// retained for the future per-API-key auto-execute / account-abstraction tier. The v1-beta
-    /// completion path renders a user-signed payload via [`Self::render_schnorr_payload`]
-    /// instead; both share [`Self::prepare_schnorr`].
+    /// Schnorr twin of [`Self::execute_verification`] — the **auto-execute** broadcast path for
+    /// the per-API-key auto-execute / account-abstraction tier. The completion handler renders a
+    /// user-signed payload via [`Self::render_schnorr_payload`]; both share
+    /// [`Self::prepare_schnorr`].
     pub async fn execute_schnorr_verification(
         &mut self,
         msg_hash: FixedBytes<32>,

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -3,6 +3,7 @@ use crate::sequencer::{InFlightTask, in_flight_task, set_task_failed, set_task_r
 use crate::store::SqliteStore;
 use crate::task_data::GasKillerTaskData;
 use alloy::network::Ethereum;
+use alloy::sol_types::SolValue;
 use alloy_primitives::{Address, Bytes, FixedBytes, U256};
 use alloy_provider::Provider;
 use anyhow::Result;
@@ -15,6 +16,7 @@ use gas_killer_common::bindings::gaskillersdk::{
 };
 use gas_killer_common::bindings::schnorrgaskillersdk::SchnorrGasKillerSDK;
 use gas_killer_common::bindings::{GAS_KILLER_INTERFACE_ID, SCHNORR_GAS_KILLER_INTERFACE_ID};
+use gas_killer_common::{BundleProof, PayloadView, TaskBundle};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -26,6 +28,101 @@ use tracing::{debug, info, warn};
 const DEFAULT_RECEIPT_TIMEOUT_L1_SECS: u64 = 120;
 /// Default receipt-wait timeout on L2, where blocks land in seconds or less.
 const DEFAULT_RECEIPT_TIMEOUT_L2_SECS: u64 = 30;
+
+/// Gas estimate recorded in a rendered payload when `eth_estimateGas` fails. It is advisory —
+/// the user re-fills gas when submitting — so a transient RPC failure still yields a submittable
+/// payload rather than failing an already-completed round.
+const PAYLOAD_GAS_ESTIMATE_FALLBACK: u64 = 3_000_000;
+
+/// Rebuilds the operator-state-retriever `NonSignerStakesAndSignature` into the distinct
+/// `GasKillerSDK` binding type. Each `sol!` invocation mints its own Rust type, so the fields
+/// are copied across even though the ABI layout is identical.
+fn reshape_non_signer(
+    data: RetrieverIBLSTypes::NonSignerStakesAndSignature,
+) -> GasKillerIBLSTypes::NonSignerStakesAndSignature {
+    GasKillerIBLSTypes::NonSignerStakesAndSignature {
+        nonSignerQuorumBitmapIndices: data.nonSignerQuorumBitmapIndices,
+        nonSignerPubkeys: data
+            .nonSignerPubkeys
+            .into_iter()
+            .map(|p| BN254::G1Point { X: p.X, Y: p.Y })
+            .collect(),
+        quorumApks: data
+            .quorumApks
+            .into_iter()
+            .map(|p| BN254::G1Point { X: p.X, Y: p.Y })
+            .collect(),
+        apkG2: BN254::G2Point {
+            X: data.apkG2.X,
+            Y: data.apkG2.Y,
+        },
+        sigma: BN254::G1Point {
+            X: data.sigma.X,
+            Y: data.sigma.Y,
+        },
+        quorumApkIndices: data.quorumApkIndices,
+        totalStakeIndices: data.totalStakeIndices,
+        nonSignerStakeIndices: data.nonSignerStakeIndices,
+    }
+}
+
+/// The [`ExecutionResult`] a completion handler returns for a rendered (non-broadcast) round.
+///
+/// The v1-beta completion path persists the payload/bundle rather than submitting a transaction,
+/// so there is no receipt to report; the submitter only needs an `Ok` to mark the height settled.
+fn rendered_execution_result() -> ExecutionResult {
+    ExecutionResult {
+        transaction_hash: String::new(),
+        block_number: None,
+        gas_used: None,
+        status: None,
+        contract_address: None,
+    }
+}
+
+/// Resolved inputs for a BLS `verifyAndUpdate` call, assembled once by
+/// [`GasKillerHandler::prepare_bls`] and consumed by either the render path
+/// ([`GasKillerHandler::render_bls_payload`]) or the retained broadcast path
+/// ([`GasKillerHandler::execute_verification`]).
+struct PreparedBls<P> {
+    provider: P,
+    chain_id: u64,
+    target_addr: Address,
+    from_address: Address,
+    msg_hash: FixedBytes<32>,
+    quorum_numbers: Bytes,
+    /// `current_block_number - 1`; see [`GasKillerHandler::prepare_bls`].
+    reference_block_number: u32,
+    storage_updates: Bytes,
+    transition_index: u64,
+    target_function: FixedBytes<4>,
+    non_signer: GasKillerIBLSTypes::NonSignerStakesAndSignature,
+}
+
+/// Resolved inputs for a Schnorr `verifyAndUpdate` call; the Schnorr twin of [`PreparedBls`],
+/// swapping the BN254 non-signer struct for the aggregate `(s, Raddr)` and the ascending
+/// `non_signers`.
+struct PreparedSchnorr<P> {
+    provider: P,
+    chain_id: u64,
+    target_addr: Address,
+    from_address: Address,
+    msg_hash: FixedBytes<32>,
+    reference_block_number: u32,
+    storage_updates: Bytes,
+    transition_index: u64,
+    target_function: FixedBytes<4>,
+    s: U256,
+    r_addr: Address,
+    non_signers: Vec<Address>,
+}
+
+/// A completed round rendered for user execution: the ready-to-sign transaction request plus the
+/// durable [`TaskBundle`] it was derived from.
+struct RenderedRound {
+    payload: PayloadView,
+    bundle: TaskBundle,
+}
 
 /// Handler for executing verifyAndUpdate transactions with multi-chain support
 pub struct GasKillerHandler<P> {
@@ -52,6 +149,9 @@ pub struct GasKillerHandler<P> {
     /// Shared with [`crate::sequencer::GasKillerTaskSource`]; see
     /// [`crate::sequencer::InFlightTask`].
     in_flight: InFlightTask,
+    /// Blocks past the reference block for which a rendered payload's `valid_until_block` is set.
+    /// Sourced from `PAYLOAD_BLOCK_BUFFER`.
+    payload_block_buffer: u64,
 }
 
 impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> {
@@ -68,6 +168,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             receipt_timeout_override: None,
             store: None,
             in_flight: in_flight_task(),
+            payload_block_buffer: gas_killer_common::DEFAULT_PAYLOAD_BLOCK_BUFFER,
         }
     }
 
@@ -82,6 +183,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             receipt_timeout_override: None,
             store: None,
             in_flight: in_flight_task(),
+            payload_block_buffer: gas_killer_common::DEFAULT_PAYLOAD_BLOCK_BUFFER,
         }
     }
 
@@ -121,6 +223,13 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
     /// won't map back to its task.
     pub fn with_in_flight_task(mut self, in_flight: InFlightTask) -> Self {
         self.in_flight = in_flight;
+        self
+    }
+
+    /// Sets the block buffer used to compute a rendered payload's `valid_until_block`
+    /// (`reference_block_number + buffer`).
+    pub fn with_payload_block_buffer(mut self, buffer: u64) -> Self {
+        self.payload_block_buffer = buffer;
         self
     }
 
@@ -181,49 +290,29 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         Ok(supported)
     }
 
-    async fn execute_verification(
-        &mut self,
+    /// Runs the shared preflight for a BLS round and resolves every `verifyAndUpdate` input.
+    ///
+    /// Reshapes the non-signer struct into the SDK binding type, resolves the chain provider,
+    /// confirms the locally recomputed payload hash matches the quorum-signed hash, and gates on
+    /// the target's ERC-165 GasKiller interface. `reference_block_number = current_block_number
+    /// - 1` so that a simulation at the current block satisfies the on-chain
+    /// `require(referenceBlockNumber < block.number)`; without the decrement a simulation at
+    /// block N would see `referenceBlockNumber == N` and revert with `FutureBlockNumber`.
+    async fn prepare_bls(
+        &self,
         msg_hash: FixedBytes<32>,
         quorum_numbers: Bytes,
         current_block_number: u32,
         non_signer_data: RetrieverIBLSTypes::NonSignerStakesAndSignature,
         task_data: Option<&GasKillerTaskData>,
-    ) -> Result<ExecutionResult> {
-        let data = non_signer_data;
+    ) -> Result<PreparedBls<P>> {
+        let non_signer = reshape_non_signer(non_signer_data);
 
-        // Convert the non-signer data to the format expected by the GasKillerSDK
-        let non_signer_struct_data = GasKillerIBLSTypes::NonSignerStakesAndSignature {
-            nonSignerQuorumBitmapIndices: data.nonSignerQuorumBitmapIndices,
-            nonSignerPubkeys: data
-                .nonSignerPubkeys
-                .into_iter()
-                .map(|p| BN254::G1Point { X: p.X, Y: p.Y })
-                .collect(),
-            quorumApks: data
-                .quorumApks
-                .into_iter()
-                .map(|p| BN254::G1Point { X: p.X, Y: p.Y })
-                .collect(),
-            apkG2: BN254::G2Point {
-                X: data.apkG2.X,
-                Y: data.apkG2.Y,
-            },
-            sigma: BN254::G1Point {
-                X: data.sigma.X,
-                Y: data.sigma.Y,
-            },
-            quorumApkIndices: data.quorumApkIndices,
-            totalStakeIndices: data.totalStakeIndices,
-            nonSignerStakeIndices: data.nonSignerStakeIndices,
-        };
-
-        // Validate that task data is provided
         let task_data = task_data
             .ok_or_else(|| anyhow::anyhow!("Task data is required for gas killer verification"))?;
 
         let chain_id: u64 = task_data.chain_id;
 
-        // Get the chain-specific provider
         let provider = self
             .get_provider(chain_id)
             .ok_or_else(|| anyhow::anyhow!("No provider configured for chain: {}", chain_id))?
@@ -235,15 +324,14 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             "Using storage updates from task data on detected chain"
         );
 
-        // Extract task data parameters - use pre-computed storage_updates from task data
         let storage_updates = task_data.storage_updates.clone();
-        let transition_index = U256::from(task_data.transition_index);
+        let transition_index = task_data.transition_index;
         let target_function = task_data.function_selector();
         let target_addr = task_data.target_address;
+        let from_address = task_data.from_address;
 
-        // Debug: Log exact inputs for hash comparison
         debug!(
-            transition_index = %transition_index,
+            transition_index,
             target_address = %target_addr,
             target_function = %target_function,
             storage_updates_len = storage_updates.len(),
@@ -276,7 +364,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             warn!(
                 offchain_msg_hash = %msg_hash,
                 local_expected_hash = %expected_hash,
-                transition_index = %transition_index,
+                transition_index,
                 target_address = %target_addr,
                 target_function = %target_function,
                 storage_updates_len = storage_updates.len(),
@@ -302,25 +390,73 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             ));
         }
 
+        Ok(PreparedBls {
+            provider,
+            chain_id,
+            target_addr,
+            from_address,
+            msg_hash,
+            quorum_numbers,
+            reference_block_number: current_block_number.saturating_sub(1),
+            storage_updates,
+            transition_index,
+            target_function,
+            non_signer,
+        })
+    }
+
+    /// Broadcasts a BLS `verifyAndUpdate` on-chain from the router's funded wallet and waits for
+    /// the receipt.
+    ///
+    /// This is the **auto-execute** path, retained as the entry point for the future
+    /// per-API-key auto-execute / account-abstraction tier that submits the round on the user's
+    /// behalf. The v1-beta completion path renders a user-signed payload via
+    /// [`Self::render_bls_payload`] instead of calling this; both share [`Self::prepare_bls`], so
+    /// switching between them later is a localized branch.
+    pub async fn execute_verification(
+        &mut self,
+        msg_hash: FixedBytes<32>,
+        quorum_numbers: Bytes,
+        current_block_number: u32,
+        non_signer_data: RetrieverIBLSTypes::NonSignerStakesAndSignature,
+        task_data: Option<&GasKillerTaskData>,
+    ) -> Result<ExecutionResult> {
+        let prepared = self
+            .prepare_bls(
+                msg_hash,
+                quorum_numbers,
+                current_block_number,
+                non_signer_data,
+                task_data,
+            )
+            .await?;
+        let PreparedBls {
+            provider,
+            chain_id,
+            target_addr,
+            msg_hash,
+            quorum_numbers,
+            reference_block_number,
+            storage_updates,
+            transition_index,
+            target_function,
+            non_signer,
+            ..
+        } = prepared;
+
         let gas_killer_sdk = GasKillerSDK::new(target_addr, provider);
 
-        // Execute the gas killer verifyAndUpdate
-        // Use referenceBlockNumber = current_block_number - 1 so that eth_estimateGas (which
-        // simulates at the current block) satisfies the on-chain check:
-        //   require(referenceBlockNumber < block.number)
-        // Without the decrement, eth_estimateGas at block N sees referenceBlockNumber == N
-        // and reverts with FutureBlockNumber.
         info!("Sending verifyAndUpdate transaction");
         let tx_send_start = Instant::now();
         let send_result = gas_killer_sdk
             .verifyAndUpdate(
                 msg_hash,
                 quorum_numbers,
-                current_block_number.saturating_sub(1),
+                reference_block_number,
                 storage_updates,
-                transition_index,
+                U256::from(transition_index),
                 target_function,
-                non_signer_struct_data,
+                non_signer,
             )
             .send()
             .await
@@ -377,6 +513,106 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         })
     }
 
+    /// Renders a completed BLS round into a user-signable transaction request and the durable
+    /// [`TaskBundle`] it derives from, without broadcasting.
+    ///
+    /// `data` is the full `verifyAndUpdate` calldata; `estimated_gas` comes from
+    /// `eth_estimateGas` simulated as the requesting account, falling back to
+    /// [`PAYLOAD_GAS_ESTIMATE_FALLBACK`] if the estimate fails so a transient RPC error still
+    /// yields a submittable payload. `value` is fixed at zero: `verifyAndUpdate` is not payable
+    /// in beta and the value is kept server-controlled so a future on-chain fee is a server
+    /// change, not an integrator client-code change.
+    async fn render_bls_payload(
+        &self,
+        msg_hash: FixedBytes<32>,
+        quorum_numbers: Bytes,
+        current_block_number: u32,
+        non_signer_data: RetrieverIBLSTypes::NonSignerStakesAndSignature,
+        task_data: Option<&GasKillerTaskData>,
+    ) -> Result<RenderedRound> {
+        let prepared = self
+            .prepare_bls(
+                msg_hash,
+                quorum_numbers,
+                current_block_number,
+                non_signer_data,
+                task_data,
+            )
+            .await?;
+        let PreparedBls {
+            provider,
+            chain_id,
+            target_addr,
+            from_address,
+            msg_hash,
+            quorum_numbers,
+            reference_block_number,
+            storage_updates,
+            transition_index,
+            target_function,
+            non_signer,
+        } = prepared;
+
+        // Capture the ABI-encoded proof for the bundle before the struct is moved into the call.
+        let non_signer_abi = Bytes::from(non_signer.abi_encode());
+        let value = U256::ZERO;
+
+        let sdk = GasKillerSDK::new(target_addr, provider);
+        let call = sdk
+            .verifyAndUpdate(
+                msg_hash,
+                quorum_numbers.clone(),
+                reference_block_number,
+                storage_updates.clone(),
+                U256::from(transition_index),
+                target_function,
+                non_signer,
+            )
+            .from(from_address)
+            .value(value);
+
+        let data = call.calldata().clone();
+        let estimated_gas = match call.estimate_gas().await {
+            Ok(gas) => gas,
+            Err(e) => {
+                warn!(
+                    target = %target_addr,
+                    error = %e,
+                    fallback = PAYLOAD_GAS_ESTIMATE_FALLBACK,
+                    "verifyAndUpdate gas estimation failed; using fallback estimate"
+                );
+                PAYLOAD_GAS_ESTIMATE_FALLBACK
+            }
+        };
+
+        let valid_until_block = reference_block_number as u64 + self.payload_block_buffer;
+
+        let payload = PayloadView {
+            to: target_addr,
+            data,
+            value,
+            chain_id,
+            estimated_gas,
+            valid_until_block,
+        };
+        let bundle = TaskBundle {
+            msg_hash,
+            reference_block_number,
+            transition_index,
+            target_address: target_addr,
+            target_function,
+            storage_updates,
+            chain_id,
+            value,
+            valid_until_block,
+            proof: BundleProof::Bls {
+                quorum_numbers,
+                non_signer_stakes_and_signature: non_signer_abi,
+            },
+        };
+        Ok(RenderedRound { payload, bundle })
+    }
+
     /// Schnorr twin of [`Self::supports_gas_killer_interface`], checking the
     /// `ISchnorrGasKillerSDK` interface ID instead. Shares the same memo cache: a
     /// process runs exactly one signature scheme, so a given target address is
@@ -410,19 +646,18 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         Ok(supported)
     }
 
-    /// Schnorr twin of [`Self::execute_verification`]: identical preflights
-    /// (payload-hash match, ERC-165 gate, `refBlock = head − 1`), but the quorum
-    /// proof is a single aggregate signature `(s, Raddr)` plus the strictly
-    /// ascending non-signer list, submitted through the Schnorr SDK ABI.
-    async fn execute_schnorr_verification(
-        &mut self,
+    /// Schnorr twin of [`Self::prepare_bls`]: identical preflights (payload-hash match, ERC-165
+    /// gate, `reference_block_number = head − 1`), resolving the aggregate `(s, Raddr)` and the
+    /// strictly ascending `non_signers` instead of the BN254 non-signer struct.
+    async fn prepare_schnorr(
+        &self,
         msg_hash: FixedBytes<32>,
         current_block_number: u32,
         s: U256,
         r_addr: Address,
         non_signers: Vec<Address>,
         task_data: Option<&GasKillerTaskData>,
-    ) -> Result<ExecutionResult> {
+    ) -> Result<PreparedSchnorr<P>> {
         let task_data = task_data
             .ok_or_else(|| anyhow::anyhow!("Task data is required for gas killer verification"))?;
 
@@ -433,9 +668,10 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             .clone();
 
         let storage_updates = task_data.storage_updates.clone();
-        let transition_index = U256::from(task_data.transition_index);
+        let transition_index = task_data.transition_index;
         let target_function = task_data.function_selector();
         let target_addr = task_data.target_address;
+        let from_address = task_data.from_address;
 
         // The payload-hash preflight and the ERC-165 interface check are
         // independent, so run them concurrently. Once the interface result is
@@ -461,7 +697,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             warn!(
                 offchain_msg_hash = %msg_hash,
                 local_expected_hash = %expected_hash,
-                transition_index = %transition_index,
+                transition_index,
                 target_address = %target_addr,
                 "Message hash mismatch between aggregation and local computation"
             );
@@ -484,11 +720,62 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             ));
         }
 
+        Ok(PreparedSchnorr {
+            provider,
+            chain_id,
+            target_addr,
+            from_address,
+            msg_hash,
+            reference_block_number: current_block_number.saturating_sub(1),
+            storage_updates,
+            transition_index,
+            target_function,
+            s,
+            r_addr,
+            non_signers,
+        })
+    }
+
+    /// Schnorr twin of [`Self::execute_verification`] — the **auto-execute** broadcast path,
+    /// retained for the future per-API-key auto-execute / account-abstraction tier. The v1-beta
+    /// completion path renders a user-signed payload via [`Self::render_schnorr_payload`]
+    /// instead; both share [`Self::prepare_schnorr`].
+    pub async fn execute_schnorr_verification(
+        &mut self,
+        msg_hash: FixedBytes<32>,
+        current_block_number: u32,
+        s: U256,
+        r_addr: Address,
+        non_signers: Vec<Address>,
+        task_data: Option<&GasKillerTaskData>,
+    ) -> Result<ExecutionResult> {
+        let prepared = self
+            .prepare_schnorr(
+                msg_hash,
+                current_block_number,
+                s,
+                r_addr,
+                non_signers,
+                task_data,
+            )
+            .await?;
+        let PreparedSchnorr {
+            provider,
+            chain_id,
+            target_addr,
+            msg_hash,
+            reference_block_number,
+            storage_updates,
+            transition_index,
+            target_function,
+            s,
+            r_addr,
+            non_signers,
+            ..
+        } = prepared;
+
         let sdk = SchnorrGasKillerSDK::new(target_addr, provider);
 
-        // referenceBlockNumber = current_block_number - 1 so eth_estimateGas (which
-        // simulates at the current block) satisfies the on-chain
-        // `require(referenceBlockNumber < block.number)` check.
         info!(
             non_signers = non_signers.len(),
             "Sending Schnorr verifyAndUpdate transaction"
@@ -497,9 +784,9 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         let send_result = sdk
             .verifyAndUpdate(
                 msg_hash,
-                current_block_number.saturating_sub(1),
+                reference_block_number,
                 storage_updates,
-                transition_index,
+                U256::from(transition_index),
                 target_function,
                 s,
                 r_addr,
@@ -559,6 +846,104 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         })
     }
 
+    /// Schnorr twin of [`Self::render_bls_payload`]: renders a completed Schnorr round into a
+    /// user-signable transaction request and its durable [`TaskBundle`] without broadcasting.
+    /// The outer payload is scheme-agnostic — only the encoded `data` and the bundle's proof
+    /// differ from the BLS rendering.
+    #[allow(clippy::too_many_arguments)]
+    async fn render_schnorr_payload(
+        &self,
+        msg_hash: FixedBytes<32>,
+        current_block_number: u32,
+        s: U256,
+        r_addr: Address,
+        non_signers: Vec<Address>,
+        task_data: Option<&GasKillerTaskData>,
+    ) -> Result<RenderedRound> {
+        let prepared = self
+            .prepare_schnorr(
+                msg_hash,
+                current_block_number,
+                s,
+                r_addr,
+                non_signers,
+                task_data,
+            )
+            .await?;
+        let PreparedSchnorr {
+            provider,
+            chain_id,
+            target_addr,
+            from_address,
+            msg_hash,
+            reference_block_number,
+            storage_updates,
+            transition_index,
+            target_function,
+            s,
+            r_addr,
+            non_signers,
+        } = prepared;
+
+        let value = U256::ZERO;
+        let sdk = SchnorrGasKillerSDK::new(target_addr, provider);
+        let call = sdk
+            .verifyAndUpdate(
+                msg_hash,
+                reference_block_number,
+                storage_updates.clone(),
+                U256::from(transition_index),
+                target_function,
+                s,
+                r_addr,
+                non_signers.clone(),
+            )
+            .from(from_address)
+            .value(value);
+
+        let data = call.calldata().clone();
+        let estimated_gas = match call.estimate_gas().await {
+            Ok(gas) => gas,
+            Err(e) => {
+                warn!(
+                    target = %target_addr,
+                    error = %e,
+                    fallback = PAYLOAD_GAS_ESTIMATE_FALLBACK,
+                    "verifyAndUpdate gas estimation failed; using fallback estimate"
+                );
+                PAYLOAD_GAS_ESTIMATE_FALLBACK
+            }
+        };
+
+        let valid_until_block = reference_block_number as u64 + self.payload_block_buffer;
+
+        let payload = PayloadView {
+            to: target_addr,
+            data,
+            value,
+            chain_id,
+            estimated_gas,
+            valid_until_block,
+        };
+        let bundle = TaskBundle {
+            msg_hash,
+            reference_block_number,
+            transition_index,
+            target_address: target_addr,
+            target_function,
+            storage_updates,
+            chain_id,
+            value,
+            valid_until_block,
+            proof: BundleProof::Schnorr {
+                s,
+                r_addr,
+                non_signers,
+            },
+        };
+        Ok(RenderedRound { payload, bundle })
+    }
+
     /// Schnorr twin of [`BlsSignatureVerificationHandler::handle_verification`]:
     /// same metrics envelope and task settlement, the proof arguments swap the
     /// BN254 non-signer struct for the aggregate `(s, Raddr)` and the strictly
@@ -586,7 +971,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         let exec_start = Instant::now();
 
         let result = self
-            .execute_schnorr_verification(
+            .render_schnorr_payload(
                 msg_hash,
                 current_block_number,
                 s,
@@ -616,19 +1001,22 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         // Settle the task this height was executing. `GasKillerTaskSource::next_task`
         // set the in-flight slot when it dispatched this task; taking it here both
         // records the outcome and clears the slot so a later skipped height is not
-        // mistaken for this one.
+        // mistaken for this one. A successful round persists the rendered payload and its
+        // bundle; the on-chain submission is left to the user (or the future auto-execute tier).
         if let Some(store) = &self.store
             && let Some(task_id) = self.in_flight.lock().ok().and_then(|mut slot| slot.take())
         {
             match &result {
-                Ok(_) => set_task_ready(store, &task_id).await,
+                Ok(rendered) => {
+                    set_task_ready(store, &task_id, &rendered.payload, &rendered.bundle).await
+                }
                 Err(e) => {
                     set_task_failed(store, &task_id, &format!("verification failed: {e}")).await
                 }
             }
         }
 
-        result
+        result.map(|_| rendered_execution_result())
     }
 }
 
@@ -666,7 +1054,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
         let exec_start = Instant::now();
 
         let result = self
-            .execute_verification(
+            .render_bls_payload(
                 msg_hash,
                 quorum_numbers,
                 current_block_number,
@@ -681,9 +1069,8 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
             match &result {
                 Ok(_) => {
                     m.aggregation_rounds_completed.inc();
-                    // End-to-end latency: sequencer dispatch through receipt confirmation.
-                    // Failed heights are skipped — they have no on-chain confirmation, and
-                    // a receipt-timeout sample would distort the percentiles.
+                    // End-to-end latency: sequencer dispatch through round completion.
+                    // Failed heights are skipped — a failure sample would distort the percentiles.
                     if let Some(start) = dispatch_start {
                         m.round_latency_seconds
                             .observe(start.elapsed().as_secs_f64());
@@ -698,21 +1085,22 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> BlsSignatureVerifica
         // Settle the task this height was executing. `GasKillerTaskSource::next_task`
         // set the in-flight slot when it dispatched this task; taking it here both
         // records the outcome and clears the slot so a later skipped height is not
-        // mistaken for this one. The task carries no user-executable payload yet
-        // (that arrives with the payload-delivery work), so a successful execution
-        // is recorded as `ready` with the status transition alone.
+        // mistaken for this one. A successful round persists the rendered payload and its
+        // bundle; the on-chain submission is left to the user (or the future auto-execute tier).
         if let Some(store) = &self.store
             && let Some(task_id) = self.in_flight.lock().ok().and_then(|mut slot| slot.take())
         {
             match &result {
-                Ok(_) => set_task_ready(store, &task_id).await,
+                Ok(rendered) => {
+                    set_task_ready(store, &task_id, &rendered.payload, &rendered.bundle).await
+                }
                 Err(e) => {
                     set_task_failed(store, &task_id, &format!("verification failed: {e}")).await
                 }
             }
         }
 
-        result
+        result.map(|_| rendered_execution_result())
     }
 }
 
@@ -918,8 +1306,8 @@ mod tests {
             .with_store(store.clone())
             .with_in_flight_task(in_flight.clone());
 
-        // `task_data: None` makes `execute_verification` fail immediately (before any
-        // provider call), exercising the settlement wiring without needing a real
+        // `task_data: None` makes `render_bls_payload` fail immediately in `prepare_bls`
+        // (before any provider call), exercising the settlement wiring without needing a real
         // chain, ABI-encoded certificate, or registered operator set.
         let result = handler
             .handle_verification(
@@ -949,6 +1337,99 @@ mod tests {
                 .as_deref()
                 .is_some_and(|e| e.contains("verification failed"))
         );
+    }
+
+    #[tokio::test]
+    async fn handle_verification_settles_ready_with_rendered_payload_and_bundle() {
+        use alloy::sol_types::SolCall;
+        use gas_killer_common::bindings::gaskillersdk::GasKillerSDK;
+
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store
+            .create_task(&key, &request_body())
+            .await
+            .expect("task creation should succeed");
+
+        // Task data whose signed hash matches its own storage updates, so the render preflight
+        // passes and a payload is produced.
+        let storage_updates = Bytes::from(vec![0xaa, 0xbb, 0xcc, 0xdd]);
+        let task_data = GasKillerTaskData {
+            storage_updates: storage_updates.clone(),
+            transition_index: 0,
+            target_address: Address::from([0x11; 20]),
+            call_data: vec![0x12, 0x34, 0x56, 0x78],
+            from_address: Address::from([0x22; 20]),
+            value: U256::ZERO,
+            block_height: 1,
+            chain_id: 1,
+        };
+        let msg_hash =
+            FixedBytes::<32>::from(task_data.build_payload_hash(storage_updates.as_ref()).0);
+
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        // The only queued RPC answers the ERC-165 interface probe. The subsequent
+        // eth_estimateGas drains the now-empty asserter and errors, exercising the fallback
+        // estimate — the round still renders a payload rather than failing.
+        push_supports_interface(&asserter, true);
+
+        let in_flight = in_flight_task();
+        *in_flight.lock().unwrap() = Some(task.id.clone());
+        let mut handler = GasKillerHandler::new(1, provider)
+            .with_store(store.clone())
+            .with_in_flight_task(in_flight.clone())
+            .with_payload_block_buffer(50);
+
+        let current_block = 100u32;
+        let quorum_numbers = Bytes::from(vec![0x00]);
+        let result = handler
+            .handle_verification(
+                0,
+                msg_hash,
+                quorum_numbers.clone(),
+                current_block,
+                empty_non_signer_data(),
+                Some(&task_data),
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert!(
+            in_flight.lock().unwrap().is_none(),
+            "the slot must be cleared once the task settles"
+        );
+
+        let settled = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(settled.status, TaskStatus::Ready);
+
+        let payload: PayloadView =
+            serde_json::from_str(settled.payload.as_deref().expect("payload persisted")).unwrap();
+        assert_eq!(payload.to, task_data.target_address);
+        assert_eq!(payload.value, U256::ZERO);
+        assert_eq!(payload.chain_id, 1);
+        assert_eq!(payload.estimated_gas, PAYLOAD_GAS_ESTIMATE_FALLBACK);
+        // reference_block_number = current_block - 1; valid_until = reference + buffer.
+        assert_eq!(payload.valid_until_block, (current_block as u64 - 1) + 50);
+
+        // The rendered calldata ABI-decodes to a verifyAndUpdate call carrying the round inputs.
+        let decoded = GasKillerSDK::verifyAndUpdateCall::abi_decode(payload.data.as_ref())
+            .expect("payload data should decode as verifyAndUpdate");
+        assert_eq!(decoded.msgHash, msg_hash);
+        assert_eq!(decoded.quorumNumbers, quorum_numbers);
+        assert_eq!(decoded.referenceBlockNumber, current_block - 1);
+        assert_eq!(decoded.storageUpdates, storage_updates);
+        assert_eq!(decoded.transitionIndex, U256::ZERO);
+        assert_eq!(decoded.targetFunction, task_data.function_selector());
+
+        // The structured bundle persists alongside the payload and round-trips.
+        let bundle: TaskBundle =
+            serde_json::from_str(settled.bundle.as_deref().expect("bundle persisted")).unwrap();
+        assert_eq!(bundle.msg_hash, msg_hash);
+        assert_eq!(bundle.reference_block_number, current_block - 1);
+        assert_eq!(bundle.transition_index, 0);
+        assert_eq!(bundle.chain_id, 1);
+        assert!(matches!(bundle.proof, BundleProof::Bls { .. }));
     }
 
     #[tokio::test]
@@ -993,9 +1474,9 @@ mod tests {
             .with_store(store.clone())
             .with_in_flight_task(in_flight.clone());
 
-        // `task_data: None` makes `execute_schnorr_verification` fail immediately
-        // (before any provider call), exercising the settlement wiring without
-        // needing a real chain or a valid aggregate signature.
+        // `task_data: None` makes `render_schnorr_payload` fail immediately in
+        // `prepare_schnorr` (before any provider call), exercising the settlement wiring
+        // without needing a real chain or a valid aggregate signature.
         let result = handler
             .handle_schnorr_verification(
                 0,

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -381,7 +381,8 @@ async fn create_handler_parts(
         .with_metrics(metrics)
         .with_dispatch_time(dispatch_time)
         .with_receipt_timeout(receipt_timeout_override)
-        .with_in_flight_task(in_flight);
+        .with_in_flight_task(in_flight)
+        .with_payload_block_buffer(gas_killer_common::payload_block_buffer());
     if let Some(store) = store {
         gas_killer_handler = gas_killer_handler.with_store(store);
     }

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -835,33 +835,39 @@ async fn render_or_reject_payload<P: Provider + Clone>(
         None => return Ok(Some(payload)),
     };
 
+    // Block-window check first (cheapest), short-circuiting before the contract call. It is
+    // measured on the operator-set chain (L1): the certificate's reference block — from which
+    // `valid_until_block` is derived — is an L1 block, since operator state lives on L1, even when
+    // the target executes on L2. Comparing against the target chain's height would falsely expire
+    // every L2 payload. If no L1 provider is configured, skip the window check.
+    if let Some(l1_provider) = providers.get(&ChainRole::L1) {
+        let current_block = match freshness.cached_block_number(ChainRole::L1) {
+            Some(block) => block,
+            None => {
+                let block = l1_provider
+                    .get_block_number()
+                    .await
+                    .map_err(|e| ApiError::from(OnchainValidationError::RpcError(e.to_string())))?;
+                freshness.store_block_number(ChainRole::L1, block);
+                block
+            }
+        };
+        if current_block > bundle.valid_until_block {
+            let reason = format!(
+                "payload valid_until_block {} passed (current block {}); re-request",
+                bundle.valid_until_block, current_block
+            );
+            let _ = store.mark_task_expired(&task.id, &reason).await;
+            return Err(ApiError::payload_expired(reason));
+        }
+    }
+
+    // Consumed-bundle check on the target chain: `stateTransitionCount` is target-contract state,
+    // so it is read from the chain the target is deployed on (L1 or L2).
     let role = detect_contract_chain(providers, bundle.target_address).await?;
     let provider = providers
         .get(&role)
         .ok_or_else(|| ApiError::internal("no provider for detected chain"))?;
-
-    // Cheapest check first — the block window — short-circuiting before the contract call.
-    let current_block = match freshness.cached_block_number(role) {
-        Some(block) => block,
-        None => {
-            let block = provider
-                .get_block_number()
-                .await
-                .map_err(|e| ApiError::from(OnchainValidationError::RpcError(e.to_string())))?;
-            freshness.store_block_number(role, block);
-            block
-        }
-    };
-    if current_block > bundle.valid_until_block {
-        let reason = format!(
-            "payload valid_until_block {} passed (current block {}); re-request",
-            bundle.valid_until_block, current_block
-        );
-        let _ = store.mark_task_expired(&task.id, &reason).await;
-        return Err(ApiError::payload_expired(reason));
-    }
-
-    // Consumed-bundle check: the on-chain transition index has advanced past the bundle's.
     let current_count = match freshness.cached_transition_count(role, bundle.target_address) {
         Some(count) => count,
         None => {
@@ -2376,9 +2382,9 @@ mod tests {
             let task = store.get_task(&id).await.unwrap().unwrap();
 
             let asserter = Asserter::new();
-            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: L1 code
-            asserter.push_success(&U64::from(90u64)); // eth_blockNumber, within window
-            asserter.push_success(&Bytes::from(U256::from(3u64).abi_encode())); // count == index
+            asserter.push_success(&U64::from(90u64)); // block-window: L1 eth_blockNumber, within window
+            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: target code
+            asserter.push_success(&Bytes::from(U256::from(3u64).abi_encode())); // stateTransitionCount == index
 
             let provider = ProviderBuilder::new().connect_mocked_client(asserter);
             let mut providers = HashMap::new();
@@ -2391,7 +2397,7 @@ mod tests {
 
         #[tokio::test]
         async fn stale_check_rejects_when_block_past_valid_until() {
-            use alloy_primitives::{Bytes, U64};
+            use alloy_primitives::U64;
             use alloy_provider::{ProviderBuilder, mock::Asserter};
 
             let payload = fresh_payload(50);
@@ -2400,10 +2406,10 @@ mod tests {
             let task = store.get_task(&id).await.unwrap().unwrap();
 
             let asserter = Asserter::new();
-            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: L1 code
-            asserter.push_success(&U64::from(51u64)); // past valid_until_block (50)
-            // No stateTransitionCount response is queued: if the block check did not short-circuit,
-            // the contract call would drain the empty asserter and this test would fail.
+            asserter.push_success(&U64::from(51u64)); // block-window: L1 block past valid_until_block (50)
+            // Nothing else is queued: the block-window check short-circuits before detecting the
+            // target chain or reading stateTransitionCount, so any further RPC would drain the
+            // empty asserter and fail the test.
 
             let provider = ProviderBuilder::new().connect_mocked_client(asserter);
             let mut providers = HashMap::new();
@@ -2433,9 +2439,9 @@ mod tests {
             let task = store.get_task(&id).await.unwrap().unwrap();
 
             let asserter = Asserter::new();
-            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: L1 code
-            asserter.push_success(&U64::from(40u64)); // within window
-            asserter.push_success(&Bytes::from(U256::from(9u64).abi_encode())); // count 9 != index 3
+            asserter.push_success(&U64::from(40u64)); // block-window: L1 block within window
+            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: target code
+            asserter.push_success(&Bytes::from(U256::from(9u64).abi_encode())); // stateTransitionCount 9 != index 3
 
             let provider = ProviderBuilder::new().connect_mocked_client(asserter);
             let mut providers = HashMap::new();
@@ -2460,7 +2466,7 @@ mod tests {
             let task = store.get_task(&id).await.unwrap().unwrap();
 
             let asserter = Asserter::new();
-            asserter.push_failure_msg("rpc down"); // detect_contract_chain get_code fails
+            asserter.push_failure_msg("rpc down"); // block-window: L1 get_block_number fails
 
             let provider = ProviderBuilder::new().connect_mocked_client(asserter);
             let mut providers = HashMap::new();

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -37,9 +37,23 @@ const FRESHNESS_CACHE_TTL: Duration = Duration::from_secs(6);
 pub struct FreshnessCache {
     block_numbers: RwLock<HashMap<ChainRole, (u64, Instant)>>,
     transition_counts: RwLock<HashMap<(ChainRole, Address), (u64, Instant)>>,
+    chain_roles: RwLock<HashMap<Address, (ChainRole, Instant)>>,
 }
 
 impl FreshnessCache {
+    fn cached_chain_role(&self, target: Address) -> Option<ChainRole> {
+        let guard = self.chain_roles.read().ok()?;
+        guard
+            .get(&target)
+            .and_then(|(role, at)| (at.elapsed() < FRESHNESS_CACHE_TTL).then_some(*role))
+    }
+
+    fn store_chain_role(&self, target: Address, role: ChainRole) {
+        if let Ok(mut guard) = self.chain_roles.write() {
+            guard.insert(target, (role, Instant::now()));
+        }
+    }
+
     fn cached_block_number(&self, role: ChainRole) -> Option<u64> {
         let guard = self.block_numbers.read().ok()?;
         guard
@@ -787,9 +801,10 @@ pub struct ListTasksQuery {
 ///
 /// The check is the freshness authority for `GET /tasks/{id}`: a caller must fetch here (not the
 /// list endpoint) before submitting. It is ordered cheapest-first and short-circuits so a poll
-/// costs at most one `eth_blockNumber` and one `stateTransitionCount`, both served from a
-/// short-TTL cache under rapid polling. Once a payload is found stale the task is recorded
-/// `expired`, so every later poll returns immediately without a chain read.
+/// costs at most one `eth_getCode` (chain detection), one `eth_blockNumber`, and one
+/// `stateTransitionCount`, all served from a short-TTL cache under rapid polling. Once a payload is
+/// found stale the task is recorded `expired`, so every later poll returns immediately without a
+/// chain read.
 async fn render_or_reject_payload<P: Provider + Clone>(
     providers: &HashMap<ChainRole, P>,
     freshness: &FreshnessCache,
@@ -863,8 +878,17 @@ async fn render_or_reject_payload<P: Provider + Clone>(
     }
 
     // Consumed-bundle check on the target chain: `stateTransitionCount` is target-contract state,
-    // so it is read from the chain the target is deployed on (L1 or L2).
-    let role = detect_contract_chain(providers, bundle.target_address).await?;
+    // so it is read from the chain the target is deployed on (L1 or L2). The resolved chain is
+    // cached per target — a contract's chain does not change — so rapid polling skips the
+    // `eth_getCode` detection probe.
+    let role = match freshness.cached_chain_role(bundle.target_address) {
+        Some(role) => role,
+        None => {
+            let role = detect_contract_chain(providers, bundle.target_address).await?;
+            freshness.store_chain_role(bundle.target_address, role);
+            role
+        }
+    };
     let provider = providers
         .get(&role)
         .ok_or_else(|| ApiError::internal("no provider for detected chain"))?;
@@ -2393,6 +2417,37 @@ mod tests {
 
             let result = render_or_reject_payload(&providers, &freshness, &store, &task).await;
             assert_eq!(result.unwrap(), Some(payload));
+        }
+
+        #[tokio::test]
+        async fn stale_check_reuses_cache_across_repeat_polls() {
+            use alloy::sol_types::SolValue;
+            use alloy_primitives::{Bytes, U64};
+            use alloy_provider::{ProviderBuilder, mock::Asserter};
+
+            let payload = fresh_payload(100);
+            let bundle = fresh_bundle(3, 100);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            // Exactly one poll's worth of responses: block number, chain-detection code, and
+            // transition count. A second poll that issued any RPC would drain the empty asserter
+            // and fail, so the two passing calls prove every read — including chain detection — is
+            // served from the freshness cache.
+            let asserter = Asserter::new();
+            asserter.push_success(&U64::from(90u64));
+            asserter.push_success(&Bytes::from(vec![0x60, 0x00]));
+            asserter.push_success(&Bytes::from(U256::from(3u64).abi_encode()));
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let mut providers = HashMap::new();
+            providers.insert(ChainRole::L1, provider);
+            let freshness = FreshnessCache::default();
+
+            let first = render_or_reject_payload(&providers, &freshness, &store, &task).await;
+            assert_eq!(first.unwrap(), Some(payload.clone()));
+            let second = render_or_reject_payload(&providers, &freshness, &store, &task).await;
+            assert_eq!(second.unwrap(), Some(payload));
         }
 
         #[tokio::test]

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -16,12 +16,56 @@ use gas_killer_common::ReadOnlyProvider;
 use gas_killer_common::bindings::gaskillersdk::GasKillerSDK;
 use gas_killer_common::config::CHAIN_DETECTION_ORDER;
 use gas_killer_common::task_data::MAX_EVM_TX_CALLDATA_SIZE;
+use gas_killer_common::{PayloadView, TaskBundle};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 use tracing::{info, warn};
+
+/// TTL for the chain reads backing the payload freshness check. Roughly half an L1 block, so a
+/// burst of polls for the same task reuses one read while a stale payload is still caught within
+/// a block.
+const FRESHNESS_CACHE_TTL: Duration = Duration::from_secs(6);
+
+/// Short-lived cache of the chain reads that back the `ready`-payload freshness check, keyed so
+/// rapid polling of the same task reuses a read rather than issuing an RPC per poll. Shared across
+/// [`IngressState`] clones.
+#[derive(Default)]
+pub struct FreshnessCache {
+    block_numbers: RwLock<HashMap<ChainRole, (u64, Instant)>>,
+    transition_counts: RwLock<HashMap<(ChainRole, Address), (u64, Instant)>>,
+}
+
+impl FreshnessCache {
+    fn cached_block_number(&self, role: ChainRole) -> Option<u64> {
+        let guard = self.block_numbers.read().ok()?;
+        guard
+            .get(&role)
+            .and_then(|(value, at)| (at.elapsed() < FRESHNESS_CACHE_TTL).then_some(*value))
+    }
+
+    fn store_block_number(&self, role: ChainRole, value: u64) {
+        if let Ok(mut guard) = self.block_numbers.write() {
+            guard.insert(role, (value, Instant::now()));
+        }
+    }
+
+    fn cached_transition_count(&self, role: ChainRole, target: Address) -> Option<u64> {
+        let guard = self.transition_counts.read().ok()?;
+        guard
+            .get(&(role, target))
+            .and_then(|(value, at)| (at.elapsed() < FRESHNESS_CACHE_TTL).then_some(*value))
+    }
+
+    fn store_transition_count(&self, role: ChainRole, target: Address, value: u64) {
+        if let Ok(mut guard) = self.transition_counts.write() {
+            guard.insert((role, target), (value, Instant::now()));
+        }
+    }
+}
 
 /// AVS identity metadata served at `GET /avs-metadata`.
 ///
@@ -65,6 +109,8 @@ pub struct IngressState {
     pub max_queue_depth: usize,
     pub metrics: Option<Arc<MetricsCollector>>,
     pub providers: Arc<HashMap<ChainRole, ReadOnlyProvider>>,
+    /// Short-lived cache backing the `ready`-payload freshness check on `GET /tasks/{id}`.
+    pub freshness: Arc<FreshnessCache>,
     /// Shared secret guarding the `/admin/keys` endpoints (`ADMIN_KEY`). `None` disables the
     /// admin API, so keys cannot be managed until it is set.
     pub admin_key: Option<String>,
@@ -95,6 +141,7 @@ impl IngressState {
             max_queue_depth,
             metrics: Some(metrics),
             providers: Arc::new(providers),
+            freshness: Arc::new(FreshnessCache::default()),
             admin_key: None,
             avs_metadata,
             store: None,
@@ -114,6 +161,7 @@ impl IngressState {
             max_queue_depth: gas_killer_common::p2p_message_backlog(),
             metrics: None,
             providers: Arc::new(HashMap::new()),
+            freshness: Arc::new(FreshnessCache::default()),
             admin_key: None,
             avs_metadata: AvsMetadata::default(),
             store: None,
@@ -674,18 +722,29 @@ pub struct TaskView {
     pub created_at: i64,
     pub updated_at: i64,
     pub error: Option<String>,
-    pub payload: Option<String>,
+    pub payload: Option<PayloadView>,
 }
 
 impl From<Task> for TaskView {
     fn from(task: Task) -> Self {
+        // Lenient parse: the stored payload is JSON the server itself wrote, so it always parses;
+        // a failure yields `None` (logged) rather than failing the whole response. The list
+        // endpoint relies on this to surface the stored payload without a freshness check, while
+        // `GET /tasks/{id}` overwrites `payload` with the stale-checked result.
+        let payload = task.payload.as_deref().and_then(|raw| {
+            serde_json::from_str::<PayloadView>(raw)
+                .inspect_err(|e| {
+                    tracing::warn!(task_id = %task.id, error = %e, "stored payload failed to parse");
+                })
+                .ok()
+        });
         Self {
             task_id: task.id,
             status: task.status,
             created_at: task.created_at,
             updated_at: task.updated_at,
             error: task.error,
-            payload: task.payload,
+            payload,
         }
     }
 }
@@ -722,11 +781,123 @@ pub struct ListTasksQuery {
     offset: Option<i64>,
 }
 
+/// Validates a task's stored `ready` payload against current chain state, returning the payload to
+/// serve, `None` when the task has no submittable payload, or a typed re-request error when the
+/// payload has gone stale.
+///
+/// The check is the freshness authority for `GET /tasks/{id}`: a caller must fetch here (not the
+/// list endpoint) before submitting. It is ordered cheapest-first and short-circuits so a poll
+/// costs at most one `eth_blockNumber` and one `stateTransitionCount`, both served from a
+/// short-TTL cache under rapid polling. Once a payload is found stale the task is recorded
+/// `expired`, so every later poll returns immediately without a chain read.
+async fn render_or_reject_payload<P: Provider + Clone>(
+    providers: &HashMap<ChainRole, P>,
+    freshness: &FreshnessCache,
+    store: &SqliteStore,
+    task: &Task,
+) -> Result<Option<PayloadView>, ApiError> {
+    let payload = match task.payload.as_deref() {
+        Some(raw) => serde_json::from_str::<PayloadView>(raw).map_err(|e| {
+            tracing::error!(task_id = %task.id, error = %e, "stored payload failed to parse");
+            ApiError::internal("Internal error: stored payload is malformed")
+        })?,
+        // No payload recorded yet (queued/processing/failed).
+        None => return Ok(None),
+    };
+
+    // A task recorded `expired` had its payload found stale on an earlier poll; return the
+    // re-request error without touching the chain again.
+    if task.status == TaskStatus::Expired {
+        return Err(ApiError::payload_expired(
+            task.error
+                .clone()
+                .unwrap_or_else(|| "payload is no longer valid; re-request".to_string()),
+        ));
+    }
+
+    // Only a ready task carries a submittable payload.
+    if task.status != TaskStatus::Ready {
+        return Ok(None);
+    }
+
+    // Store-only harnesses (no providers) cannot reach a chain; serve the stored payload as-is.
+    if providers.is_empty() {
+        return Ok(Some(payload));
+    }
+
+    // The bundle carries the chain / target / transition / validity data the check needs.
+    let bundle: TaskBundle = match task.bundle.as_deref() {
+        Some(raw) => serde_json::from_str(raw).map_err(|e| {
+            tracing::error!(task_id = %task.id, error = %e, "stored bundle failed to parse");
+            ApiError::internal("Internal error: stored bundle is malformed")
+        })?,
+        // Ready without a bundle: nothing to validate against, so serve as-is.
+        None => return Ok(Some(payload)),
+    };
+
+    let role = detect_contract_chain(providers, bundle.target_address).await?;
+    let provider = providers
+        .get(&role)
+        .ok_or_else(|| ApiError::internal("no provider for detected chain"))?;
+
+    // Cheapest check first — the block window — short-circuiting before the contract call.
+    let current_block = match freshness.cached_block_number(role) {
+        Some(block) => block,
+        None => {
+            let block = provider
+                .get_block_number()
+                .await
+                .map_err(|e| ApiError::from(OnchainValidationError::RpcError(e.to_string())))?;
+            freshness.store_block_number(role, block);
+            block
+        }
+    };
+    if current_block > bundle.valid_until_block {
+        let reason = format!(
+            "payload valid_until_block {} passed (current block {}); re-request",
+            bundle.valid_until_block, current_block
+        );
+        let _ = store.mark_task_expired(&task.id, &reason).await;
+        return Err(ApiError::payload_expired(reason));
+    }
+
+    // Consumed-bundle check: the on-chain transition index has advanced past the bundle's.
+    let current_count = match freshness.cached_transition_count(role, bundle.target_address) {
+        Some(count) => count,
+        None => {
+            let contract = GasKillerSDK::new(bundle.target_address, provider.clone());
+            let count = contract
+                .stateTransitionCount()
+                .call()
+                .await
+                .map_err(|e| ApiError::from(OnchainValidationError::RpcError(e.to_string())))?;
+            let count: u64 = count.try_into().map_err(|_| {
+                ApiError::from(OnchainValidationError::RpcError(
+                    "stateTransitionCount overflow".into(),
+                ))
+            })?;
+            freshness.store_transition_count(role, bundle.target_address, count);
+            count
+        }
+    };
+    if current_count != bundle.transition_index {
+        let reason = format!(
+            "bundle consumed: on-chain transition index is {current_count}, payload targets {}; re-request",
+            bundle.transition_index
+        );
+        let _ = store.mark_task_expired(&task.id, &reason).await;
+        return Err(ApiError::payload_expired(reason));
+    }
+
+    Ok(Some(payload))
+}
+
 /// Handler for `GET /tasks/{task_id}` — returns the full state of a single task.
 ///
 /// A task is visible only to the API key that created it: an unknown id yields `404`, and a task
 /// owned by a different key yields `403` (kept distinct from `404` so a caller can tell "no such
-/// task" from "not yours").
+/// task" from "not yours"). For a `ready` task this is the authoritative freshness check: a stale
+/// payload yields a `409 PAYLOAD_EXPIRED` re-request error rather than calldata that would revert.
 pub async fn get_task_handler(
     State(state): State<IngressState>,
     headers: HeaderMap,
@@ -749,7 +920,11 @@ pub async fn get_task_handler(
         return Err(ApiError::forbidden("Task belongs to a different API key"));
     }
 
-    Ok(Json(task.into()))
+    let payload =
+        render_or_reject_payload(&*state.providers, &state.freshness, store, &task).await?;
+    let mut view = TaskView::from(task);
+    view.payload = payload;
+    Ok(Json(view))
 }
 
 /// Handler for `GET /tasks` — lists the calling key's tasks, newest first.
@@ -2102,10 +2277,25 @@ mod tests {
 
         #[tokio::test]
         async fn get_task_ready_includes_payload() {
+            use alloy_primitives::Bytes;
             let (app, store, _rx) = make_app_with_store(None).await;
             let key = store.create_api_key(None, None).await.unwrap();
             let id = seed_task(&store, &key.id).await;
-            store.mark_task_ready(&id, "0xdeadbeef").await.unwrap();
+
+            let payload = PayloadView {
+                to: Address::from([0x11; 20]),
+                data: Bytes::from(vec![0x93, 0xde, 0x45, 0x31]),
+                value: U256::ZERO,
+                chain_id: 31337,
+                estimated_gas: 234_000,
+                valid_until_block: 22_345_678,
+            };
+            // The store-less test harness has no providers, so the freshness check is skipped and
+            // the stored payload is returned as-is (the bundle is not consulted here).
+            store
+                .mark_task_ready_with_bundle(&id, &serde_json::to_string(&payload).unwrap(), "{}")
+                .await
+                .unwrap();
 
             let view = task_view(
                 app.oneshot(get_request(&format!("/tasks/{id}"), Some(&key.key)))
@@ -2114,7 +2304,226 @@ mod tests {
             )
             .await;
             assert_eq!(view.status, TaskStatus::Ready);
-            assert_eq!(view.payload.as_deref(), Some("0xdeadbeef"));
+            // The payload comes back as a structured object, not a string.
+            assert_eq!(
+                view.payload.expect("ready task should carry a payload"),
+                payload
+            );
+        }
+
+        // -- payload freshness (stale re-request) check --
+
+        fn fresh_payload(valid_until_block: u64) -> PayloadView {
+            PayloadView {
+                to: Address::from([0x11; 20]),
+                data: alloy_primitives::Bytes::new(),
+                value: U256::ZERO,
+                chain_id: 31337,
+                estimated_gas: 21_000,
+                valid_until_block,
+            }
+        }
+
+        fn fresh_bundle(transition_index: u64, valid_until_block: u64) -> TaskBundle {
+            TaskBundle {
+                msg_hash: alloy_primitives::B256::ZERO,
+                reference_block_number: 10,
+                transition_index,
+                target_address: Address::from([0x11; 20]),
+                target_function: alloy_primitives::FixedBytes::<4>::ZERO,
+                storage_updates: alloy_primitives::Bytes::new(),
+                chain_id: 31337,
+                value: U256::ZERO,
+                valid_until_block,
+                proof: gas_killer_common::BundleProof::Bls {
+                    quorum_numbers: alloy_primitives::Bytes::new(),
+                    non_signer_stakes_and_signature: alloy_primitives::Bytes::new(),
+                },
+            }
+        }
+
+        /// In-memory store holding a single `ready` task carrying the given payload and bundle.
+        async fn ready_store_task(
+            payload: &PayloadView,
+            bundle: &TaskBundle,
+        ) -> (SqliteStore, String) {
+            let store = SqliteStore::connect_in_memory().await.unwrap();
+            let key = store.create_api_key(None, None).await.unwrap();
+            let task = store
+                .create_task(&key.id, &valid_request().body)
+                .await
+                .unwrap();
+            store
+                .mark_task_ready_with_bundle(
+                    &task.id,
+                    &serde_json::to_string(payload).unwrap(),
+                    &serde_json::to_string(bundle).unwrap(),
+                )
+                .await
+                .unwrap();
+            (store, task.id)
+        }
+
+        #[tokio::test]
+        async fn stale_check_serves_payload_in_window_with_matching_index() {
+            use alloy::sol_types::SolValue;
+            use alloy_primitives::{Bytes, U64};
+            use alloy_provider::{ProviderBuilder, mock::Asserter};
+
+            let payload = fresh_payload(100);
+            let bundle = fresh_bundle(3, 100);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            let asserter = Asserter::new();
+            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: L1 code
+            asserter.push_success(&U64::from(90u64)); // eth_blockNumber, within window
+            asserter.push_success(&Bytes::from(U256::from(3u64).abi_encode())); // count == index
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let mut providers = HashMap::new();
+            providers.insert(ChainRole::L1, provider);
+            let freshness = FreshnessCache::default();
+
+            let result = render_or_reject_payload(&providers, &freshness, &store, &task).await;
+            assert_eq!(result.unwrap(), Some(payload));
+        }
+
+        #[tokio::test]
+        async fn stale_check_rejects_when_block_past_valid_until() {
+            use alloy_primitives::{Bytes, U64};
+            use alloy_provider::{ProviderBuilder, mock::Asserter};
+
+            let payload = fresh_payload(50);
+            let bundle = fresh_bundle(3, 50);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            let asserter = Asserter::new();
+            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: L1 code
+            asserter.push_success(&U64::from(51u64)); // past valid_until_block (50)
+            // No stateTransitionCount response is queued: if the block check did not short-circuit,
+            // the contract call would drain the empty asserter and this test would fail.
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let mut providers = HashMap::new();
+            providers.insert(ChainRole::L1, provider);
+            let freshness = FreshnessCache::default();
+
+            let err = render_or_reject_payload(&providers, &freshness, &store, &task)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code, ErrorCode::PayloadExpired);
+            assert_eq!(err.status, StatusCode::CONFLICT);
+
+            // The task is now recorded expired so later polls short-circuit without a chain read.
+            let settled = store.get_task(&id).await.unwrap().unwrap();
+            assert_eq!(settled.status, TaskStatus::Expired);
+        }
+
+        #[tokio::test]
+        async fn stale_check_rejects_on_transition_mismatch() {
+            use alloy::sol_types::SolValue;
+            use alloy_primitives::{Bytes, U64};
+            use alloy_provider::{ProviderBuilder, mock::Asserter};
+
+            let payload = fresh_payload(100);
+            let bundle = fresh_bundle(3, 100);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            let asserter = Asserter::new();
+            asserter.push_success(&Bytes::from(vec![0x60, 0x00])); // detect_contract_chain: L1 code
+            asserter.push_success(&U64::from(40u64)); // within window
+            asserter.push_success(&Bytes::from(U256::from(9u64).abi_encode())); // count 9 != index 3
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let mut providers = HashMap::new();
+            providers.insert(ChainRole::L1, provider);
+            let freshness = FreshnessCache::default();
+
+            let err = render_or_reject_payload(&providers, &freshness, &store, &task)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code, ErrorCode::PayloadExpired);
+            let settled = store.get_task(&id).await.unwrap().unwrap();
+            assert_eq!(settled.status, TaskStatus::Expired);
+        }
+
+        #[tokio::test]
+        async fn stale_check_maps_rpc_error_to_503() {
+            use alloy_provider::{ProviderBuilder, mock::Asserter};
+
+            let payload = fresh_payload(100);
+            let bundle = fresh_bundle(3, 100);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            let asserter = Asserter::new();
+            asserter.push_failure_msg("rpc down"); // detect_contract_chain get_code fails
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let mut providers = HashMap::new();
+            providers.insert(ChainRole::L1, provider);
+            let freshness = FreshnessCache::default();
+
+            let err = render_or_reject_payload(&providers, &freshness, &store, &task)
+                .await
+                .unwrap_err();
+            assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(err.code, ErrorCode::RpcUnavailable);
+            // A transient RPC failure must not expire the task.
+            let settled = store.get_task(&id).await.unwrap().unwrap();
+            assert_eq!(settled.status, TaskStatus::Ready);
+        }
+
+        #[tokio::test]
+        async fn stale_check_skipped_without_providers() {
+            let payload = fresh_payload(100);
+            let bundle = fresh_bundle(3, 100);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            let providers: HashMap<ChainRole, ReadOnlyProvider> = HashMap::new();
+            let freshness = FreshnessCache::default();
+            let result = render_or_reject_payload(&providers, &freshness, &store, &task).await;
+            assert_eq!(result.unwrap(), Some(payload));
+        }
+
+        #[tokio::test]
+        async fn stale_check_returns_none_for_non_ready_task() {
+            let store = SqliteStore::connect_in_memory().await.unwrap();
+            let key = store.create_api_key(None, None).await.unwrap();
+            let task = store
+                .create_task(&key.id, &valid_request().body)
+                .await
+                .unwrap();
+
+            let providers: HashMap<ChainRole, ReadOnlyProvider> = HashMap::new();
+            let freshness = FreshnessCache::default();
+            let result = render_or_reject_payload(&providers, &freshness, &store, &task).await;
+            assert_eq!(result.unwrap(), None);
+        }
+
+        #[tokio::test]
+        async fn stale_check_short_circuits_when_already_expired() {
+            let payload = fresh_payload(100);
+            let bundle = fresh_bundle(3, 100);
+            let (store, id) = ready_store_task(&payload, &bundle).await;
+            store
+                .mark_task_expired(&id, "payload valid_until_block passed; re-request")
+                .await
+                .unwrap();
+            let task = store.get_task(&id).await.unwrap().unwrap();
+
+            // Even with providers configured, an already-expired task never touches the chain.
+            let providers: HashMap<ChainRole, ReadOnlyProvider> = HashMap::new();
+            let freshness = FreshnessCache::default();
+            let err = render_or_reject_payload(&providers, &freshness, &store, &task)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code, ErrorCode::PayloadExpired);
+            assert_eq!(err.status, StatusCode::CONFLICT);
         }
 
         #[tokio::test]

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -189,16 +189,22 @@ fn main() {
     let port = port.parse::<u16>().expect("Port not well-formed");
     tracing::info!(port, "loaded port");
 
-    // A rendered payload's `valid_until_block` must stay within the contract's operator-set
-    // window (`referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number`); a buffer larger
-    // than the staleness window would advertise payloads the chain already rejects.
-    let payload_block_buffer = gas_killer_common::payload_block_buffer();
+    // A rendered payload's `valid_until_block` must stay within the contract's operator-set window
+    // (`referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number`). `payload_block_buffer()`
+    // clamps to the staleness window so the effective value always holds; warn when an operator
+    // configured a larger buffer so it is clear the value was reduced.
     let block_stale_measure = gas_killer_common::block_stale_measure();
-    if payload_block_buffer > block_stale_measure {
+    let payload_block_buffer = gas_killer_common::payload_block_buffer();
+    if let Some(requested) = std::env::var("PAYLOAD_BLOCK_BUFFER")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        && requested > block_stale_measure
+    {
         tracing::warn!(
-            payload_block_buffer,
+            requested,
             block_stale_measure,
-            "PAYLOAD_BLOCK_BUFFER exceeds BLOCK_STALE_MEASURE; rendered payloads may expire on-chain before valid_until_block"
+            effective = payload_block_buffer,
+            "PAYLOAD_BLOCK_BUFFER exceeds BLOCK_STALE_MEASURE; clamped to the staleness window so rendered payloads stay submittable on-chain"
         );
     }
 

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -189,6 +189,19 @@ fn main() {
     let port = port.parse::<u16>().expect("Port not well-formed");
     tracing::info!(port, "loaded port");
 
+    // A rendered payload's `valid_until_block` must stay within the contract's operator-set
+    // window (`referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number`); a buffer larger
+    // than the staleness window would advertise payloads the chain already rejects.
+    let payload_block_buffer = gas_killer_common::payload_block_buffer();
+    let block_stale_measure = gas_killer_common::block_stale_measure();
+    if payload_block_buffer > block_stale_measure {
+        tracing::warn!(
+            payload_block_buffer,
+            block_stale_measure,
+            "PAYLOAD_BLOCK_BUFFER exceeds BLOCK_STALE_MEASURE; rendered payloads may expire on-chain before valid_until_block"
+        );
+    }
+
     // Log the router's public key G2 coordinates for config generation
     let my_pub_key = signer.public_key();
     let g2_point = G2Affine::deserialize_compressed(my_pub_key.as_ref()).unwrap();

--- a/router/src/sequencer.rs
+++ b/router/src/sequencer.rs
@@ -12,6 +12,7 @@ use crate::store::{SqliteStore, TaskStatus};
 use commonware_avs_router::sequencer::{SequencedTask, TaskSource};
 use gas_killer_common::GasKillerValidator;
 use gas_killer_common::task_data::GasKillerTaskData;
+use gas_killer_common::{PayloadView, TaskBundle};
 
 use alloy_primitives::Bytes;
 use anyhow::Result;
@@ -80,8 +81,33 @@ async fn set_task_processing(store: &SqliteStore, task_id: &str) {
     }
 }
 
-pub(crate) async fn set_task_ready(store: &SqliteStore, task_id: &str) {
-    if let Err(e) = store.update_task_status(task_id, TaskStatus::Ready).await {
+/// Settles a task ready, persisting both the rendered transaction-request `payload` and the
+/// structured `bundle` it was derived from (each as JSON). A serialization failure is logged and
+/// the transition skipped rather than propagated, following the best-effort convention above.
+pub(crate) async fn set_task_ready(
+    store: &SqliteStore,
+    task_id: &str,
+    payload: &PayloadView,
+    bundle: &TaskBundle,
+) {
+    let payload_json = match serde_json::to_string(payload) {
+        Ok(json) => json,
+        Err(e) => {
+            error!(task_id, error = %e, "failed to serialize payload; task not marked ready");
+            return;
+        }
+    };
+    let bundle_json = match serde_json::to_string(bundle) {
+        Ok(json) => json,
+        Err(e) => {
+            error!(task_id, error = %e, "failed to serialize bundle; task not marked ready");
+            return;
+        }
+    };
+    if let Err(e) = store
+        .mark_task_ready_with_bundle(task_id, &payload_json, &bundle_json)
+        .await
+    {
         error!(task_id, error = %e, "failed to mark task ready");
     }
 }
@@ -398,7 +424,8 @@ impl TaskSource<GasKillerTaskData> for GasKillerTaskSource {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{Address, U256};
+    use alloy::primitives::{Address, B256, FixedBytes, U256};
+    use gas_killer_common::BundleProof;
 
     fn sample_request(transition_index: Option<u64>) -> GasKillerTaskRequest {
         GasKillerTaskRequest {
@@ -482,6 +509,35 @@ mod tests {
         }
     }
 
+    fn sample_payload() -> PayloadView {
+        PayloadView {
+            to: Address::from([0x11; 20]),
+            data: Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+            value: U256::ZERO,
+            chain_id: 31337,
+            estimated_gas: 21_000,
+            valid_until_block: 100,
+        }
+    }
+
+    fn sample_bundle() -> TaskBundle {
+        TaskBundle {
+            msg_hash: B256::ZERO,
+            reference_block_number: 50,
+            transition_index: 0,
+            target_address: Address::from([0x11; 20]),
+            target_function: FixedBytes::<4>::from([0x12, 0x34, 0x56, 0x78]),
+            storage_updates: Bytes::new(),
+            chain_id: 31337,
+            value: U256::ZERO,
+            valid_until_block: 100,
+            proof: BundleProof::Bls {
+                quorum_numbers: Bytes::from(vec![0x00]),
+                non_signer_stakes_and_signature: Bytes::new(),
+            },
+        }
+    }
+
     fn unreachable_validator() -> Arc<GasKillerValidator> {
         // Nothing listens on this port; RPC calls fail fast with connection refused
         // rather than hanging, so `enrich` errors quickly and deterministically.
@@ -501,11 +557,14 @@ mod tests {
             TaskStatus::Processing
         );
 
-        set_task_ready(&store, &done.id).await;
-        assert_eq!(
-            store.get_task(&done.id).await.unwrap().unwrap().status,
-            TaskStatus::Ready
-        );
+        set_task_ready(&store, &done.id, &sample_payload(), &sample_bundle()).await;
+        let ready = store.get_task(&done.id).await.unwrap().unwrap();
+        assert_eq!(ready.status, TaskStatus::Ready);
+        // Both the rendered payload and the structured bundle are persisted as JSON.
+        let payload: PayloadView = serde_json::from_str(ready.payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload, sample_payload());
+        let bundle: TaskBundle = serde_json::from_str(ready.bundle.as_deref().unwrap()).unwrap();
+        assert_eq!(bundle, sample_bundle());
 
         set_task_failed(&store, &doomed.id, "boom").await;
         let failed = store.get_task(&doomed.id).await.unwrap().unwrap();

--- a/router/src/store/tasks.rs
+++ b/router/src/store/tasks.rs
@@ -24,7 +24,7 @@ use crate::ingress::GasKillerTaskRequestBody;
 /// Columns selected for every task read, in the order the [`TaskRow`] fields expect. sqlx maps
 /// by column name, but listing them once keeps the queries consistent and self-documenting.
 const TASK_COLUMNS: &str = "id, key_id, status, target_address, call_data, transition_index, \
-     from_address, value, block_height, payload, error, created_at, updated_at";
+     from_address, value, block_height, payload, bundle, error, created_at, updated_at";
 
 /// Lifecycle state of a task as it moves through aggregation.
 ///
@@ -82,8 +82,12 @@ pub struct Task {
     pub status: TaskStatus,
     /// The original request, preserved so the task can be rebuilt and re-enqueued on restart.
     pub request: GasKillerTaskRequestBody,
-    /// Executable payload, populated once the task is [`TaskStatus::Ready`].
+    /// Serialized [`gas_killer_common::PayloadView`] — the ready-to-sign transaction request,
+    /// populated once the task is [`TaskStatus::Ready`].
     pub payload: Option<String>,
+    /// Serialized [`gas_killer_common::TaskBundle`] — the structured completed round the payload
+    /// is rendered from, populated alongside `payload` once the task is [`TaskStatus::Ready`].
+    pub bundle: Option<String>,
     /// Human-readable failure reason, populated once the task is `failed` or `expired`.
     pub error: Option<String>,
     pub created_at: i64,
@@ -104,6 +108,7 @@ struct TaskRow {
     value: String,
     block_height: i64,
     payload: Option<String>,
+    bundle: Option<String>,
     error: Option<String>,
     created_at: i64,
     updated_at: i64,
@@ -132,6 +137,7 @@ impl TryFrom<TaskRow> for Task {
             key_id: row.key_id,
             request,
             payload: row.payload,
+            bundle: row.bundle,
             error: row.error,
             created_at: row.created_at,
             updated_at: row.updated_at,
@@ -177,6 +183,7 @@ impl SqliteStore {
             status: TaskStatus::Queued,
             request: request.clone(),
             payload: None,
+            bundle: None,
             error: None,
             created_at,
             updated_at,
@@ -250,6 +257,49 @@ impl SqliteStore {
         .execute(self.pool())
         .await
         .context("marking task ready")?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Settles a task as [`TaskStatus::Ready`], recording both the rendered transaction-request
+    /// `payload` and the structured round `bundle` it was rendered from, and stamping
+    /// `updated_at`. Both are stored as JSON. Returns `true` if a task with that id existed.
+    pub async fn mark_task_ready_with_bundle(
+        &self,
+        id: &str,
+        payload: &str,
+        bundle: &str,
+    ) -> anyhow::Result<bool> {
+        let result = sqlx::query(
+            "UPDATE tasks SET status = 'ready', payload = ?2, bundle = ?3, \
+             updated_at = unixepoch() WHERE id = ?1",
+        )
+        .bind(id)
+        .bind(payload)
+        .bind(bundle)
+        .execute(self.pool())
+        .await
+        .context("marking task ready with bundle")?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Settles a task as [`TaskStatus::Expired`], recording why and stamping `updated_at`.
+    ///
+    /// The read path uses this when a ready payload is no longer submittable — its
+    /// `valid_until_block` has passed or the on-chain transition index has advanced — so a later
+    /// poll short-circuits to the re-request error without another chain read. Returns `true` if a
+    /// task with that id existed.
+    pub async fn mark_task_expired(&self, id: &str, reason: &str) -> anyhow::Result<bool> {
+        let result = sqlx::query(
+            "UPDATE tasks SET status = 'expired', error = ?2, updated_at = unixepoch() \
+             WHERE id = ?1",
+        )
+        .bind(id)
+        .bind(reason)
+        .execute(self.pool())
+        .await
+        .context("marking task expired")?;
 
         Ok(result.rows_affected() > 0)
     }
@@ -487,6 +537,57 @@ mod tests {
         assert_eq!(fetched.status, TaskStatus::Ready);
         assert_eq!(fetched.payload.as_deref(), Some("0xcafe"));
         assert!(fetched.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_ready_with_bundle_records_both() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request()).await.unwrap();
+
+        assert!(
+            store
+                .mark_task_ready_with_bundle(&task.id, "{\"payload\":1}", "{\"bundle\":2}")
+                .await
+                .unwrap()
+        );
+        let fetched = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, TaskStatus::Ready);
+        assert_eq!(fetched.payload.as_deref(), Some("{\"payload\":1}"));
+        assert_eq!(fetched.bundle.as_deref(), Some("{\"bundle\":2}"));
+        assert!(fetched.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_expired_records_reason() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let task = store.create_task(&key, &request()).await.unwrap();
+        store
+            .mark_task_ready_with_bundle(&task.id, "{}", "{}")
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .mark_task_expired(&task.id, "payload validity window elapsed")
+                .await
+                .unwrap()
+        );
+        let fetched = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, TaskStatus::Expired);
+        assert_eq!(
+            fetched.error.as_deref(),
+            Some("payload validity window elapsed")
+        );
+
+        assert!(
+            !store
+                .mark_task_expired("does-not-exist", "nope")
+                .await
+                .unwrap(),
+            "expiring an unknown task should report no change"
+        );
     }
 
     #[tokio::test]

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -262,16 +262,15 @@ echo -e "${GREEN}Minted API key for task submission${NC}"
 echo -e "${YELLOW}Step 10: Triggering task and verifying execution...${NC}"
 echo "Sending a test task to the router..."
 cd "$PROJECT_ROOT/scripts"
-# send_request now submits the router-rendered payload itself and prints the user-submitted
-# verifyAndUpdate tx hash; capture its output so the diagnostics below can trace that tx. The
-# `tee` pipeline exits 0, so `set -e` does not abort here — the real status comes from PIPESTATUS.
+# send_request signs and submits the rendered payload and prints the verifyAndUpdate tx hash;
+# capture its output so the diagnostics below can trace that tx. The `tee` pipeline exits 0, so
+# `set -e` does not abort here — the real status comes from PIPESTATUS.
 SEND_REQUEST_LOG="$(mktemp)"
 cargo run --release -p scripts --bin send_request 2>&1 | tee "$SEND_REQUEST_LOG"
 TRIGGER_STATUS=${PIPESTATUS[0]}
 cd "$PROJECT_ROOT"
 
-# The user-submitted verifyAndUpdate tx hash, extracted from send_request's output (the router no
-# longer broadcasts, so it is not in the router logs).
+# The user-submitted verifyAndUpdate tx hash, extracted from send_request's output.
 USER_TX_HASH=$(grep -oE 'landed: tx 0x[a-fA-F0-9]{64}' "$SEND_REQUEST_LOG" | sed -E 's/.*tx //' | tail -1)
 
 if [ $TRIGGER_STATUS -eq 0 ]; then

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -262,9 +262,17 @@ echo -e "${GREEN}Minted API key for task submission${NC}"
 echo -e "${YELLOW}Step 10: Triggering task and verifying execution...${NC}"
 echo "Sending a test task to the router..."
 cd "$PROJECT_ROOT/scripts"
-cargo run --release -p scripts --bin send_request
-TRIGGER_STATUS=$?
+# send_request now submits the router-rendered payload itself and prints the user-submitted
+# verifyAndUpdate tx hash; capture its output so the diagnostics below can trace that tx. The
+# `tee` pipeline exits 0, so `set -e` does not abort here — the real status comes from PIPESTATUS.
+SEND_REQUEST_LOG="$(mktemp)"
+cargo run --release -p scripts --bin send_request 2>&1 | tee "$SEND_REQUEST_LOG"
+TRIGGER_STATUS=${PIPESTATUS[0]}
 cd "$PROJECT_ROOT"
+
+# The user-submitted verifyAndUpdate tx hash, extracted from send_request's output (the router no
+# longer broadcasts, so it is not in the router logs).
+USER_TX_HASH=$(grep -oE 'landed: tx 0x[a-fA-F0-9]{64}' "$SEND_REQUEST_LOG" | sed -E 's/.*tx //' | tail -1)
 
 if [ $TRIGGER_STATUS -eq 0 ]; then
     echo -e "${GREEN}✅ Array summation verified successfully - state was updated!${NC}"
@@ -274,12 +282,11 @@ else
     docker compose logs --tail=100 router || true
     echo -e "${YELLOW}Recent node logs:${NC}"
     docker compose logs --tail=50 node-1 node-2 node-3 || true
-    # Trace the verifyAndUpdate transaction, if one was submitted, to surface a revert reason.
+    # If the user-submitted verifyAndUpdate reverted, re-simulate it to surface a revert reason.
     # cast run re-simulates the transaction, so this is best-effort diagnostic output.
-    TX_HASH=$(docker compose logs router 2>/dev/null | grep "Contract execution result" | grep -o "transaction_hash=0x[a-fA-F0-9]*" | sed 's/transaction_hash=//' | tail -1)
-    if [ -n "$TX_HASH" ] && command -v cast >/dev/null 2>&1; then
-        echo -e "${YELLOW}Execution trace for $TX_HASH:${NC}"
-        cast run "$TX_HASH" --rpc-url http://localhost:8545 || true
+    if [ -n "$USER_TX_HASH" ] && command -v cast >/dev/null 2>&1; then
+        echo -e "${YELLOW}Execution trace for $USER_TX_HASH:${NC}"
+        cast run "$USER_TX_HASH" --rpc-url http://localhost:8545 || true
     fi
     exit 1
 fi
@@ -288,12 +295,11 @@ fi
 echo -e "${YELLOW}Recent router logs:${NC}"
 docker compose logs --tail=50 router || true
 
-# Print the execution trace of the successful verifyAndUpdate for inspection.
+# Print the execution trace of the successful user-submitted verifyAndUpdate for inspection.
 # debug_traceTransaction reflects the real mined execution, not a re-simulation.
-TX_HASH=$(docker compose logs router 2>/dev/null | grep "Contract execution result" | grep -o "transaction_hash=0x[a-fA-F0-9]*" | sed 's/transaction_hash=//' | tail -1)
-if [ -n "$TX_HASH" ] && command -v cast >/dev/null 2>&1; then
-    echo -e "${YELLOW}Execution trace for $TX_HASH:${NC}"
-    cast rpc debug_traceTransaction "$TX_HASH" '{"tracer":"callTracer"}' --rpc-url http://localhost:8545 | jq '.' || true
+if [ -n "$USER_TX_HASH" ] && command -v cast >/dev/null 2>&1; then
+    echo -e "${YELLOW}Execution trace for $USER_TX_HASH:${NC}"
+    cast rpc debug_traceTransaction "$USER_TX_HASH" '{"tracer":"callTracer"}' --rpc-url http://localhost:8545 | jq '.' || true
 fi
 
 echo -e "${GREEN}✅ Test passed - Stack is up and array summation completed successfully!${NC}"

--- a/scripts/send_request.rs
+++ b/scripts/send_request.rs
@@ -189,10 +189,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .ok()
         .filter(|k| !k.is_empty());
 
-    // The router no longer submits `verifyAndUpdate` itself: it renders a ready-to-sign payload.
-    // Poll until the task is `ready`, extract that payload, submit it ourselves with a funded key,
-    // then confirm the on-chain effect (`currentSum` moving) — the same end-to-end assertion, now
-    // driven by the user's submission rather than a router-broadcast transaction.
+    // Poll until the task is `ready`, extract the rendered payload, submit it with a funded key,
+    // then confirm the on-chain effect by checking `currentSum` moved.
     let http_rpc = env::var("HTTP_RPC")?;
     // Prefer FUNDED_KEY (the Anvil dev account funded on the fork) so a hand-edited `.env` with a
     // real-but-unfunded PRIVATE_KEY doesn't accidentally break local submission.

--- a/scripts/send_request.rs
+++ b/scripts/send_request.rs
@@ -1,7 +1,11 @@
+use alloy::network::{EthereumWallet, TransactionBuilder};
 use alloy::primitives::{Address, U256, hex};
 use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolCall;
 use bindings::arraysummation::ArraySummation::sumCall;
+use gas_killer_common::PayloadView;
 use gas_killer_router::ingress::{GasKillerTaskRequest, GasKillerTaskRequestBody};
 use serde_json::json;
 use std::env;
@@ -185,64 +189,54 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .ok()
         .filter(|k| !k.is_empty());
 
-    // Poll currentSum until it changes or timeout
-    use tokio::time::{Duration, Instant, sleep};
-    let max_wait_time = Duration::from_secs(150);
-    let check_interval = Duration::from_secs(10);
-    let start_time = Instant::now();
+    // The router no longer submits `verifyAndUpdate` itself: it renders a ready-to-sign payload.
+    // Poll until the task is `ready`, extract that payload, submit it ourselves with a funded key,
+    // then confirm the on-chain effect (`currentSum` moving) — the same end-to-end assertion, now
+    // driven by the user's submission rather than a router-broadcast transaction.
+    let http_rpc = env::var("HTTP_RPC")?;
+    // Prefer FUNDED_KEY (the Anvil dev account funded on the fork) so a hand-edited `.env` with a
+    // real-but-unfunded PRIVATE_KEY doesn't accidentally break local submission.
+    let submit_key = env::var("FUNDED_KEY")
+        .or_else(|_| env::var("PRIVATE_KEY"))
+        .map_err(|_| "FUNDED_KEY or PRIVATE_KEY required to submit the payload")?;
 
-    loop {
-        let current_sum = array_contract
-            .currentSum()
-            .call()
-            .await
-            .map_err(|e| format!("Failed to read currentSum after trigger: {}", e))?
-            .to::<u64>();
+    let payload =
+        wait_for_ready_payload(&client, &task_status_url, api_key.as_deref(), &task_id).await?;
 
-        println!(
-            "currentSum: {}, Initial: {}, Elapsed: {:.1}s",
-            current_sum,
-            initial_sum,
-            start_time.elapsed().as_secs_f64()
-        );
+    submit_payload(&payload, &http_rpc, &submit_key).await?;
 
-        if current_sum != initial_sum {
-            println!(
-                "✅ currentSum changed from {} to {} — confirming task {} reaches 'ready'",
-                initial_sum, current_sum, task_id
-            );
-            return confirm_task_ready(&client, &task_status_url, api_key.as_deref(), &task_id)
-                .await;
-        }
-
-        if start_time.elapsed() >= max_wait_time {
-            println!(
-                "❌ TIMEOUT: currentSum unchanged ({}), waited {:.1} seconds",
-                current_sum,
-                max_wait_time.as_secs_f64()
-            );
-            return Err("Timeout waiting for currentSum to change".into());
-        }
-
-        sleep(check_interval).await;
+    let final_sum = array_contract
+        .currentSum()
+        .call()
+        .await
+        .map_err(|e| format!("Failed to read currentSum after submission: {}", e))?
+        .to::<u64>();
+    if final_sum == initial_sum {
+        return Err(format!(
+            "currentSum unchanged ({final_sum}) after submitting the payload; verifyAndUpdate had no effect"
+        )
+        .into());
     }
+    println!(
+        "✅ SUCCESS: currentSum changed {} → {} after the user-submitted verifyAndUpdate (task {})",
+        initial_sum, final_sum, task_id
+    );
+    Ok(())
 }
 
-/// Confirms `task_id` settles to `ready` shortly after `currentSum` moves,
-/// exercising the status-transition wiring (not just the on-chain effect).
+/// Polls `GET /tasks/{id}` until the task is `ready` and returns its rendered payload.
 ///
-/// The on-chain confirmation and the `ready` write happen back-to-back inside the
-/// same `handle_verification` call (see `router/src/executor.rs`), so this is a
-/// short, bounded follow-up poll — not another long wait for a fresh aggregation
-/// round.
-async fn confirm_task_ready(
+/// A `ready` response carries the transaction request the user submits as-is. A `failed`/`expired`
+/// settlement, or a non-success status (e.g. `409 PAYLOAD_EXPIRED` if the payload went stale before
+/// we submitted), is terminal and surfaces as an error.
+async fn wait_for_ready_payload(
     client: &reqwest::Client,
     task_status_url: &Url,
     api_key: Option<&str>,
     task_id: &str,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<PayloadView, Box<dyn std::error::Error + Send + Sync>> {
     use tokio::time::{Duration, Instant, sleep};
-    let max_wait_time = Duration::from_secs(60);
+    let max_wait_time = Duration::from_secs(150);
     let check_interval = Duration::from_secs(5);
     let start_time = Instant::now();
 
@@ -251,13 +245,28 @@ async fn confirm_task_ready(
         if let Some(api_key) = api_key {
             req = req.header("Authorization", format!("Bearer {api_key}"));
         }
-        let body: serde_json::Value = req
+        let resp = req
             .send()
             .await
-            .map_err(|e| format!("Failed to poll task {}: {}", task_id, e))?
+            .map_err(|e| format!("Failed to poll task {}: {}", task_id, e))?;
+        let status_code = resp.status();
+        let body: serde_json::Value = resp
             .json()
             .await
             .map_err(|e| format!("Failed to parse task {} response: {}", task_id, e))?;
+
+        // A non-success status (e.g. 409 PAYLOAD_EXPIRED) carries an error envelope, not a task.
+        if !status_code.is_success() {
+            let code = body
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_str())
+                .unwrap_or("UNKNOWN");
+            return Err(
+                format!("Task {task_id} status query returned {status_code} ({code})").into(),
+            );
+        }
+
         let task_status = body
             .get("status")
             .and_then(|s| s.as_str())
@@ -273,8 +282,21 @@ async fn confirm_task_ready(
 
         match task_status.as_str() {
             "ready" => {
-                println!("✅ SUCCESS: task {} reached 'ready'", task_id);
-                return Ok(());
+                let payload_value = body
+                    .get("payload")
+                    .cloned()
+                    .ok_or_else(|| format!("ready task {task_id} carried no payload"))?;
+                let payload: PayloadView = serde_json::from_value(payload_value)
+                    .map_err(|e| format!("failed to parse task {task_id} payload: {e}"))?;
+                println!(
+                    "✅ task {} ready: to={:?} chain_id={} estimated_gas={} valid_until_block={}",
+                    task_id,
+                    payload.to,
+                    payload.chain_id,
+                    payload.estimated_gas,
+                    payload.valid_until_block
+                );
+                return Ok(payload);
             }
             "failed" | "expired" => {
                 let error = body
@@ -290,7 +312,7 @@ async fn confirm_task_ready(
 
         if start_time.elapsed() >= max_wait_time {
             return Err(format!(
-                "Task {} did not reach 'ready' within {:.0}s of currentSum changing (last status: {})",
+                "Task {} did not reach 'ready' within {:.0}s (last status: {})",
                 task_id,
                 max_wait_time.as_secs_f64(),
                 task_status
@@ -300,6 +322,53 @@ async fn confirm_task_ready(
 
         sleep(check_interval).await;
     }
+}
+
+/// Signs and submits a rendered payload with a funded key, mirroring what an integrator does, and
+/// asserts the `verifyAndUpdate` transaction lands successfully.
+async fn submit_payload(
+    payload: &PayloadView,
+    http_rpc: &str,
+    private_key: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let signer: PrivateKeySigner = private_key
+        .parse()
+        .map_err(|_| "invalid FUNDED_KEY/PRIVATE_KEY format")?;
+    let sender = signer.address();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer))
+        .connect_http(http_rpc.parse().map_err(|_| "invalid HTTP_RPC URL")?);
+
+    let tx = TransactionRequest::default()
+        .with_to(payload.to)
+        .with_value(payload.value)
+        .with_input(payload.data.clone());
+
+    println!(
+        "Submitting verifyAndUpdate as {sender} to {:?} ({} bytes calldata)",
+        payload.to,
+        payload.data.len()
+    );
+    let pending = provider
+        .send_transaction(tx)
+        .await
+        .map_err(|e| format!("failed to send verifyAndUpdate: {e}"))?;
+    let receipt = pending
+        .get_receipt()
+        .await
+        .map_err(|e| format!("failed to get verifyAndUpdate receipt: {e}"))?;
+    if !receipt.status() {
+        return Err(format!(
+            "verifyAndUpdate reverted (tx {:?}, block {:?})",
+            receipt.transaction_hash, receipt.block_number
+        )
+        .into());
+    }
+    println!(
+        "✅ verifyAndUpdate landed: tx {:?} in block {:?}",
+        receipt.transaction_hash, receipt.block_number
+    );
+    Ok(())
 }
 
 fn env_var(name: &str) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {


### PR DESCRIPTION
Closes #195.

Shifts execution to the user for v1 beta: instead of the router custodying a funded key and broadcasting `verifyAndUpdate`, a completed aggregation round is persisted as a structured **bundle** and `GET /tasks/{id}` returns a ready-to-sign **transaction request** the user submits themselves.

## Acceptance criteria
- Round completion → task `ready` with a populated `payload` (previously always `null`).
- Round persisted as a `TaskBundle` (msgHash, quorum/proof, referenceBlockNumber, storageUpdates, transitionIndex, targetFunction, chainId, validity) in a new `tasks.bundle` column (migration `0003`); the payload is rendered from it.
- `payload` is a full `{ to, data, value, chain_id, estimated_gas, valid_until_block }` request. `to`/`value` are server-controlled (`value = 0`, not payable in beta) so a future on-chain fee is a server change, not an integrator client-code change.
- `valid_until_block = reference_block + PAYLOAD_BLOCK_BUFFER` (env, default 50, compile-time-asserted `<= BLOCK_STALE_MEASURE`).
- A stale or consumed bundle (past `valid_until_block`, or on-chain `stateTransitionCount` advanced) returns a typed `409 PAYLOAD_EXPIRED` re-request error rather than calldata that would revert. Backed by a short-TTL freshness cache plus persisting `expired` on first detection so repeat polls skip the chain reads.
- The `Executor` is disconnected from the completion path (bundle written, not broadcast) but **retained and reachable** — `execute_verification` / `execute_schnorr_verification` and the funded wallet provider are the future per-API-key **auto-execute** entry point and share `prepare_*` with the render path so switching between render and broadcast stays a localized branch.

Both BLS and Schnorr completion twins are handled.

## Implementation
- `common/src/payload.rs` — new `PayloadView` / `TaskBundle` / `BundleProof` DTOs.
- `common/src/config.rs` — `PAYLOAD_BLOCK_BUFFER` accessor + default.
- `router/src/executor.rs` — factored into `prepare_bls`/`prepare_schnorr` (shared preflight) → `render_*` (calldata via `.calldata()` + `eth_estimateGas`, no broadcast) and the retained `execute_*` broadcast path; completion handlers render + persist.
- `router/src/store/tasks.rs` (+ migration `0003`) — `bundle` column, `mark_task_ready_with_bundle`, `mark_task_expired`.
- `router/src/{sequencer,factories,error,ingress,main}.rs` — settle helper carries payload+bundle; `PayloadExpired` error; `render_or_reject_payload` freshness check on `GET /tasks/{id}`; startup warn when buffer exceeds the staleness window.
- `scripts/send_request.rs` + `run_e2e_test.sh` — e2e reworked to poll until `ready`, sign+submit the payload with `FUNDED_KEY`, and assert `currentSum` moved.
- `example.env`, Helm values/router-deployment, docker-compose — `PAYLOAD_BLOCK_BUFFER` threaded.

## Testing
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` (zero warnings), `cargo test --all-targets --all-features` — all pass locally.
- New coverage: payload/bundle serde + wire shape, ABI-decode of rendered calldata, the full stale-check matrix (in-window pass, block-past, transition-mismatch, RPC→503, no-providers skip, non-ready, already-expired short-circuit), and store bundle/expired transitions.
- The docker-compose + Anvil e2e (`run_e2e_test.sh`) runs in the `e2e-test.yml` matrix (bls, schnorr).
