### PR TITLE
feat: end schnorr payload validity before the operator set can change

### DIFF
--- a/common/src/bindings/mod.rs
+++ b/common/src/bindings/mod.rs
@@ -33,3 +33,14 @@ pub mod gaskillersdk;
     dead_code
 )]
 pub mod schnorrgaskillersdk;
+
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    clippy::pub_underscore_fields,
+    clippy::style,
+    clippy::empty_structs_with_brackets,
+    missing_docs,
+    dead_code
+)]
+pub mod schnorrstakeregistry;

--- a/common/src/bindings/schnorrstakeregistry.rs
+++ b/common/src/bindings/schnorrstakeregistry.rs
@@ -1,0 +1,16 @@
+use alloy::sol;
+
+// The router reads a single view function off `SchnorrStakeRegistry`, so it declares just that
+// function rather than vendoring the contract's ABI artifact a second time (the deploy tooling in
+// `scripts` already carries the full artifact, bytecode included, because it deploys the registry).
+// `scripts::bindings` pins this declaration against that artifact so an upstream rename fails a
+// test rather than silently degrading into a warning at runtime.
+sol! {
+    #[sol(rpc)]
+    interface ISchnorrStakeRegistry {
+        /// The earliest block at which the operator set can change, or `type(uint256).max` when no
+        /// change is scheduled. A settlement is safe from set-mutation invalidation while the block
+        /// it lands in is below this value.
+        function nextPossibleMutationBlock() external view returns (uint256);
+    }
+}

--- a/example.env
+++ b/example.env
@@ -178,11 +178,16 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 #
 # SCHNORR_NOTICE_WINDOW: blocks a SchnorrStakeRegistry operator-set change must be
 # announced ahead of taking effect (schnorr mode only; see SIGNATURE_SCHEME). Announcing
-# publishes a horizon via nextPossibleMutationBlock() that a round can check, so a
-# settlement is never assembled against one operator set and verified against another.
+# publishes a horizon via nextPossibleMutationBlock(); the router reads it when rendering a
+# payload and ends that payload's validity before it, so a settlement is never assembled
+# against one operator set and verified against another.
 # Defaults to 0, which applies changes as soon as they are committed — correct for this
 # stack, where the whole operator set is registered before the target contract deploys and
 # no round is ever in flight for a mutation to invalidate.
+#
+# The horizon only covers announced changes. registerOperator / deregisterOperator bypass
+# the window for bootstrap and emergencies and emit ForcedMutation; a forced change can
+# still invalidate a payload the router already handed out.
 #
 # A deployment that changes its operator set while rounds are in flight must set this
 # above the signing round's duration plus BLOCK_STALE_MEASURE, since a rendered payload
@@ -199,6 +204,10 @@ BLOCK_STALE_MEASURE=300
 # returns a PAYLOAD_EXPIRED re-request error instead of calldata that would revert on-chain. A
 # payload is only submittable while referenceBlockNumber + BLOCK_STALE_MEASURE >= block.number, so
 # values above BLOCK_STALE_MEASURE are clamped to it. Default: 50.
+#
+# In schnorr mode this is an upper bound rather than the final value: a payload's validity is also
+# clamped to end before the registry's next possible operator-set change (see
+# SCHNORR_NOTICE_WINDOW), so it can expire sooner than this buffer allows.
 # PAYLOAD_BLOCK_BUFFER=50
 #
 # The GET /tasks/{id} block-window freshness check measures valid_until_block against the L1 chain

--- a/router/src/executor.rs
+++ b/router/src/executor.rs
@@ -15,6 +15,7 @@ use gas_killer_common::bindings::gaskillersdk::{
     BN254, GasKillerSDK, IBLSSignatureCheckerTypes as GasKillerIBLSTypes,
 };
 use gas_killer_common::bindings::schnorrgaskillersdk::SchnorrGasKillerSDK;
+use gas_killer_common::bindings::schnorrstakeregistry::ISchnorrStakeRegistry;
 use gas_killer_common::bindings::{GAS_KILLER_INTERFACE_ID, SCHNORR_GAS_KILLER_INTERFACE_ID};
 use gas_killer_common::{BundleProof, PayloadView, TaskBundle};
 use std::collections::HashMap;
@@ -126,6 +127,27 @@ struct PreparedSchnorr<P> {
 struct RenderedRound {
     payload: PayloadView,
     bundle: TaskBundle,
+}
+
+/// Bound a rendered payload's validity so it expires before the operator set can change.
+///
+/// A payload is submittable until `valid_until_block`, but a Schnorr settlement only verifies while
+/// the operator set still matches the one its signature was assembled against. `horizon` is the
+/// registry's earliest possible mutation block, so validity must end strictly below it — a
+/// settlement landing *on* that block can already see the mutated set.
+///
+/// `None` leaves the value untouched (the horizon could not be read). `u64::MAX` — which the
+/// registry returns as `type(uint256).max` when nothing is scheduled — is the common case and
+/// clamps nothing. A horizon at or below the existing validity yields a payload that is already
+/// expired; that is deliberate, and `GET /tasks/{id}` answers it with the usual `PAYLOAD_EXPIRED`
+/// re-request rather than handing over calldata that would revert.
+fn clamp_to_mutation_horizon(valid_until_block: u64, horizon: Option<U256>) -> u64 {
+    let Some(horizon) = horizon else {
+        return valid_until_block;
+    };
+    // Saturating: an unscheduled horizon is `type(uint256).max`, far beyond u64.
+    let horizon = u64::try_from(horizon).unwrap_or(u64::MAX);
+    valid_until_block.min(horizon.saturating_sub(1))
 }
 
 /// Handler for executing verifyAndUpdate transactions with multi-chain support
@@ -850,6 +872,49 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
         })
     }
 
+    /// Read the target's Schnorr registry horizon: the earliest block at which its operator set
+    /// can change.
+    ///
+    /// `SchnorrStakeRegistry` holds a single current aggregate key rather than per-block history,
+    /// so any operator-set change invalidates a signature an off-chain round already assembled
+    /// against the previous set. Changes are announced ahead of time and this horizon publishes
+    /// when the earliest one becomes applicable, which is what lets a rendered payload be given a
+    /// validity that ends before the set can move underneath it.
+    ///
+    /// Returns `None` when the horizon cannot be established, in which case the payload keeps its
+    /// unclamped validity: a transient RPC failure should not discard a completed signing round,
+    /// and the registry's own fail-closed watermark still rejects a settlement assembled against a
+    /// stale set. The guarantee is best-effort for the same reason it is only a guarantee for the
+    /// announced path — `registerOperator` / `deregisterOperator` bypass the notice window
+    /// entirely and emit `ForcedMutation`.
+    async fn schnorr_mutation_horizon(&self, provider: P, target_addr: Address) -> Option<U256> {
+        let sdk = SchnorrGasKillerSDK::new(target_addr, provider.clone());
+        let registry_addr = match sdk.schnorrRegistry().call().await {
+            Ok(addr) => addr,
+            Err(error) => {
+                warn!(
+                    target = %target_addr,
+                    %error,
+                    "could not read schnorrRegistry; leaving payload validity unclamped"
+                );
+                return None;
+            }
+        };
+
+        let registry = ISchnorrStakeRegistry::new(registry_addr, provider);
+        match registry.nextPossibleMutationBlock().call().await {
+            Ok(horizon) => Some(horizon),
+            Err(error) => {
+                warn!(
+                    registry = %registry_addr,
+                    %error,
+                    "could not read nextPossibleMutationBlock; leaving payload validity unclamped"
+                );
+                None
+            }
+        }
+    }
+
     /// Schnorr twin of [`Self::render_bls_payload`]: renders a completed Schnorr round into a
     /// user-signable transaction request and its durable [`TaskBundle`] without broadcasting.
     /// The outer payload is scheme-agnostic — only the encoded `data` and the bundle's proof
@@ -919,7 +984,20 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> GasKillerHandler<P> 
             }
         };
 
-        let valid_until_block = reference_block_number as u64 + self.payload_block_buffer;
+        let unclamped_valid_until = reference_block_number as u64 + self.payload_block_buffer;
+        let horizon = self
+            .schnorr_mutation_horizon(sdk.provider().clone(), target_addr)
+            .await;
+        let valid_until_block = clamp_to_mutation_horizon(unclamped_valid_until, horizon);
+        if valid_until_block < unclamped_valid_until {
+            info!(
+                target = %target_addr,
+                reference_block = reference_block_number,
+                valid_until_block,
+                unclamped_valid_until,
+                "payload validity shortened to expire before the operator set can change"
+            );
+        }
 
         let payload = PayloadView {
             to: target_addr,
@@ -1119,6 +1197,44 @@ mod tests {
     // queued entry corresponds to exactly one RPC.
     fn push_supports_interface(asserter: &Asserter, supported: bool) {
         asserter.push_success(&Bytes::from(supported.abi_encode()));
+    }
+
+    // An unscheduled horizon is `type(uint256).max`, which is the state of a registry with nothing
+    // announced — by far the common case, and it must leave validity untouched.
+    #[test]
+    fn horizon_clamp_is_noop_when_no_change_is_scheduled() {
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::MAX)), 150);
+    }
+
+    // A horizon the router could not read must not silently shorten validity.
+    #[test]
+    fn horizon_clamp_is_noop_when_horizon_is_unknown() {
+        assert_eq!(clamp_to_mutation_horizon(150, None), 150);
+    }
+
+    // A horizon beyond the payload's own expiry constrains nothing.
+    #[test]
+    fn horizon_clamp_is_noop_when_horizon_is_beyond_validity() {
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::from(400))), 150);
+    }
+
+    // The payload must stop being valid strictly *below* the horizon: a settlement landing on that
+    // block can already see the mutated operator set.
+    #[test]
+    fn horizon_clamp_ends_validity_one_block_before_the_horizon() {
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::from(120))), 119);
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::from(151))), 150);
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::from(150))), 149);
+    }
+
+    // A change announced mid-round can leave the horizon at or behind the payload's reference
+    // block. The payload is then born expired, which `GET /tasks/{id}` reports as PAYLOAD_EXPIRED —
+    // preferable to handing over calldata that would revert.
+    #[test]
+    fn horizon_clamp_yields_an_already_expired_payload_when_a_change_is_imminent() {
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::from(10))), 9);
+        // A zero horizon must not underflow into u64::MAX, which would defeat the clamp entirely.
+        assert_eq!(clamp_to_mutation_horizon(150, Some(U256::ZERO)), 0);
     }
 
     #[tokio::test]

--- a/scripts/bindings/mod.rs
+++ b/scripts/bindings/mod.rs
@@ -63,3 +63,24 @@ pub mod reentrantcheckpointfactory;
     dead_code
 )]
 pub mod reentrantcheckpoint;
+
+#[cfg(test)]
+mod tests {
+    use alloy::sol_types::SolCall;
+
+    /// The router declares `nextPossibleMutationBlock` by hand
+    /// (`gas_killer_common::bindings::schnorrstakeregistry`) instead of vendoring the registry's ABI
+    /// artifact a second time. This crate does carry that artifact, because it deploys the registry,
+    /// so comparing the two selectors pins the hand-written declaration against the real ABI.
+    ///
+    /// Without this, an upstream rename would leave the router's call reverting at runtime and
+    /// silently falling back to unclamped payload validity — a warning in the logs rather than a
+    /// failure.
+    #[test]
+    fn router_registry_declaration_matches_the_deploy_artifact() {
+        assert_eq!(
+            gas_killer_common::bindings::schnorrstakeregistry::ISchnorrStakeRegistry::nextPossibleMutationBlockCall::SELECTOR,
+            crate::schnorrstakeregistry::SchnorrStakeRegistry::nextPossibleMutationBlockCall::SELECTOR,
+        );
+    }
+}


### PR DESCRIPTION
Closes #339.

## Summary

`SchnorrStakeRegistry` publishes `nextPossibleMutationBlock()` — the earliest block its operator set can change (gas-killer/solidity-sdk#69, design in gas-killer/solidity-sdk#60). Nothing read it, so the horizon was inert and a mutation could still invalidate a payload the router had already handed out.

The router now reads it when rendering a Schnorr payload and ends that payload's validity before it:

```
valid_until_block = min(referenceBlock + PAYLOAD_BLOCK_BUFFER, horizon - 1)
```

A client that submits within the payload's stated validity therefore cannot eat an `InvalidQuorumSignature` caused by an announced operator-set change.

## Why this shape

**Not at submission — the router does not submit.** `render_schnorr_payload` builds calldata and persists a user-signable payload; the on-chain submission is the user's. So the check has to happen at render time.

**Reusing payload expiry rather than adding a mechanism.** A rendered payload already carries `valid_until_block`, and `GET /tasks/{id}` already answers a passed one with a `PAYLOAD_EXPIRED` re-request. Clamping that value expresses "this payload dies before the set can move" in machinery that exists — no new API surface, no new error variant, and an expired payload is already a re-request rather than a failure.

**Strictly below the horizon.** A settlement landing *on* the mutation block can already see the mutated set, hence `horizon - 1`.

**No new config.** `SchnorrGasKillerSDK.schnorrRegistry()` already exists, so the router discovers the registry from the target contract rather than needing an address threaded through the environment.

## Failure and edge behaviour

- **Nothing scheduled** — the registry returns `type(uint256).max`, so the clamp is a no-op. This is the common case, and the only case today since `SCHNORR_NOTICE_WINDOW` defaults to 0.
- **Horizon unreadable** (transient RPC failure, or the registry surface drifting) — logs a warning and leaves validity unclamped. A completed signing round should not be discarded for a transient error, and the registry's own fail-closed watermark still rejects a settlement assembled against a stale set. Same posture as the existing `estimate_gas` fallback immediately above it.
- **Change announced mid-round**, leaving the horizon at or behind the reference block — the payload is born expired and `GET /tasks/{id}` reports `PAYLOAD_EXPIRED`, so the client re-requests against the post-mutation set. Deliberate: preferable to handing over calldata that would revert. A zero horizon saturates rather than underflowing into `u64::MAX`, which would silently defeat the clamp.
- **Forced mutations still bypass it.** `registerOperator` / `deregisterOperator` skip the notice window and emit `ForcedMutation`; the horizon is a guarantee for the announced path only. Documented in the code and in `example.env` rather than implied.

## Registry binding: one function, pinned to the real ABI

The router needs exactly one view function, so `common/src/bindings/schnorrstakeregistry.rs` declares just that rather than vendoring `SchnorrStakeRegistry.json` a second time — `scripts` already carries the full artifact because it deploys the registry, and #338 was a reminder that duplicated artifacts drift.

The obvious objection is that a hand-written declaration can drift silently. Two things prevent that:

- The router's own call site pins it at **compile time** — I verified a rename fails the build with `no method named nextPossibleMutationBlock`.
- `router_registry_declaration_matches_the_deploy_artifact` (in `scripts/bindings`, which owns the artifact) asserts the hand-written selector equals the artifact-generated one, so an **upstream** rename fails a test instead of degrading into a runtime warning. Verified non-vacuous: with the declaration renamed and the call site fixed, the test fails on `left: [246, 119, 49, 145] / right: [109, 17, 169, 122]`.

## Tests

Five cases on `clamp_to_mutation_horizon`, which is a free function so the arithmetic is testable without mocking a provider: no-op on `U256::MAX`, no-op on `None`, no-op when the horizon is beyond validity, the `horizon - 1` boundary (including horizon == validity), and the born-expired case with the zero-horizon underflow guard. Plus the selector pin above.

**258 tests pass** (252 before). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo check --all-targets --all-features` all clean.

## Scope

**#339 only.** gas-killer/solidity-sdk#66 changes the Schnorr `verifyAndUpdate` signature (drops `targetFunction`, adds `anchorHash` / `callerAddress` / `contractCalldata`), and the service side of that is unstarted. It is near-orthogonal to this change — #66 churns calldata construction and the signed digest, this touches `valid_until_block` in the same function — so the rebase is cheap and this does not front-run an unmerged PR.

No behaviour change for any current deployment: every stack runs `SCHNORR_NOTICE_WINDOW=0`, where the horizon is unbounded and the clamp does nothing. The two extra reads per Schnorr render are the only observable difference until a window is set.
