### PR TITLE
feat: task deduplication for POST /tasks

### DIFF
--- a/router/migrations/0005_task_dedup_index.sql
+++ b/router/migrations/0005_task_dedup_index.sql
@@ -1,0 +1,16 @@
+-- Serves the deduplication lookup on POST /tasks.
+--
+-- A client that retries after a timeout submits the same logical request twice. An in-flight
+-- (`queued`/`processing`) or `ready` task sharing a submission's
+-- (key_id, target_address, transition_index) is that same work, so the submit path collapses onto
+-- it rather than creating a duplicate that would race a doomed second transaction onto the chain
+-- (only one can consume a given transition_index). A `failed` or `expired` task is not a duplicate,
+-- so re-submission after one proceeds normally.
+--
+-- The index is partial on `transition_index IS NOT NULL`: an "auto" request (NULL index) leaves the
+-- slot for the server to resolve at dequeue time, so two auto submissions are distinct requests
+-- that each take their own slot (safe parallel submissions) and are never deduplicated. The lookup
+-- therefore only ever probes non-NULL index rows, which this index covers.
+CREATE INDEX idx_tasks_dedup
+    ON tasks (key_id, target_address, transition_index)
+    WHERE transition_index IS NOT NULL;

--- a/router/src/ingress.rs
+++ b/router/src/ingress.rs
@@ -3,7 +3,7 @@ use crate::metrics::MetricsCollector;
 use crate::rate_limit::KeyRateLimiter;
 use crate::sequencer::{QueuedTask, TaskQueueDepth, TaskSender};
 use crate::store::{
-    ApiKeyMetadata, AuthenticatedKey, CreatedApiKey, SqliteStore, Task, TaskStatus,
+    ApiKeyMetadata, AuthenticatedKey, CreatedApiKey, SqliteStore, SubmittedTask, Task, TaskStatus,
 };
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
@@ -618,11 +618,17 @@ impl GasKillerTaskRequest {
 }
 
 /// Body returned by `POST /tasks` (and its deprecated alias `POST /trigger`) when a task is
-/// accepted: the id the client polls for status, and the task's initial state.
+/// accepted: the id the client polls for status, and the task's current state.
+///
+/// `deduplicated` is `true` when the submission collapsed onto an existing in-flight or `ready`
+/// task rather than creating a new one — a retry keyed on `(key_id, target_address,
+/// transition_index)` is idempotent, returning the original task id with a `200 OK`. A fresh
+/// submission carries `false` and a `202 Accepted`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TaskAcceptedResponse {
     pub task_id: String,
     pub status: TaskStatus,
+    pub deduplicated: bool,
 }
 
 /// `Retry-After` estimate (seconds) returned alongside a `503 QUEUE_FULL`. The router drains
@@ -789,13 +795,38 @@ pub async fn submit_task_handler(
     let store = require_store(&state)?;
     let key_id = auth.ok_or_else(ApiError::unauthorized)?.id;
 
-    let task = store
-        .create_task(&key_id, &request.body)
+    let SubmittedTask { task, deduplicated } = store
+        .create_task_deduplicated(&key_id, &request.body)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "failed to persist task");
             ApiError::internal("Internal error: failed to persist task")
         })?;
+
+    // A retry that collapsed onto an existing task must not be enqueued a second time — the
+    // original submission already owns a queue slot (or has settled). Release this request's
+    // reserved slot (the guard drops uncommitted) and hand back the existing task with `200 OK`,
+    // so the client polls the same id idempotently.
+    if deduplicated {
+        info!(
+            task_id = %task.id,
+            status = ?task.status,
+            target_address = %request.body.target_address,
+            transition_index = ?request.body.transition_index,
+            "Task deduplicated onto existing submission"
+        );
+        if let Some(m) = &state.metrics {
+            m.ingress_deduplicated.inc();
+        }
+        return Ok((
+            StatusCode::OK,
+            Json(TaskAcceptedResponse {
+                task_id: task.id,
+                status: task.status,
+                deduplicated: true,
+            }),
+        ));
+    }
 
     info!(
         task_id = %task.id,
@@ -824,6 +855,7 @@ pub async fn submit_task_handler(
         Json(TaskAcceptedResponse {
             task_id: task.id,
             status: task.status,
+            deduplicated: false,
         }),
     ))
 }
@@ -1605,12 +1637,18 @@ mod tests {
         }
 
         fn valid_body() -> String {
+            valid_body_with_index(0)
+        }
+
+        /// A valid submission body pinned to an explicit `transition_index`, so successive
+        /// submissions are distinct work rather than deduplicated retries of the same request.
+        fn valid_body_with_index(transition_index: u64) -> String {
             serde_json::json!({
                 "body": {
                     "target_address": "0x0000000000000000000000000000000000000001",
                     "from_address":   "0x0000000000000000000000000000000000000002",
                     "call_data":      [0xAB, 0xCD, 0xEF, 0x01],
-                    "transition_index": 0,
+                    "transition_index": transition_index,
                     "value": "0x0",
                     "block_height": 1
                 }
@@ -1971,15 +2009,15 @@ mod tests {
 
         #[tokio::test]
         async fn test_valid_request_does_not_leave_extra_tasks() {
-            // Two sequential valid requests → queue should hold exactly two tasks.
+            // Two sequential valid requests for distinct work → queue should hold exactly two tasks.
             let (app, store, mut receiver) = make_app_with_store(None).await;
             let created = store.create_api_key(None, None).await.unwrap();
 
             app.clone()
-                .oneshot(bearer_request(&valid_body(), &created.key))
+                .oneshot(bearer_request(&valid_body_with_index(0), &created.key))
                 .await
                 .unwrap();
-            app.oneshot(bearer_request(&valid_body(), &created.key))
+            app.oneshot(bearer_request(&valid_body_with_index(1), &created.key))
                 .await
                 .unwrap();
 
@@ -2338,6 +2376,120 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn duplicate_submission_returns_200_and_does_not_reenqueue() {
+            let (app, store, mut rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+
+            let first = app
+                .clone()
+                .oneshot(bearer_request(&valid_body(), &key.key))
+                .await
+                .unwrap();
+            assert_eq!(first.status(), StatusCode::ACCEPTED);
+            let first_body = accepted_body(first).await;
+            assert!(
+                !first_body.deduplicated,
+                "a fresh submission is not deduplicated"
+            );
+            assert!(
+                rx.try_recv().is_ok(),
+                "the first submission enqueues a task"
+            );
+
+            // Same request again: a retry collapses onto the in-flight task.
+            let second = app
+                .oneshot(bearer_request(&valid_body(), &key.key))
+                .await
+                .unwrap();
+            assert_eq!(
+                second.status(),
+                StatusCode::OK,
+                "a deduplicated retry answers 200 OK, not 202"
+            );
+            let second_body = accepted_body(second).await;
+            assert!(second_body.deduplicated);
+            assert_eq!(
+                second_body.task_id, first_body.task_id,
+                "the retry returns the original task id"
+            );
+            assert_eq!(second_body.status, TaskStatus::Queued);
+            assert!(
+                rx.try_recv().is_err(),
+                "a deduplicated retry must not enqueue a second task"
+            );
+        }
+
+        #[tokio::test]
+        async fn resubmission_after_failure_creates_new_task() {
+            let (app, store, mut rx) = make_app_with_store(None).await;
+            let key = store.create_api_key(None, None).await.unwrap();
+
+            let first = app
+                .clone()
+                .oneshot(bearer_request(&valid_body(), &key.key))
+                .await
+                .unwrap();
+            assert_eq!(first.status(), StatusCode::ACCEPTED);
+            let first_body = accepted_body(first).await;
+            assert!(rx.try_recv().is_ok());
+
+            // Once the task fails, its work is no longer covered by an in-flight submission.
+            store
+                .mark_task_failed(&first_body.task_id, "aggregation timed out")
+                .await
+                .unwrap();
+
+            let second = app
+                .oneshot(bearer_request(&valid_body(), &key.key))
+                .await
+                .unwrap();
+            assert_eq!(
+                second.status(),
+                StatusCode::ACCEPTED,
+                "resubmission after a failure creates a fresh task"
+            );
+            let second_body = accepted_body(second).await;
+            assert!(!second_body.deduplicated);
+            assert_ne!(second_body.task_id, first_body.task_id);
+            assert!(
+                rx.try_recv().is_ok(),
+                "the fresh task is enqueued for aggregation"
+            );
+        }
+
+        #[tokio::test]
+        async fn deduplicated_submission_increments_metric() {
+            let (sender, mut rx) = crate::sequencer::task_channel();
+            let queue_depth = crate::sequencer::task_queue_depth();
+            let metrics = Arc::new(MetricsCollector::new());
+            let store = SqliteStore::connect_in_memory()
+                .await
+                .expect("in-memory store should open");
+            let key = store.create_api_key(None, None).await.unwrap();
+            let mut state = IngressState::without_metrics(sender, queue_depth).with_store(store);
+            state.metrics = Some(Arc::clone(&metrics));
+            let app = build_app().with_state(state);
+
+            app.clone()
+                .oneshot(bearer_request(&valid_body(), &key.key))
+                .await
+                .unwrap();
+            let _ = rx.try_recv();
+            let second = app
+                .oneshot(bearer_request(&valid_body(), &key.key))
+                .await
+                .unwrap();
+            assert_eq!(second.status(), StatusCode::OK);
+
+            assert_eq!(metrics.ingress_deduplicated.get(), 1);
+            assert_eq!(
+                metrics.ingress_accepted.get(),
+                1,
+                "only the fresh submission counts as accepted"
+            );
+        }
+
+        #[tokio::test]
         async fn tasks_endpoint_rejects_missing_token_when_store_present() {
             let (app, _store, _rx) = make_app_with_store(None).await;
             let req = Request::builder()
@@ -2627,10 +2779,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            for _ in 0..5 {
+            for i in 0..5 {
                 let resp = app
                     .clone()
-                    .oneshot(bearer_request(&valid_body(), &key.key))
+                    .oneshot(bearer_request(&valid_body_with_index(i), &key.key))
                     .await
                     .unwrap();
                 assert_eq!(

--- a/router/src/metrics.rs
+++ b/router/src/metrics.rs
@@ -7,6 +7,8 @@ pub struct MetricsCollector {
     registry: Registry,
     /// Ingress requests that passed validation and were queued.
     pub ingress_accepted: Counter<u64, AtomicU64>,
+    /// Ingress requests that collapsed onto an existing task via deduplication.
+    pub ingress_deduplicated: Counter<u64, AtomicU64>,
     /// Ingress requests rejected by validation.
     pub ingress_rejected: Counter<u64, AtomicU64>,
     /// Ingress requests dropped because the task queue is at capacity.
@@ -60,6 +62,13 @@ impl MetricsCollector {
             "gas_killer_ingress_requests_accepted",
             "Total ingress task requests accepted and queued",
             ingress_accepted.clone(),
+        );
+
+        let ingress_deduplicated = Counter::default();
+        registry.register(
+            "gas_killer_ingress_requests_deduplicated",
+            "Total ingress task requests that collapsed onto an existing task via deduplication",
+            ingress_deduplicated.clone(),
         );
 
         let ingress_rejected = Counter::default();
@@ -200,6 +209,7 @@ impl MetricsCollector {
         Self {
             registry,
             ingress_accepted,
+            ingress_deduplicated,
             ingress_rejected,
             ingress_at_capacity,
             ingress_rate_limited,

--- a/router/src/store/mod.rs
+++ b/router/src/store/mod.rs
@@ -13,7 +13,7 @@ mod api_keys;
 mod tasks;
 
 pub use api_keys::{ApiKeyMetadata, AuthenticatedKey, CreatedApiKey};
-pub use tasks::{Task, TaskStatus};
+pub use tasks::{SubmittedTask, Task, TaskStatus};
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/router/src/store/tasks.rs
+++ b/router/src/store/tasks.rs
@@ -94,6 +94,14 @@ pub struct Task {
     pub updated_at: i64,
 }
 
+/// Outcome of a deduplicated submission: the task the client polls, and whether the submission
+/// collapsed onto an existing task (`true`) rather than creating a fresh one (`false`).
+#[derive(Debug, Clone)]
+pub struct SubmittedTask {
+    pub task: Task,
+    pub deduplicated: bool,
+}
+
 /// Raw column values as read from SQLite, before Ethereum types are parsed back out of their
 /// text encodings. Kept private; callers only ever see [`Task`].
 #[derive(FromRow)]
@@ -188,6 +196,123 @@ impl SqliteStore {
             created_at,
             updated_at,
         })
+    }
+
+    /// Persists a task for the given API key, collapsing a duplicate submission onto the existing
+    /// task instead of creating a second one.
+    ///
+    /// A client that retries after a timeout submits the same logical request twice. Without
+    /// deduplication both tasks pass validation, but only the first to reach the chain succeeds —
+    /// the second's `transition_index` is already consumed — so the retry races a doomed
+    /// transaction. Keying idempotency on `(key_id, target_address, transition_index)` makes the
+    /// retry safe: it returns the existing task rather than creating a duplicate.
+    ///
+    /// A match counts as a duplicate only while it is in flight (`queued`/`processing`) or `ready`.
+    /// A `failed` or `expired` task is not a duplicate — its work must be re-run — so a submission
+    /// matching one creates a fresh task. Deduplication applies only to an explicit
+    /// `transition_index`; an `auto` (NULL) request leaves the slot for the server to resolve at
+    /// dequeue time, so two `auto` submissions are distinct requests that each take their own slot
+    /// (safe parallel submissions) and are never collapsed.
+    ///
+    /// The duplicate check and the insert are one atomic statement — an `INSERT ... SELECT` guarded
+    /// by `WHERE NOT EXISTS` — so a concurrent retry cannot slip between them. SQLite serializes
+    /// writers, so a racer that loses observes the winner's committed row, inserts nothing, and this
+    /// method returns that task as the deduplicated result.
+    pub async fn create_task_deduplicated(
+        &self,
+        key_id: &str,
+        request: &GasKillerTaskRequestBody,
+    ) -> anyhow::Result<SubmittedTask> {
+        // Auto submissions carry no idempotency key, so they always create a fresh task.
+        let Some(transition_index) = request.transition_index else {
+            let task = self.create_task(key_id, request).await?;
+            return Ok(SubmittedTask {
+                task,
+                deduplicated: false,
+            });
+        };
+
+        let id = Uuid::new_v4().to_string();
+        let inserted: Option<(i64, i64)> = sqlx::query_as(
+            "INSERT INTO tasks \
+             (id, key_id, status, target_address, call_data, transition_index, from_address, \
+              value, block_height) \
+             SELECT ?1, ?2, 'queued', ?3, ?4, ?5, ?6, ?7, ?8 \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 FROM tasks \
+                 WHERE key_id = ?2 AND target_address = ?3 AND transition_index = ?5 \
+                   AND status IN ('queued', 'processing', 'ready') \
+             ) \
+             RETURNING created_at, updated_at",
+        )
+        .bind(&id)
+        .bind(key_id)
+        .bind(request.target_address.to_string())
+        .bind(request.call_data.as_slice())
+        .bind(transition_index as i64)
+        .bind(request.from_address.to_string())
+        .bind(request.value.to_string())
+        .bind(request.block_height as i64)
+        .fetch_optional(self.pool())
+        .await
+        .context("inserting task with deduplication")?;
+
+        match inserted {
+            Some((created_at, updated_at)) => Ok(SubmittedTask {
+                task: Task {
+                    id,
+                    key_id: key_id.to_string(),
+                    status: TaskStatus::Queued,
+                    request: request.clone(),
+                    payload: None,
+                    bundle: None,
+                    error: None,
+                    created_at,
+                    updated_at,
+                },
+                deduplicated: false,
+            }),
+            // The guard's `NOT EXISTS` was false: an active task already covers this work, so read
+            // it back and return it as the deduplicated result.
+            None => {
+                let task = self
+                    .active_duplicate_task(key_id, request.target_address, transition_index)
+                    .await?
+                    .context(
+                        "deduplication guard blocked the insert but no active duplicate was found",
+                    )?;
+                Ok(SubmittedTask {
+                    task,
+                    deduplicated: true,
+                })
+            }
+        }
+    }
+
+    /// Finds the active task a duplicate submission collapses onto: the newest `queued`,
+    /// `processing`, or `ready` task for `(key_id, target_address, transition_index)`. Terminal
+    /// (`failed`/`expired`) tasks are excluded so their work can be re-submitted. Returns `None`
+    /// when no such task exists.
+    async fn active_duplicate_task(
+        &self,
+        key_id: &str,
+        target_address: Address,
+        transition_index: u64,
+    ) -> anyhow::Result<Option<Task>> {
+        let row: Option<TaskRow> = sqlx::query_as(&format!(
+            "SELECT {TASK_COLUMNS} FROM tasks \
+             WHERE key_id = ?1 AND target_address = ?2 AND transition_index = ?3 \
+               AND status IN ('queued', 'processing', 'ready') \
+             ORDER BY created_at DESC, id LIMIT 1",
+        ))
+        .bind(key_id)
+        .bind(target_address.to_string())
+        .bind(transition_index as i64)
+        .fetch_optional(self.pool())
+        .await
+        .context("finding active duplicate task")?;
+
+        row.map(Task::try_from).transpose()
     }
 
     /// Fetches a task by id, or `None` if no such task exists. The returned task carries its
@@ -654,5 +779,274 @@ mod tests {
     fn status_serializes_snake_case() {
         let json = serde_json::to_string(&TaskStatus::Processing).unwrap();
         assert_eq!(json, r#""processing""#);
+    }
+
+    // -- deduplication --
+
+    #[tokio::test]
+    async fn dedup_collapses_onto_queued() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let first = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        assert!(!first.deduplicated, "the first submission creates a task");
+
+        let second = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        assert!(
+            second.deduplicated,
+            "a retry while the task is queued collapses onto it"
+        );
+        assert_eq!(second.task.id, first.task.id);
+
+        let listed = store.list_tasks_for_key(&key, None, 100, 0).await.unwrap();
+        assert_eq!(listed.len(), 1, "no duplicate row is created");
+    }
+
+    #[tokio::test]
+    async fn dedup_collapses_onto_processing() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let first = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        store
+            .update_task_status(&first.task.id, TaskStatus::Processing)
+            .await
+            .unwrap();
+
+        let second = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        assert!(second.deduplicated);
+        assert_eq!(second.task.id, first.task.id);
+        assert_eq!(second.task.status, TaskStatus::Processing);
+    }
+
+    #[tokio::test]
+    async fn dedup_collapses_onto_ready() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let first = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        store
+            .mark_task_ready(&first.task.id, "0xcafe")
+            .await
+            .unwrap();
+
+        let second = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        assert!(second.deduplicated, "a ready task still absorbs a retry");
+        assert_eq!(second.task.id, first.task.id);
+        assert_eq!(second.task.status, TaskStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn dedup_resubmits_after_failed() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let first = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        store
+            .mark_task_failed(&first.task.id, "aggregation timed out")
+            .await
+            .unwrap();
+
+        let second = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        assert!(
+            !second.deduplicated,
+            "a failed task is not a duplicate, so its work can be re-submitted"
+        );
+        assert_ne!(second.task.id, first.task.id);
+        assert_eq!(second.task.status, TaskStatus::Queued);
+    }
+
+    #[tokio::test]
+    async fn dedup_resubmits_after_expired() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let first = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        store
+            .mark_task_expired(&first.task.id, "payload validity window elapsed")
+            .await
+            .unwrap();
+
+        let second = store
+            .create_task_deduplicated(&key, &request())
+            .await
+            .unwrap();
+        assert!(
+            !second.deduplicated,
+            "an expired task is not a duplicate, so its work can be re-submitted"
+        );
+        assert_ne!(second.task.id, first.task.id);
+    }
+
+    #[tokio::test]
+    async fn dedup_is_scoped_per_key() {
+        let store = store().await;
+        let key_a = key_id(&store).await;
+        let key_b = key_id(&store).await;
+
+        let a = store
+            .create_task_deduplicated(&key_a, &request())
+            .await
+            .unwrap();
+        let b = store
+            .create_task_deduplicated(&key_b, &request())
+            .await
+            .unwrap();
+        assert!(!a.deduplicated);
+        assert!(
+            !b.deduplicated,
+            "the same request under a different key is distinct work"
+        );
+        assert_ne!(a.task.id, b.task.id);
+    }
+
+    #[tokio::test]
+    async fn dedup_distinguishes_transition_index() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let mut first_req = request();
+        first_req.transition_index = Some(1);
+        let mut second_req = request();
+        second_req.transition_index = Some(2);
+
+        let first = store
+            .create_task_deduplicated(&key, &first_req)
+            .await
+            .unwrap();
+        let second = store
+            .create_task_deduplicated(&key, &second_req)
+            .await
+            .unwrap();
+        assert!(!first.deduplicated);
+        assert!(
+            !second.deduplicated,
+            "a different transition_index is different work"
+        );
+        assert_ne!(first.task.id, second.task.id);
+    }
+
+    #[tokio::test]
+    async fn dedup_distinguishes_target_address() {
+        let store = store().await;
+        let key = key_id(&store).await;
+
+        let mut first_req = request();
+        first_req.target_address = Address::from([0xaa; 20]);
+        let mut second_req = request();
+        second_req.target_address = Address::from([0xbb; 20]);
+
+        let first = store
+            .create_task_deduplicated(&key, &first_req)
+            .await
+            .unwrap();
+        let second = store
+            .create_task_deduplicated(&key, &second_req)
+            .await
+            .unwrap();
+        assert!(!first.deduplicated);
+        assert!(
+            !second.deduplicated,
+            "a different target_address is different work"
+        );
+        assert_ne!(first.task.id, second.task.id);
+    }
+
+    #[tokio::test]
+    async fn auto_transition_index_never_deduplicates() {
+        let store = store().await;
+        let key = key_id(&store).await;
+        let mut req = request();
+        req.transition_index = None;
+
+        let first = store.create_task_deduplicated(&key, &req).await.unwrap();
+        let second = store.create_task_deduplicated(&key, &req).await.unwrap();
+        assert!(!first.deduplicated);
+        assert!(
+            !second.deduplicated,
+            "auto submissions each take their own slot and are never collapsed"
+        );
+        assert_ne!(first.task.id, second.task.id);
+
+        let listed = store.list_tasks_for_key(&key, None, 100, 0).await.unwrap();
+        assert_eq!(
+            listed.len(),
+            2,
+            "both auto submissions persist distinct rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_duplicate_submissions_collapse_to_one_task() {
+        // A real file-backed store (WAL, multi-connection pool) so the racing submissions run on
+        // separate connections — the in-memory store is capped at one connection and would
+        // serialize them, hiding the concurrency the atomic insert must survive.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteStore::connect_at(&dir.path().join("router.db"))
+            .await
+            .expect("file store should open and migrate");
+        let key = key_id(&store).await;
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let store = store.clone();
+            let key = key.clone();
+            handles.push(tokio::spawn(async move {
+                store
+                    .create_task_deduplicated(&key, &request())
+                    .await
+                    .expect("concurrent dedup submission should succeed")
+            }));
+        }
+
+        let mut created = 0usize;
+        let mut ids = std::collections::HashSet::new();
+        for handle in handles {
+            let submission = handle.await.unwrap();
+            if !submission.deduplicated {
+                created += 1;
+            }
+            ids.insert(submission.task.id);
+        }
+
+        assert_eq!(
+            created, 1,
+            "exactly one concurrent submission may create the task"
+        );
+        assert_eq!(
+            ids.len(),
+            1,
+            "every concurrent submission returns the same task id"
+        );
+
+        let listed = store.list_tasks_for_key(&key, None, 100, 0).await.unwrap();
+        assert_eq!(listed.len(), 1, "only one row exists after the race");
     }
 }


### PR DESCRIPTION
Closes #197.

## Summary

A client that retries after a timeout submits the same logical request twice. Both tasks pass validation, but only the first to reach the chain succeeds — the second's `transition_index` is already consumed. This makes retries safe and idempotent by keying deduplication on `(key_id, target_address, transition_index)`.

- **`POST /tasks`**: if an in-flight (`queued`/`processing`) or `ready` task exists for the same key, target, and transition index, the existing task id is returned with `200 OK` (and `"deduplicated": true`) instead of creating a new task.
- A `failed` or `expired` task is **not** a duplicate — its work must be re-run — so re-submission creates a fresh task (`202 Accepted`).
- The check and creation are **one atomic SQL statement** (`INSERT … SELECT … WHERE NOT EXISTS`). SQLite serializes writers, so a concurrent retry that loses the race observes the winner's committed row, inserts nothing, and gets that task back.
- The response shape is identical to a fresh submission, plus a `deduplicated` field (present on both paths).

## Design note

Deduplication applies **only to an explicit `transition_index`**. An `"auto"` (NULL) request leaves the slot for the server to resolve at dequeue time, so two auto submissions are distinct requests that each take their own slot (the existing *safe parallel submissions* behavior) and are never collapsed. This also matches the failure scenario in the issue, which is specifically about an explicit index being consumed on-chain.

## Changes

- `router/migrations/0005_task_dedup_index.sql` — partial index on `(key_id, target_address, transition_index)` where the index is non-NULL, serving the dedup lookup.
- `store/tasks.rs` — `SubmittedTask`, `create_task_deduplicated()`, and `active_duplicate_task()`.
- `ingress.rs` — `deduplicated` response field; handler returns `200 OK` without re-enqueue on a dedup hit (releasing the reserved queue slot).
- `metrics.rs` — `gas_killer_ingress_requests_deduplicated` counter.

No new runtime config, so `example.env` / Helm / config fixtures are unchanged.

## Tests

- **Store**: collapses onto queued/processing/ready; re-submits after failed/expired; per-key scoping; distinguishes `transition_index` and `target_address`; auto never dedups; and a 16-way concurrency test on a real file-backed WAL store proving exactly one row is created.
- **HTTP**: `200` + no re-enqueue on retry, `202` + fresh task after failure, and the metric increment.

Local gate green: `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo check`, and the full test suite.