### PR TITLE
feat: enforce global queue depth cap with backpressure

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -189,6 +189,25 @@ pub fn p2p_message_backlog() -> usize {
         .unwrap_or(DEFAULT_P2P_MESSAGE_BACKLOG)
 }
 
+/// Default maximum number of tasks the ingress queue holds before shedding load.
+///
+/// The router processes one task at a time, so a deep queue means later submissions are
+/// aggregated long after their block references have gone stale. Capping the depth bounds
+/// both memory and worst-case queue latency; requests arriving at capacity are rejected with
+/// `503 QUEUE_FULL` rather than accepted and starved. Configurable via `MAX_QUEUE_DEPTH`.
+pub const DEFAULT_MAX_QUEUE_DEPTH: usize = 100;
+
+/// Reads the ingress queue-depth cap from `MAX_QUEUE_DEPTH`, defaulting to
+/// [`DEFAULT_MAX_QUEUE_DEPTH`]. Zero or unparseable values fall back to the default,
+/// since a cap of zero would reject every request.
+pub fn max_queue_depth() -> usize {
+    env::var("MAX_QUEUE_DEPTH")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .filter(|&v: &usize| v > 0)
+        .unwrap_or(DEFAULT_MAX_QUEUE_DEPTH)
+}
+
 /// Reads the P2P channel rate limit from `P2P_MESSAGES_PER_SECOND` and returns the
 /// per-message quota period (`1 / rate`), defaulting to
 /// [`DEFAULT_P2P_MESSAGES_PER_SECOND`] when unset or invalid.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,9 +11,9 @@ pub use config::{
     ChainRole, DEFAULT_PAYLOAD_BLOCK_BUFFER, KeyConfig, OrchestratorConfig, SignatureScheme,
     SpeculativePrebuildConfig, ack_messages_per_second, agg_activity_timeout, agg_window,
     block_stale_measure, detect_chain_for_address, get_operator_states, load_key_from_file,
-    load_orchestrator_config, p2p_message_backlog, p2p_quota_period, payload_block_buffer,
-    quorum_threshold_fraction, rebroadcast_interval, round_timeout, schnorr_messages_per_second,
-    schnorr_stage_timeout, signature_scheme, storage_directory,
+    load_orchestrator_config, max_queue_depth, p2p_message_backlog, p2p_quota_period,
+    payload_block_buffer, quorum_threshold_fraction, rebroadcast_interval, round_timeout,
+    schnorr_messages_per_second, schnorr_stage_timeout, signature_scheme, storage_directory,
 };
 pub use payload::{BundleProof, PayloadView, TaskBundle};
 pub use providers::{build_read_providers, chain_rpc_urls_from_env};

--- a/example.env
+++ b/example.env
@@ -249,6 +249,12 @@ SIGNER_ENDPOINT=http://signer:50051
 INGRESS=true
 INGRESS_ADDRESS=0.0.0.0:8080
 INGRESS_TIMEOUT_MS=0
+# MAX_QUEUE_DEPTH: maximum number of tasks allowed in the ingress queue before the router sheds
+# load. Once the queue is at capacity, POST /tasks returns 503 QUEUE_FULL with a Retry-After hint
+# instead of accepting work that would be aggregated long after its block reference goes stale.
+# The router processes one task at a time, so this bounds both memory and worst-case queue
+# latency. Zero or unparseable values fall back to the default. Default: 100.
+# MAX_QUEUE_DEPTH=100
 # Shared secret guarding the /admin/keys endpoints, used to mint and revoke per-client API keys
 # via `Authorization: Bearer <ADMIN_KEY>`. Clients then authenticate /trigger with their minted
 # key. Leave unset to disable the admin API. Required for TESTNET mode with ingress enabled.

--- a/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
+++ b/helm/gas-killer/templates/monitoring-grafana-dashboard.yaml
@@ -293,7 +293,7 @@ data:
           "gridPos": { "x": 18, "y": 24, "w": 6, "h": 8 },
           "targets": [
             {
-              "expr": "gas_killer_task_queue_depth",
+              "expr": "gas_killer_queue_depth",
               "legendFormat": "queued tasks"
             }
           ],

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -293,6 +293,8 @@ spec:
               value: {{ .Values.router.persistence.mountPath | quote }}
             - name: INGRESS_TIMEOUT_MS
               value: {{ .Values.router.ingress.timeoutMs | quote }}
+            - name: MAX_QUEUE_DEPTH
+              value: {{ .Values.router.ingress.maxQueueDepth | quote }}
             {{- if or (and (eq .Values.global.environment "TESTNET") .Values.router.ingress.enabled) .Values.secrets.adminKey .Values.secrets.existingSecret }}
             - name: ADMIN_KEY
               valueFrom:

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -335,6 +335,10 @@ router:
     # IMPORTANT: Must be quoted string to prevent YAML from converting to scientific notation.
     # "0" means no timeout — router waits indefinitely for an incoming task.
     timeoutMs: "0"
+    # Maximum tasks the ingress queue holds before shedding load. At capacity, POST /tasks
+    # returns 503 QUEUE_FULL with a Retry-After hint. The router processes one task at a time,
+    # so this bounds both memory and worst-case queue latency (MAX_QUEUE_DEPTH).
+    maxQueueDepth: "100"
   # AVS identity metadata served at GET /avs-metadata.
   # Set metadata.uri in config.json to the public URL of this endpoint
   # (e.g. https://api.gaskiller.xyz/avs-metadata) before calling updateAVSMetadataURI.

--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -13,8 +13,8 @@
 
 use axum::extract::rejection::{JsonRejection, QueryRejection};
 use axum::extract::{FromRequest, FromRequestParts, Query, Request};
-use axum::http::StatusCode;
 use axum::http::request::Parts;
+use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::{Json, async_trait};
 use serde::{Deserialize, Serialize};
@@ -88,6 +88,10 @@ pub struct ApiError {
     pub status: StatusCode,
     pub code: ErrorCode,
     pub message: String,
+    /// When set, emitted as a `Retry-After` header (in seconds) so a client that hit a
+    /// transient limit knows roughly how long to wait before retrying. Only meaningful for
+    /// retryable statuses (e.g. 503 `QUEUE_FULL`).
+    pub retry_after_secs: Option<u64>,
 }
 
 impl ApiError {
@@ -96,7 +100,14 @@ impl ApiError {
             status,
             code,
             message: message.into(),
+            retry_after_secs: None,
         }
+    }
+
+    /// Attaches a `Retry-After` estimate (in seconds), returned as a header on the response.
+    pub fn with_retry_after(mut self, secs: u64) -> Self {
+        self.retry_after_secs = Some(secs);
+        self
     }
 
     /// 401 with [`ErrorCode::Unauthorized`].
@@ -125,13 +136,15 @@ impl ApiError {
         Self::new(StatusCode::CONFLICT, ErrorCode::PayloadExpired, message)
     }
 
-    /// 503 with [`ErrorCode::QueueFull`].
-    pub fn queue_full(message: impl Into<String>) -> Self {
+    /// 503 with [`ErrorCode::QueueFull`], carrying a `Retry-After` estimate (seconds) so a
+    /// load-shed client backs off rather than hot-looping against a full queue.
+    pub fn queue_full(message: impl Into<String>, retry_after_secs: u64) -> Self {
         Self::new(
             StatusCode::SERVICE_UNAVAILABLE,
             ErrorCode::QueueFull,
             message,
         )
+        .with_retry_after(retry_after_secs)
     }
 
     /// 500 with [`ErrorCode::Internal`].
@@ -146,13 +159,21 @@ impl ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
+        let retry_after = self.retry_after_secs;
+        let status = self.status;
         let body = ApiErrorEnvelope {
             error: ApiErrorBody {
                 code: self.code,
                 message: self.message,
             },
         };
-        (self.status, Json(body)).into_response()
+        let mut response = (status, Json(body)).into_response();
+        if let Some(secs) = retry_after
+            && let Ok(value) = HeaderValue::from_str(&secs.to_string())
+        {
+            response.headers_mut().insert(header::RETRY_AFTER, value);
+        }
+        response
     }
 }
 
@@ -262,6 +283,22 @@ mod tests {
         let err = ApiError::payload_expired("valid_until_block 100 passed; re-request");
         assert_eq!(err.status, StatusCode::CONFLICT);
         assert_eq!(err.code, ErrorCode::PayloadExpired);
+    }
+
+    #[tokio::test]
+    async fn queue_full_response_sets_retry_after_header() {
+        let resp = ApiError::queue_full("full", 60).into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            resp.headers().get(header::RETRY_AFTER).unwrap(),
+            &HeaderValue::from_static("60")
+        );
+    }
+
+    #[tokio::test]
+    async fn error_without_retry_after_omits_the_header() {
+        let resp = ApiError::not_found("nope").into_response();
+        assert!(resp.headers().get(header::RETRY_AFTER).is_none());
     }
 
     #[test]

--- a/router/src/factories.rs
+++ b/router/src/factories.rs
@@ -172,7 +172,7 @@ pub async fn create_ingress(metrics: Arc<MetricsCollector>) -> Result<IngressHan
     let ingress_state = IngressState::new(
         sender.clone(),
         queue_depth.clone(),
-        gas_killer_common::p2p_message_backlog(),
+        gas_killer_common::max_queue_depth(),
         metrics,
         providers,
         avs_metadata,

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -172,7 +172,7 @@ impl IngressState {
         Self {
             sender,
             queue_depth,
-            max_queue_depth: gas_killer_common::p2p_message_backlog(),
+            max_queue_depth: gas_killer_common::max_queue_depth(),
             metrics: None,
             providers: Arc::new(HashMap::new()),
             freshness: Arc::new(FreshnessCache::default()),
@@ -615,6 +615,75 @@ pub struct TaskAcceptedResponse {
     pub status: TaskStatus,
 }
 
+/// `Retry-After` estimate (seconds) returned alongside a `503 QUEUE_FULL`. The router drains
+/// the queue one task at a time, so a slot typically frees once the in-flight round settles;
+/// sizing the hint to roughly one round nudges a shed client to retry about when capacity is
+/// likely to open rather than hot-looping against a full queue.
+const QUEUE_FULL_RETRY_AFTER_SECS: u64 = 60;
+
+/// A reserved slot in the ingress queue.
+///
+/// [`QueueSlot::reserve`] atomically increments the shared depth counter only while it is below
+/// the cap, so the capacity check and the reservation are a single operation with no
+/// check-then-increment race. Dropping the guard releases the slot (decrement + gauge refresh)
+/// unless it has been [`committed`](QueueSlot::commit) to an enqueued task, so a submission that
+/// is rejected or fails after reserving never permanently consumes capacity — regardless of which
+/// early-return path it takes.
+struct QueueSlot<'a> {
+    state: &'a IngressState,
+    committed: bool,
+}
+
+impl<'a> QueueSlot<'a> {
+    /// Atomically reserves a slot when the queue is below its cap, returning the guard and the
+    /// resulting depth. Returns `Err(current_depth)` when already at capacity, taking no slot.
+    fn reserve(state: &'a IngressState) -> Result<(Self, usize), usize> {
+        let max = state.max_queue_depth;
+        match state
+            .queue_depth
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                (n < max).then_some(n + 1)
+            }) {
+            Ok(prev) => {
+                let depth = prev + 1;
+                if let Some(m) = &state.metrics {
+                    m.task_queue_depth.set(depth as i64);
+                }
+                Ok((
+                    Self {
+                        state,
+                        committed: false,
+                    },
+                    depth,
+                ))
+            }
+            Err(current) => Err(current),
+        }
+    }
+
+    /// Transfers the reservation to an enqueued task so it is not released on drop; the sequencer
+    /// decrements the depth when it dequeues the task.
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for QueueSlot<'_> {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        let depth = self
+            .state
+            .queue_depth
+            .fetch_sub(1, Ordering::Relaxed)
+            .saturating_sub(1);
+        if let Some(m) = &self.state.metrics {
+            m.task_queue_depth.set(depth as i64);
+        }
+    }
+}
+
 /// Handler for `POST /tasks`, and its deprecated alias `POST /trigger`.
 ///
 /// Validates the request, persists it as a `queued` task before responding — so a restart can
@@ -629,24 +698,29 @@ pub async fn submit_task_handler(
 ) -> Result<(StatusCode, Json<TaskAcceptedResponse>), ApiError> {
     let key_id = authenticate_caller(&state, &headers).await?;
 
-    // Load-shed before any validation work. Onchain validation costs multiple RPC
-    // round-trips, so rejecting at-capacity requests up front keeps an overloaded
-    // service from amplifying its own load; a request that would have failed
-    // validation gets a 503 instead of a 400 while the queue is full.
-    let current_depth = state.queue_depth.load(Ordering::Relaxed);
-    if current_depth >= state.max_queue_depth {
-        warn!(
-            queue_depth = current_depth,
-            max_queue_depth = state.max_queue_depth,
-            "Task rejected: queue at capacity"
-        );
-        if let Some(m) = &state.metrics {
-            m.ingress_at_capacity.inc();
+    // Load-shed before any validation work by atomically reserving a queue slot. Onchain
+    // validation costs multiple RPC round-trips, so rejecting at-capacity requests up front keeps
+    // an overloaded service from amplifying its own load; a request that would have failed
+    // validation gets a 503 instead of a 400 while the queue is full. The reservation is released
+    // (see `QueueSlot`) on every early return below, so only a task that is actually enqueued
+    // consumes lasting capacity.
+    let slot = match QueueSlot::reserve(&state) {
+        Ok((slot, _depth)) => slot,
+        Err(current_depth) => {
+            warn!(
+                queue_depth = current_depth,
+                max_queue_depth = state.max_queue_depth,
+                "Task rejected: queue at capacity"
+            );
+            if let Some(m) = &state.metrics {
+                m.ingress_at_capacity.inc();
+            }
+            return Err(ApiError::queue_full(
+                "Service at capacity, please retry shortly",
+                QUEUE_FULL_RETRY_AFTER_SECS,
+            ));
         }
-        return Err(ApiError::queue_full(
-            "Service at capacity, please try again in a few minutes",
-        ));
-    }
+    };
 
     if let Err(e) = request.validate() {
         warn!(
@@ -701,19 +775,19 @@ pub async fn submit_task_handler(
         call_data_len = request.body.call_data.len(),
         "Task accepted"
     );
-    let depth = state.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
     let queued = QueuedTask {
         task_id: task.id.clone(),
         request,
     };
     if state.sender.send(queued).is_err() {
-        state.queue_depth.fetch_sub(1, Ordering::Relaxed);
         tracing::error!(task_id = %task.id, "task channel closed, dropping request");
         return Err(ApiError::internal("Internal error: task queue unavailable"));
     }
+    // The enqueued task now owns the reserved slot; the sequencer decrements the depth counter
+    // when it dequeues. Releasing here would double-count against a task that is genuinely queued.
+    slot.commit();
     if let Some(m) = &state.metrics {
         m.ingress_accepted.inc();
-        m.task_queue_depth.set(depth as i64);
     }
     Ok((
         StatusCode::ACCEPTED,
@@ -1361,6 +1435,49 @@ mod tests {
         assert_eq!(clamp_offset(Some(-1)), 0);
         assert_eq!(clamp_offset(Some(0)), 0);
         assert_eq!(clamp_offset(Some(42)), 42);
+    }
+
+    // -- queue-slot reservation --
+
+    fn slot_test_state(max_queue_depth: usize) -> (IngressState, TaskQueueDepth) {
+        // The receiver is unused: reservation only touches the depth counter, never the channel.
+        let (sender, _receiver) = crate::sequencer::task_channel();
+        let queue_depth = crate::sequencer::task_queue_depth();
+        let mut state = IngressState::without_metrics(sender, queue_depth.clone());
+        state.max_queue_depth = max_queue_depth;
+        (state, queue_depth)
+    }
+
+    #[test]
+    fn queue_slot_reserves_up_to_cap_then_refuses() {
+        let (state, queue_depth) = slot_test_state(2);
+
+        let (_s1, d1) = QueueSlot::reserve(&state).expect("first reservation fits");
+        let (_s2, d2) = QueueSlot::reserve(&state).expect("second reservation fills the queue");
+        assert_eq!((d1, d2), (1, 2));
+        assert_eq!(queue_depth.load(Ordering::Relaxed), 2);
+
+        // At capacity the reservation is refused atomically and consumes no slot, so concurrent
+        // submissions cannot race past the cap.
+        assert!(QueueSlot::reserve(&state).is_err());
+        assert_eq!(queue_depth.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn queue_slot_releases_on_drop_but_not_after_commit() {
+        let (state, queue_depth) = slot_test_state(2);
+
+        let (dropped, _) = QueueSlot::reserve(&state).expect("reservation fits");
+        let (kept, _) = QueueSlot::reserve(&state).expect("reservation fits");
+        assert_eq!(queue_depth.load(Ordering::Relaxed), 2);
+
+        // An uncommitted slot frees capacity when it drops (a rejected/failed submission).
+        drop(dropped);
+        assert_eq!(queue_depth.load(Ordering::Relaxed), 1);
+
+        // A committed slot stays counted — the enqueued task owns it until the sequencer dequeues.
+        kept.commit();
+        assert_eq!(queue_depth.load(Ordering::Relaxed), 1);
     }
 
     // -- HTTP handler integration tests --
@@ -2194,6 +2311,31 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_full_queue_response_carries_retry_after() {
+            let (sender, _receiver) = crate::sequencer::task_channel();
+            let queue_depth = crate::sequencer::task_queue_depth();
+            let mut state = IngressState::without_metrics(sender, queue_depth.clone());
+            state.max_queue_depth = 1;
+            queue_depth.store(1, std::sync::atomic::Ordering::Relaxed);
+            let app = build_app().with_state(state);
+
+            let resp = app.oneshot(json_request(&valid_body())).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let retry_after = resp
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .expect("503 QUEUE_FULL must carry a Retry-After header");
+            assert!(
+                retry_after
+                    .to_str()
+                    .unwrap()
+                    .parse::<u64>()
+                    .is_ok_and(|secs| secs > 0),
+                "Retry-After must be a positive number of seconds"
+            );
+        }
+
+        #[tokio::test]
         async fn test_full_queue_increments_at_capacity_metric() {
             let (sender, _receiver) = crate::sequencer::task_channel();
             let queue_depth = crate::sequencer::task_queue_depth();
@@ -2250,6 +2392,36 @@ mod tests {
             assert!(
                 receiver.try_recv().is_err(),
                 "invalid task must not be pushed to queue"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_rejected_request_releases_reserved_slot() {
+            let (sender, _receiver) = crate::sequencer::task_channel();
+            let queue_depth = crate::sequencer::task_queue_depth();
+            let state = IngressState::without_metrics(sender, queue_depth.clone());
+            let app = build_app().with_state(state);
+
+            // A zero-target request reserves a slot, fails validation, and must release it on the
+            // way out so a rejected submission never permanently shrinks capacity.
+            let invalid = serde_json::json!({
+                "body": {
+                    "target_address": "0x0000000000000000000000000000000000000000",
+                    "from_address":   "0x0000000000000000000000000000000000000002",
+                    "call_data":      [0xAB, 0xCD, 0xEF, 0x01],
+                    "transition_index": 0,
+                    "value": "0x0",
+                    "block_height": 1
+                }
+            })
+            .to_string();
+
+            let resp = app.oneshot(json_request(&invalid)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                queue_depth.load(std::sync::atomic::Ordering::Relaxed),
+                0,
+                "a rejected request must not leave its reserved slot occupied"
             );
         }
 

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -131,7 +131,7 @@ impl MetricsCollector {
 
         let task_queue_depth = Gauge::default();
         registry.register(
-            "gas_killer_task_queue_depth",
+            "gas_killer_queue_depth",
             "Current number of tasks in the ingress queue awaiting processing",
             task_queue_depth.clone(),
         );

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -30,7 +30,10 @@ pub struct MetricsCollector {
     /// Excludes ingress-queue wait and router-side storage computation, which finish before the
     /// dispatch timestamp is stamped.
     pub round_latency_seconds: Histogram,
-    /// Current number of tasks sitting in the ingress queue waiting to be processed.
+    /// Current ingress queue depth: enqueued tasks awaiting processing plus submissions
+    /// holding a reserved slot while they validate. Reserved slots are released if the
+    /// submission is rejected, so a brief bump under a flood of invalid requests is expected
+    /// backpressure, not a leak.
     pub task_queue_depth: Gauge<i64, AtomicI64>,
     /// Whether the SQLite store answered its most recent health check (1 = up, 0 = down).
     pub db_up: Gauge<i64, AtomicI64>,
@@ -132,7 +135,7 @@ impl MetricsCollector {
         let task_queue_depth = Gauge::default();
         registry.register(
             "gas_killer_queue_depth",
-            "Current number of tasks in the ingress queue awaiting processing",
+            "Ingress queue depth: enqueued tasks awaiting processing plus submissions holding a reserved slot during validation",
             task_queue_depth.clone(),
         );
 


### PR DESCRIPTION
Closes #191.

## Summary

Bounds the ingress task queue so a burst of valid requests can no longer grow memory without limit or leave tasks aggregating hours later against long-stale block references.

Much of the scaffolding already existed (`QUEUE_FULL` error code, `ingress_at_capacity` counter, a queue-depth gauge, a `max_queue_depth` field). This fills the four gaps against the acceptance criteria.

## Acceptance criteria

- **`MAX_QUEUE_DEPTH` env var (default 100).** New `max_queue_depth()` config helper (`DEFAULT_MAX_QUEUE_DEPTH = 100`); `create_ingress` now reads it instead of borrowing `p2p_message_backlog()`. Documented in `example.env` and threaded through Helm (`router.ingress.maxQueueDepth` → `MAX_QUEUE_DEPTH`).
- **503 `QUEUE_FULL` with a `Retry-After` estimate.** `ApiError` carries an optional `retry_after_secs`, emitted as a `Retry-After` header. The queue-full response sends ~60s, sized to roughly one aggregation round (the router drains one task at a time, so a slot frees when the in-flight round settles).
- **Atomic check + enqueue (no TOCTOU).** The old path did `load()` → validate/persist → `fetch_add()`, so two concurrent submissions could both pass the check and push past the cap. Replaced with a `QueueSlot` RAII guard: `reserve()` does a single `fetch_update` compare-and-increment (reserves only while under cap), releases the slot on every early-return path, and is committed only once the task is genuinely enqueued.
- **Prometheus gauge `gas_killer_queue_depth`.** Renamed from `gas_killer_task_queue_depth` to match the spec; in-repo Grafana dashboard query updated.

## Tests

Added coverage for the Retry-After header (unit + HTTP integration), atomic reservation reaching the cap then refusing, slot release on drop vs. retention on commit, and slot release when a request is rejected. `cargo fmt`, `clippy --all-targets --all-features -D warnings`, `cargo check`, and `cargo test` all pass across the workspace.

## Note on the metric rename

Renaming `gas_killer_task_queue_depth` → `gas_killer_queue_depth` is a breaking change for any dashboards or alerts defined outside this repo that reference the old name; the in-repo Grafana panel is updated here. Chose to rename rather than alias because the acceptance criteria specified the exact name.
