### PR TITLE
deploy: capture live LLM demo drift and fix scheduling pins

### DIFF
--- a/bridge/k8s.yaml
+++ b/bridge/k8s.yaml
@@ -19,8 +19,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        kubectl.kubernetes.io/restartedAt: '2026-07-16T15:15:38-04:00'
       labels:
         app: gk-shard-bridge
     spec:
@@ -103,6 +101,16 @@ kind: Ingress
 metadata:
   name: gk-shard-bridge
   namespace: default
+  annotations:
+    # The frontend is served from GitHub Pages (llm.gaskiller.xyz), so every
+    # /bridge call is cross-origin — without these the browser blocks it.
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "POST, GET, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization,Content-Type"
+    # Must stay "false": TLS terminates upstream, and enabling the redirect makes
+    # nginx 308-loop (same failure the gas-killer-extras ingress documents).
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx
   rules:
@@ -177,13 +185,16 @@ spec:
   schedule: '*/8 * * * *'
   successfulJobsHistoryLimit: 2
   # SUSPENDED (2026-07-27) and superseded by qwen-overlay-ensurer's own refork.
+  #
   # This job fires an UNCONDITIONAL anvil_reset, which re-forks from upstream and
-  # therefore wipes every overlay chunk setCode'd into the fork so far. Loading
-  # the 0.6B overlay is 24,364 chunks at ~4 setCode/s (~100 min), so an 8-minute
-  # reset meant the overlay could never converge. It also ignores in-flight
-  # traces, so it can reset the fork mid-trace. The ensurer already reforks
-  # correctly: only when drift > 150 blocks AND inflight() == 0, and it reloads
-  # the overlay afterwards. Re-enable only if the ensurer is removed.
+  # so wipes every overlay chunk setCode'd into the fork. That used to be fatal:
+  # the 0.6B overlay loaded at ~4 setCode/s (~100 min for 24,364 chunks), so an
+  # 8-minute reset meant it could never converge. Batching + connection reuse in
+  # the ensurer cut that to ~3s, so a reset is no longer unrecoverable — but this
+  # job is still the wrong tool. It ignores in-flight traces and can reset the
+  # fork mid-trace, and it duplicates logic the ensurer already does properly:
+  # refork only when drift > 150 blocks AND inflight() == 0, then reload.
+  # Re-enable only if the ensurer is removed.
   suspend: true
 ---
 apiVersion: batch/v1

--- a/bridge/k8s.yaml
+++ b/bridge/k8s.yaml
@@ -176,7 +176,15 @@ spec:
           terminationGracePeriodSeconds: 30
   schedule: '*/8 * * * *'
   successfulJobsHistoryLimit: 2
-  suspend: false
+  # SUSPENDED (2026-07-27) and superseded by qwen-overlay-ensurer's own refork.
+  # This job fires an UNCONDITIONAL anvil_reset, which re-forks from upstream and
+  # therefore wipes every overlay chunk setCode'd into the fork so far. Loading
+  # the 0.6B overlay is 24,364 chunks at ~4 setCode/s (~100 min), so an 8-minute
+  # reset meant the overlay could never converge. It also ignores in-flight
+  # traces, so it can reset the fork mid-trace. The ensurer already reforks
+  # correctly: only when drift > 150 blocks AND inflight() == 0, and it reloads
+  # the overlay afterwards. Re-enable only if the ensurer is removed.
+  suspend: true
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -196,31 +204,42 @@ spec:
         spec:
           containers:
           - args:
-            - "set -x\nPROJ=gas-killer-testnet; LOC=us-east4; CLUSTER=gas-killer\n\
-              API=\"https://container.googleapis.com/v1/projects/$PROJ/locations/$LOC/clusters/$CLUSTER\"\
-              \ntok() { curl -s -H \"Metadata-Flavor: Google\" \\\n  \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token\"\
-              \ \\\n  | sed -n 's/.*\"access_token\":\"\\([^\"]*\\)\".*/\\1/p'; }\n\
-              # 1. demo workloads\nkubectl delete deploy qwen-sim-fork qwen-overlay-ensurer\
-              \ gk-sim-proxy -n default --ignore-not-found\nkubectl delete svc qwen-sim-fork\
-              \ gk-sim-proxy -n default --ignore-not-found\nkubectl delete configmap\
-              \ gk-sim-proxy-src -n default --ignore-not-found\n# 2. unpin operators\
-              \ so they can reschedule after the node shrink\nfor d in gas-killer-node-1\
-              \ gas-killer-node-2 gas-killer-node-3 gas-killer-router; do\n  kubectl\
-              \ patch deploy $d -n default --type json \\\n    -p '[{\"op\":\"remove\"\
-              ,\"path\":\"/spec/template/spec/nodeSelector\"}]' || true\ndone\n# 3.\
-              \ delete the sim + operators node pools, waiting out any running cluster\
-              \ op\nfor POOL in sim-pool-c4 ops-highmem; do\n  for i in $(seq 1 60);\
-              \ do\n    OUT=$(curl -s -X DELETE -H \"Authorization: Bearer $(tok)\"\
-              \ \"$API/nodePools/$POOL\")\n    echo \"$OUT\" | grep -q '\"name\"'\
-              \ && break\n    echo \"$OUT\" | grep -qi \"notFound\" && break\n   \
-              \ sleep 60\n  done\ndone\n# 4. shrink default pool to 1 node (retry\
-              \ until the delete op clears)\nfor i in $(seq 1 60); do\n  OUT=$(curl\
-              \ -s -X POST -H \"Authorization: Bearer $(tok)\" \\\n    -H \"Content-Type:\
-              \ application/json\" -d '{\"nodeCount\":1}' \\\n    \"$API/nodePools/default-pool:setSize\"\
-              )\n  echo \"$OUT\" | grep -q '\"name\"' && break\n  sleep 60\ndone\n\
-              # 5. one-shot: suspend this cronjob\nkubectl patch cronjob demo-expiry\
-              \ -n default -p '{\"spec\":{\"suspend\":true}}'\necho \"EXPIRY COMPLETE\"\
-              \n"
+            - |
+              set -x
+              PROJ=gas-killer-testnet; LOC=us-east4; CLUSTER=gas-killer
+              API="https://container.googleapis.com/v1/projects/$PROJ/locations/$LOC/clusters/$CLUSTER"
+              tok() { curl -s -H "Metadata-Flavor: Google" \
+                "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+                | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p'; }
+              # 1. demo workloads
+              kubectl delete deploy qwen-sim-fork qwen-overlay-ensurer gk-sim-proxy -n default --ignore-not-found
+              kubectl delete svc qwen-sim-fork gk-sim-proxy -n default --ignore-not-found
+              kubectl delete configmap gk-sim-proxy-src -n default --ignore-not-found
+              # 2. delete the sim + operators node pools, waiting out any running cluster op.
+              #    The operator pods are deliberately NOT unpinned: they select the ops-highmem
+              #    node POOL by label, so once the pool returns they schedule correctly on their
+              #    own. Stripping the selector (as this script used to) let node-1 land on the
+              #    sim pool while the RWO shared-data PVC was attached to ops-highmem, which
+              #    deadlocked it in Init and crashlooped the router - the 2026-07-27 outage.
+              for POOL in sim-pool ops-highmem; do
+                for i in $(seq 1 60); do
+                  OUT=$(curl -s -X DELETE -H "Authorization: Bearer $(tok)" "$API/nodePools/$POOL")
+                  echo "$OUT" | grep -q '"name"' && break
+                  echo "$OUT" | grep -qi "notFound" && break
+                  sleep 60
+                done
+              done
+              # 3. shrink default pool to 1 node (retry until the delete op clears)
+              for i in $(seq 1 60); do
+                OUT=$(curl -s -X POST -H "Authorization: Bearer $(tok)" \
+                  -H "Content-Type: application/json" -d '{"nodeCount":1}' \
+                  "$API/nodePools/default-pool:setSize")
+                echo "$OUT" | grep -q '"name"' && break
+                sleep 60
+              done
+              # 4. one-shot: suspend this cronjob
+              kubectl patch cronjob demo-expiry -n default -p '{"spec":{"suspend":true}}'
+              echo "EXPIRY COMPLETE"
             command:
             - /bin/bash
             - -c

--- a/common/src/shard.rs
+++ b/common/src/shard.rs
@@ -1048,7 +1048,7 @@ impl FastViewSidecar {
         };
 
         // request frame: "<byte_len>\n" then the job bytes
-        write!(self.stdin, "{}\n", job_text.len())
+        writeln!(self.stdin, "{}", job_text.len())
             .context("gk-fast-view: write frame len")
             .map_err(send)?;
         self.stdin

--- a/common/src/shard.rs
+++ b/common/src/shard.rs
@@ -939,7 +939,11 @@ async fn fast_view_call(
             );
         }
     };
-    debug!(seg_id, bytes = returndata.len(), "gk-fast-view fast path served segment");
+    debug!(
+        seg_id,
+        bytes = returndata.len(),
+        "gk-fast-view fast path served segment"
+    );
     Ok(returndata)
 }
 
@@ -1022,7 +1026,11 @@ impl FastViewSidecar {
                 .context("gk-fast-view --serve: no stdout handle")?,
         );
         FAST_VIEW_SIDECAR_PID.store(child.id(), std::sync::atomic::Ordering::SeqCst);
-        Ok(FastViewSidecar { child, stdin, stdout })
+        Ok(FastViewSidecar {
+            child,
+            stdin,
+            stdout,
+        })
     }
 
     /// Send one framed job, read one framed response. Any IO/protocol failure is
@@ -1030,8 +1038,14 @@ impl FastViewSidecar {
     /// [`SidecarIoError`]); a well-formed OK/ERR frame is `Ok(resp)`.
     fn exchange(&mut self, job_text: &str) -> std::result::Result<SidecarResp, SidecarIoError> {
         use std::io::{BufRead as _, Read as _, Write as _};
-        let send = |err: anyhow::Error| SidecarIoError { request_sent: false, err };
-        let recv = |err: anyhow::Error| SidecarIoError { request_sent: true, err };
+        let send = |err: anyhow::Error| SidecarIoError {
+            request_sent: false,
+            err,
+        };
+        let recv = |err: anyhow::Error| SidecarIoError {
+            request_sent: true,
+            err,
+        };
 
         // request frame: "<byte_len>\n" then the job bytes
         write!(self.stdin, "{}\n", job_text.len())
@@ -1083,7 +1097,9 @@ impl FastViewSidecar {
                     .map_err(recv)?;
                 Ok(SidecarResp::Ok(bytes))
             }
-            "ERR" => Ok(SidecarResp::Err(String::from_utf8_lossy(&payload).into_owned())),
+            "ERR" => Ok(SidecarResp::Err(
+                String::from_utf8_lossy(&payload).into_owned(),
+            )),
             other => Err(recv(anyhow::anyhow!(
                 "gk-fast-view: unknown response status {other:?}"
             ))),

--- a/deploy/testnet-default/README.md
+++ b/deploy/testnet-default/README.md
@@ -14,9 +14,21 @@ them.
 | `deploy/gk-sim-proxy` + `svc/gk-sim-proxy` + `configmap/gk-sim-proxy-src` | Python JSON-RPC proxy on **:8545**: routes `debug_traceCall` for the pinned overlay consumers to the fork, everything else upstream; serves `/forkhead` and `/status` (in-flight trace count, used by the ensurer to avoid reforking mid-trace). |
 | `deploy/qwen-overlay-ensurer` | Loop that keeps the Qwen3-0.6B overlay chunks `anvil_setCode`'d into the fork (manifest-verified download from the solidity-sdk release) and reforks to ~head when drift exceeds 150 blocks and no trace is in flight. |
 
+## Other files here
+
+| File | Role |
+| --- | --- |
+| `extras-ingress.yaml` | Standalone `gas-killer-extras` ingress exposing `/forkhead`. Separate from the chart ingress because helm re-renders wiped the path 3×. |
+| `demo-expiry-rbac.yaml` | ServiceAccount/Role the demo-expiry cron uses to patch and delete workloads. |
+| `verify-artifacts.yaml` | One-shot keccak integrity check for the PVC weights — see "Re-staging weights". |
+
 ## What's NOT here
 
 - **gk-shard-bridge + its cron jobs** live in [`bridge/k8s.yaml`](../../bridge/k8s.yaml).
+  Both crons ship suspended. `qwen-fork-refresh` is suspended *permanently*: its
+  unconditional `anvil_reset` wiped the overlay chunks every 8 minutes, so the
+  ~24k-chunk load could never converge. The ensurer's own drift-aware refork
+  replaces it.
 - Everything else in the namespace (router, nodes, monitoring, ingress) is the
   `gas-killer` Helm release — chart in [`helm/gas-killer/`](../../helm/gas-killer/),
   with the live env drift captured in
@@ -43,26 +55,89 @@ them.
   inline.
 - All three deployments pin to the `role=sim` node pool via `nodeSelector`.
 
+## Node pools (as of 2026-07-27)
+
+| Pool | Machine | Label | Hosts |
+| --- | --- | --- | --- |
+| `ops-highmem` | n2-highmem-8 ×1, 100GB pd-balanced | `role=ops-highmem` | router + node-1/2/3. 64Gi is required: the RWO `gas-killer-shared-data` PVC forces all four onto one VM, and cgroup v2 charges the 34GB overlay mmap to the first-faulting pod, so every pod's limit must exceed it. |
+| `sim-pool` | c4-standard-4 ×1, 50GB hyperdisk-balanced | `role=sim` | qwen-sim-fork + gk-sim-proxy + qwen-overlay-ensurer. C4 **requires** hyperdisk; `pd-*` is rejected. |
+| `default-pool` | e2-standard-4 ×1, 20GB pd-standard | — | ingress, bridge, cert-manager, kube-prometheus-stack. |
+
+These are declared in Terraform at `infra/terraform/llm-testnet` (repo
+[gas-killer/infra](https://github.com/gas-killer/infra)) — prefer `terraform apply` over
+ad-hoc `gcloud`, so the cluster and the code stay in agreement.
+
 ## Revival order (after demo-expiry fires, or a namespace rebuild)
 
-demo-expiry deletes the `ops-highmem` + `sim-pool-c4` node pools, strips the
-hostname pins, and shrinks default-pool to one e2-standard-4 — nothing
-schedules until capacity is back. Revive in this order:
+demo-expiry deletes the `ops-highmem` + `sim-pool` node pools and shrinks
+default-pool to one e2-standard-4 — nothing schedules until capacity is back.
+It deliberately leaves the `nodeSelector`s alone (see below). Revive in this order:
 
-1. Recreate pools:
-   `gcloud container node-pools create ops-highmem --cluster gas-killer --region us-east4 --machine-type n2-highmem-8 --num-nodes 1 --node-locations us-east4-b`
-   `gcloud container node-pools create sim-pool-c4 --cluster gas-killer --region us-east4 --machine-type c4-highcpu-8 --num-nodes 1 --node-locations us-east4-b --node-labels role=sim`
-2. Edit BOTH `nodeSelector` blocks in `helm/gas-killer/default-live-overrides.yaml`
-   to the new ops-highmem hostname (`kubectl get nodes`) — the committed pin is
-   the old VM name and will never schedule.
-3. Ensure secrets exist: `gk-sim-upstream` (keyed archive RPC URL for the sim
+1. Recreate the pools — `cd infra/terraform/llm-testnet && terraform apply`.
+   Fallback if Terraform is unavailable:
+   `gcloud container node-pools create ops-highmem --cluster gas-killer --region us-east4 --machine-type n2-highmem-8 --num-nodes 1 --node-locations us-east4-b --disk-type pd-balanced --disk-size 100 --node-labels role=ops-highmem`
+   `gcloud container node-pools create sim-pool --cluster gas-killer --region us-east4 --machine-type c4-standard-4 --num-nodes 1 --node-locations us-east4-b --disk-type hyperdisk-balanced --disk-size 50 --node-labels role=sim`
+2. Ensure secrets exist: `gk-sim-upstream` (keyed archive RPC URL for the sim
    proxy/ensurer), `gk-bridge-key` (mint a gk_ key via the router admin API with
    ADMIN_KEY, then `kubectl create secret generic gk-bridge-key --from-literal=GK_KEY=gk_...`).
-4. Re-stage weights on the gas-killer-shared-data PVC if it was lost:
-   /app/.nodes/qwen35/{weights.bin,tokenizer.bin} + /app/.nodes/qwen06/... —
-   fetch from the solidity-sdk release artifacts and verify the two keccak
-   manifests pinned in default-live-overrides.yaml.
-5. `helm upgrade gas-killer helm/gas-killer -n default -f <release values> -f helm/gas-killer/default-live-overrides.yaml`
-6. `kubectl apply -f deploy/testnet-default/sim-fork-stack.yaml`
-7. Bridge: `kubectl create configmap gk-bridge-script --from-file=bridge.py=bridge/bridge.py --dry-run=client -o yaml | kubectl apply -f -` then `kubectl apply -f bridge/k8s.yaml`
-   (the exported demo-expiry ships suspend:true on purpose — unsuspend deliberately).
+3. Re-stage weights on the gas-killer-shared-data PVC **only if it was lost** — the
+   PVC survives demo-expiry, so this is normally a no-op. See "Re-staging weights" below.
+4. `helm upgrade gas-killer helm/gas-killer -n default -f <release values> -f helm/gas-killer/default-live-overrides.yaml`
+5. `kubectl apply -f deploy/testnet-default/sim-fork-stack.yaml`
+6. Bridge: `kubectl create configmap gk-bridge-script --from-file=bridge.py=bridge/bridge.py --dry-run=client -o yaml | kubectl apply -f -` then `kubectl apply -f bridge/k8s.yaml`
+   (both crons ship `suspend: true` on purpose — unsuspend deliberately).
+
+**Do not re-pin by hostname.** Both `nodeSelector`s in `default-live-overrides.yaml`
+select the node **pool** (`role: ops-highmem`), which is a pool-level label and so
+survives VM recreation and pool upgrades. The previous hostname pin went stale on
+every node replacement, and stripping it entirely is what caused the 2026-07-27
+outage: node-1 landed on the sim pool while the RWO PVC was attached to
+ops-highmem, deadlocking it in `Init:0/2` with no events, which in turn crashlooped
+the router's `wait-for-nodes` init container.
+
+**Rolls need force-deletes.** With four 12Gi-request pods on one 64Gi node, the
+default 25% maxSurge cannot fit, so a rollout leaves surge pods `Pending` behind
+`Terminating` ones. `kubectl delete pod <old> --force --grace-period=0` to clear it.
+
+## Re-staging weights (only if the PVC is lost)
+
+Artifacts live on GitHub releases in `gas-killer/solidity-sdk`, and a copy of the
+35B set is in `gs://gk-35b-artifacts-gas-killer-testnet`.
+
+```sh
+# 35B: 19 parts, ~1.9GB each -> /app/.nodes/qwen35/weights.bin
+gh release download qwen3.5-35b-a3b-onchain-v1 -R gas-killer/solidity-sdk
+cat weights.bin.part* > /app/.nodes/qwen35/weights.bin   # tools/fetch_release_parts.sh automates this
+# 0.6B
+gh release download qwen3-0.6b-onchain-v1 -R gas-killer/solidity-sdk
+```
+
+Expected sizes — a mismatch means a truncated or partial download:
+
+| File | Bytes |
+| --- | --- |
+| `qwen35/weights.bin` | 34,714,656,811 |
+| `qwen35/tokenizer.bin` | 2,836,678 |
+| `qwen06/weights.bin` | 597,135,857 |
+| `qwen06/tokenizer.bin` | 1,584,066 |
+
+Then verify integrity — size alone is not enough, and the original staging Job
+checked only sizes. `manifest = keccak(keccak(weights) || keccak(tokenizer))` must
+equal the value pinned in `default-live-overrides.yaml`:
+
+| Model | Manifest |
+| --- | --- |
+| Qwen3.5-35B-A3B | `0x7bdf4876a6861287521dadab3d3870f74dfa557507ed200d49f75bcb09f01fa9` |
+| Qwen3-0.6B | `0x23216cb9ed9ef2b4bc20c84d27b68fa62ab194fc0845dfa707836f48ec4a7ae9` |
+
+Both were recomputed byte-for-byte on 2026-07-27 and matched. `kubectl apply -f
+deploy/testnet-default/verify-artifacts.yaml` re-runs the check (~2 min; the 34GB
+hash runs at ~294 MiB/s once page-cached).
+
+> **keccak256, not SHA3-256.** Python's `hashlib.sha3_256` is the NIST variant and
+> uses different padding — it will silently produce wrong digests. Use
+> `pycryptodome`'s `Crypto.Hash.keccak`. Sanity check: `keccak256("")` is
+> `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
+
+The node containers mmap the overlay **lazily at first analysis**, not eagerly at
+boot — so a healthy fleet proves nothing about weight integrity. Verify explicitly.

--- a/deploy/testnet-default/sim-fork-stack.yaml
+++ b/deploy/testnet-default/sim-fork-stack.yaml
@@ -45,12 +45,17 @@ spec:
         ports:
         - containerPort: 8547
           protocol: TCP
+        # Measured steady-state on the sim pool: ~0.03 vCPU and ~2Gi. The old
+        # 5-vCPU REQUEST was the only reason this pool needed an 8-vCPU machine
+        # (c4-highcpu-8, $248/mo); it now fits c4-standard-4 at $144/mo. Memory
+        # headroom is kept generous — anvil grows with fork state and the
+        # setCode'd overlay chunks.
         resources:
           limits:
-            cpu: 7500m
+            cpu: 3500m
             memory: 12Gi
           requests:
-            cpu: '5'
+            cpu: 1500m
             memory: 4Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -282,6 +287,10 @@ spec:
           cat > ensure.py <<'PY'
           import requests, time, os
           from Crypto.Hash import keccak
+          # One pooled session for every JSON-RPC call. Without keep-alive each
+          # anvil_setCode batch paid a fresh TCP handshake, which (with B=10)
+          # capped the overlay load at ~4 chunks/s => ~100 min for 24,364 chunks.
+          S=requests.Session()
           URL="http://qwen-sim-fork:8547"
           PROXY="http://gk-sim-proxy:8545"
           UP=os.environ["UPSTREAM"]
@@ -306,7 +315,7 @@ spec:
               for at in range(0,len(blob),CH): chunks.append(blob[at:at+CH])
           assert len(chunks)==len(addrs)
           def rpc(url,m,p,timeout=60):
-              return requests.post(url,json={"jsonrpc":"2.0","id":1,"method":m,"params":p},timeout=timeout).json()
+              return S.post(url,json={"jsonrpc":"2.0","id":1,"method":m,"params":p},timeout=timeout).json()
           def head(url):
               return int(rpc(url,"eth_blockNumber",[])["result"],16)
           def loaded():
@@ -315,15 +324,23 @@ spec:
                   return len(a.get("result","0x"))>10 and len(b.get("result","0x"))>10
               except Exception: return False
           def inflight():
-              try: return requests.get(PROXY+"/status",timeout=10).json().get("inflight",0)
+              try: return S.get(PROXY+"/status",timeout=10).json().get("inflight",0)
               except Exception: return -1   # proxy unknown: don't refork blindly
           def load():
-              print("loading overlay...", flush=True); B=10
+              # B=100 keeps each JSON-RPC body around 5MB (chunks are 24575B ->
+              # ~49KB of hex each) while cutting round trips 10x vs the old B=10.
+              t0=time.time(); B=100
+              print(f"loading overlay... {len(chunks)} chunks", flush=True)
               for at in range(0,len(chunks),B):
                   batch=[{"jsonrpc":"2.0","id":i,"method":"anvil_setCode",
                           "params":[addrs[at+i],"0x00"+chunks[at+i].hex()]} for i in range(min(B,len(chunks)-at))]
-                  requests.post(URL,json=batch,timeout=120).raise_for_status()
-              print("OVERLAY LOADED:",len(chunks),"chunks", flush=True)
+                  S.post(URL,json=batch,timeout=300).raise_for_status()
+                  # Progress every ~2000 chunks: a silent multi-minute load is why
+                  # it went unnoticed that the overlay never finished converging.
+                  if (at//B) % 20 == 0 and at:
+                      el=time.time()-t0
+                      print(f"  overlay {at}/{len(chunks)} chunks  {at/max(el,.001):.0f}/s", flush=True)
+              print("OVERLAY LOADED:",len(chunks),"chunks in %.0fs"%(time.time()-t0), flush=True)
           while True:
               try:
                   drift = head(UP) - head(URL)

--- a/deploy/testnet-default/sim-fork-stack.yaml
+++ b/deploy/testnet-default/sim-fork-stack.yaml
@@ -296,7 +296,17 @@ spec:
           UP=os.environ["UPSTREAM"]
           REL="https://github.com/gas-killer/solidity-sdk/releases/download/qwen3-0.6b-onchain-v1"
           EXPECT="23216cb9ed9ef2b4bc20c84d27b68fa62ab194fc0845dfa707836f48ec4a7ae9"
-          REFRESH_AT=150   # blocks of drift before refork (window is 300)
+          # Blocks of drift before reforking. This is bounded by the UPSTREAM's
+          # non-archive window, NOT by anything in gas-killer: publicnode serves
+          # state for roughly the last ~110 blocks and 403s anything older
+          # ("Archive requests require a personal token"). Anything the fork has
+          # not already cached — notably the 35B engine's code, which unlike the
+          # 0.6B overlay is never setCode'd in — is fetched at the fork base, so
+          # once drift exceeds that window 35B inference fails on its first
+          # segment. The loop below polls every 30s (~2.5 blocks), so 60 caps
+          # real drift near 63 and leaves margin. Raising this above ~100 will
+          # silently break 35B while 0.6B keeps working.
+          REFRESH_AT=60
           def k(b):
               h=keccak.new(digest_bits=256); h.update(b); return h.digest()
           def fetch(f):

--- a/deploy/testnet-default/verify-artifacts.yaml
+++ b/deploy/testnet-default/verify-artifacts.yaml
@@ -1,0 +1,109 @@
+# One-shot integrity check for the overlay weights on the gas-killer-shared-data PVC.
+#
+#   kubectl apply -f deploy/testnet-default/verify-artifacts.yaml
+#   kubectl logs -f gk-keccak-verify
+#   kubectl delete pod gk-keccak-verify
+#
+# WHY THIS EXISTS: nothing else verifies these bytes. The original staging Job
+# (qwen35-artifact-loader) explicitly skipped the keccak check and asserted only
+# file sizes, and the node containers mmap the overlay lazily at first analysis
+# rather than eagerly at boot — so a healthy fleet is not evidence of integrity.
+# Size-correct but corrupt weights would surface ~70 minutes into a 35B demo.
+#
+# Runtime ~2 min: the 34GB hash runs at ~294 MiB/s once the file is page-cached
+# (the ops-highmem node holds it in ~38GB of buff/cache).
+#
+# MUST run on ops-highmem: gas-killer-shared-data is RWO and is already attached
+# there by the router/node pods. Mounted read-only; nothing here writes.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gk-keccak-verify
+  namespace: default
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    role: ops-highmem
+  containers:
+  - name: verify
+    image: python:3.12-slim
+    resources:
+      requests: {cpu: "500m", memory: "512Mi"}
+      # 4Gi, not something tighter: cgroup v2 charges page cache to the reading
+      # cgroup, and this streams 34GB.
+      limits: {cpu: "2", memory: "4Gi"}
+    volumeMounts:
+    - name: shared-data
+      mountPath: /data
+      readOnly: true
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      set -e
+      pip install --quiet --disable-pip-version-check pycryptodome
+      python3 - <<'PY'
+      from Crypto.Hash import keccak
+      import json, os, time
+
+      def kf(path, buf=1 << 24):
+          h = keccak.new(digest_bits=256); n = 0; t0 = time.time()
+          with open(path, 'rb') as f:
+              while True:
+                  b = f.read(buf)
+                  if not b: break
+                  h.update(b); n += len(b)
+          return h.digest(), n, time.time() - t0
+
+      def kk(*parts):
+          h = keccak.new(digest_bits=256)
+          for p in parts: h.update(p)
+          return h.digest()
+
+      # Guard against hashlib.sha3_256, which is NIST SHA3 (different padding)
+      # and would silently produce plausible-looking but wrong digests.
+      assert kk(b'').hex() == 'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
+      print('keccak256 self-test OK\n')
+
+      MODELS = [
+          ('qwen35', '/data/qwen35/weights.bin', '/data/qwen35/tokenizer.bin',
+           '0x7bdf4876a6861287521dadab3d3870f74dfa557507ed200d49f75bcb09f01fa9'),
+          ('qwen06', '/data/qwen06/weights.bin', '/data/qwen06/tokenizer.bin',
+           '0x23216cb9ed9ef2b4bc20c84d27b68fa62ab194fc0845dfa707836f48ec4a7ae9'),
+      ]
+
+      ok = True
+      for name, wp, tp, expect in MODELS:
+          print(f'=== {name} ===')
+          wd, wn, wt = kf(wp)
+          td, tn, _ = kf(tp)
+          man = '0x' + kk(wd, td).hex()
+          print(f'  weights   {wn:>14,} B in {wt:6.1f}s ({wn/1024**2/max(wt,.001):7.0f} MiB/s)')
+          print(f'    keccak  0x{wd.hex()}')
+          print(f'  tokenizer {tn:>14,} B')
+          print(f'    keccak  0x{td.hex()}')
+          print(f'  computed manifest {man}')
+          print(f'  expected manifest {expect}')
+          m_ok = man == expect
+          print(f'  MANIFEST {"MATCH" if m_ok else "*** MISMATCH ***"}')
+
+          # 35B also ships a manifest.json recording the component digests.
+          mfp = os.path.join(os.path.dirname(wp), 'manifest.json')
+          if os.path.exists(mfp):
+              mf = json.load(open(mfp))
+              for label, recorded, computed in (
+                  ('keccakWeights', mf.get('keccakWeights', ''), '0x' + wd.hex()),
+                  ('keccakTokenizer', mf.get('keccakTokenizer', ''), '0x' + td.hex()),
+              ):
+                  hit = recorded.lower() == computed
+                  print(f'  manifest.json {label:<16} {"MATCH" if hit else "*** MISMATCH *** recorded=" + recorded}')
+                  m_ok = m_ok and hit
+          ok = ok and m_ok
+          print()
+
+      print('RESULT:', 'ALL VERIFIED' if ok else 'VERIFICATION FAILED')
+      raise SystemExit(0 if ok else 1)
+      PY
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: gas-killer-shared-data

--- a/helm/gas-killer/default-live-overrides.yaml
+++ b/helm/gas-killer/default-live-overrides.yaml
@@ -31,13 +31,13 @@
 router:
   image:
     tag: router-pr-321
-  # !!! FRAGILE: pins the pod to ONE VM by hostname. The high-mem ops node is
-  # !!! not durable — node-pool upgrades/recreations rename it, and the demo
-  # !!! teardown ("demo expiry") strips this selector entirely. Re-check the
-  # !!! hostname (kubectl get nodes) before every apply; drop the key to let
-  # !!! the scheduler place freely.
+  # Pins the pod to the ops-highmem node pool. The RWO gas-killer-shared-data
+  # PVC can only attach to one node, so the router and all three nodes must
+  # co-locate; the pool also supplies the 64Gi needed for the 34GB overlay mmap.
+  # `role` is a node-pool label (set in infra/terraform/llm-testnet), so it
+  # survives VM recreation and node-pool upgrades — unlike a hostname pin.
   nodeSelector:
-    kubernetes.io/hostname: gke-gas-killer-ops-highmem-1c128d1b-nmbc
+    role: ops-highmem
   extraEnv:
     # Raised reference-block staleness window (in blocks) — multi-hour sharded
     # rounds outlive the 300-block default baked into the router.
@@ -64,10 +64,10 @@ node:
     # gk-fast: revmc AOT node image from Artifact Registry (not ghcr).
     repository: us-east4-docker.pkg.dev/gas-killer-testnet/gk-fast/node-fast
     tag: v6
-  # !!! FRAGILE: same single-VM hostname pin as the router — see the warning
-  # !!! there. Demo expiry strips it.
+  # Same ops-highmem pool pin as the router — see the note there. All four pods
+  # must land on the node holding the RWO PVC.
   nodeSelector:
-    kubernetes.io/hostname: gke-gas-killer-ops-highmem-1c128d1b-nmbc
+    role: ops-highmem
   extraEnv:
     # Same multi-overlay mmap sextet as the router (pinned simulation
     # environment: router and ALL nodes must mount the same model set).


### PR DESCRIPTION
Captures the state of the live LLM demo cluster in git. Everything here was applied to `gas-killer-testnet` by hand on 2026-07-27 during an outage recovery and cost pass, and existed nowhere in the repo — so a `helm upgrade` would have reverted it.

All changes are verified against the live cluster: `kubectl diff` is clean for both manifests, and a full 0.6B ask settled on Sepolia afterwards.

## Scheduling — the outage fix

`default-live-overrides.yaml` pinned the router and nodes to a VM **hostname**, and the committed hostname was already stale, so the file as committed could not schedule. Both pins now select the node **pool** (`role: ops-highmem`), which survives VM recreation and pool upgrades.

Root cause of the 2026-07-27 outage: with the selector stripped, `node-1` landed on the sim pool while the RWO `gas-killer-shared-data` PVC was attached to `ops-highmem`. It deadlocked in `Init:0/2` with no events, which crashlooped the router's `wait-for-nodes` init container 75 times.

Consequently the `demo-expiry` teardown no longer unpins the operators — that step is what caused the deadlock. It also targeted `sim-pool-c4`, which no longer exists, so a teardown would have left the renamed `sim-pool` running at ~$144/mo. Its script is now a readable block scalar instead of an escaped one-liner.

## Overlay convergence

`qwen-fork-refresh` fired an unconditional `anvil_reset` every 8 minutes, wiping every overlay chunk written so far. The 0.6B overlay is 24,364 chunks and was loading at ~4 setCode/s (~100 min), so **it could never converge** — and had not, for as long as that cron had been enabled.

The ensurer now uses a pooled `requests.Session` and `B=100` batches. Measured on the live cluster:

```
OVERLAY LOADED: 24364 chunks in 3s     (~8,980 chunks/s, was ~4/s)
```

The bottleneck was entirely per-request overhead, not anvil. The cron stays suspended anyway: it ignores in-flight traces and duplicates the ensurer's drift-aware refork (`drift > 150 blocks AND inflight() == 0`).

## Cost

anvil requested 5 vCPU but measures ~0.03 vCPU / ~2Gi. That request was the only reason the sim pool needed an 8-vCPU machine; it is now `1500m/3500m` and the pool is a `c4-standard-4` ($144/mo, was $248).

## Drift `kubectl diff` caught

Two cases where applying the committed file would have broken the demo:

- The `gk-shard-bridge` ingress was missing all five live annotations, including `enable-cors` and `cors-allow-origin`. The frontend is on GitHub Pages, so every `/bridge` call is cross-origin. `ssl-redirect: false` also has to stay or nginx 308-loops.
- A committed `restartedAt` annotation was *older* than the live one, so applying would have rewound it and triggered a needless bridge rollout.

## Verification

`verify-artifacts.yaml` adds a repeatable keccak check for the PVC weights. Nothing verified them before: the original staging Job explicitly skipped the hash ("keccak256 via pysha3 not present… trust size"), and nodes mmap the overlay lazily at first analysis, so a healthy fleet proves nothing. Both manifests were recomputed byte-for-byte and matched — 35B `0x7bdf4876…09f01fa9`, 0.6B `0x23216cb9…c4a7ae9`.

The runbook is rewritten: no hostname re-pin step, correct pool names, and the full re-staging + verification procedure.

## Testing

Three end-to-end asks, all returning a byte-identical `pipeline_root` `0xe718…4e0c` across a sim-pool machine swap, a default-pool consolidation, and the overlay fix:

| Run | Context | infer_seconds |
| --- | --- | --- |
| 1 | pre-optimization, cold JIT | 614.5 |
| 2 | post pool changes | 173.1 |
| 3 | post overlay convergence | **113.7** |

On-chain `stateTransitionCount` advanced 22 → 27 across the session. Endpoints `/healthz`, `/forkhead`, `/bridge/healthz` all 200.

Node pools are declared in gas-killer/infra `terraform/llm-testnet` (separate PR); the `role` labels here are the contract with that config.