### PR TITLE
feat: manifest-driven harness for deploying and targeting example contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ test_processes.pids
 # Script build artifacts
 scripts/target
 
+# Example contracts checkout (fetched by scripts/examples/fetch_examples.sh) and the
+# scenario files deploy_example generates from it.
+/.examples
+scripts/scenarios/generated/
+
 # Helm chart dependencies (fetch via `helm dependency update`)
 helm/gas-killer/charts/*.tgz
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -2225,6 +2226,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8174,9 +8187,12 @@ name = "scripts"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
+ "clap",
  "dotenv",
  "gas-analyzer-evmsketch",
  "gas-killer-common",
@@ -8185,6 +8201,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml 0.8.23",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ license = "PPL"
 
 [workspace.dependencies]
 alloy = "1.0"
+alloy-dyn-abi = "1.0"
 alloy-eips = "1.0"
+alloy-json-abi = "1.0"
 alloy-network = "1.0"
 alloy-primitives = "1.0"
 alloy-provider = "1.0"

--- a/example.env
+++ b/example.env
@@ -379,3 +379,28 @@ ARRAY_SUMMATION_MAX_VALUE=1000
 ARRAY_SUMMATION_SEED=42
 ARRAY_SUMMATION_FACTORY_ADDRESS=0xF7ded769418Ec1Db4DA3bd2d47ab72ce2296A032
 # ARRAY_SUMMATION_ADDRESS=0x8867cf9D1FfC33fE4761c19E621Ee29323E91E56 # Setting this will override deploying a new contract
+
+# =============================================================================
+# Example Contracts Harness (scripts/examples/)
+# =============================================================================
+# The public example-contracts library is fetched and built by
+# scripts/examples/fetch_examples.sh, then deployed by the `deploy_example` bin, which
+# reads the manifest at scripts/examples/examples.toml. See scripts/README.md.
+#
+# Where the checkout and its forge artifacts live. Gitignored.
+# EXAMPLES_DIR=.examples/example-contracts
+# Git revision to build. Pinned to a SHA so a rebuild is reproducible; override with a
+# branch name to track upstream.
+# EXAMPLES_REF=f9aa0a6020ec7b3e28db47999ece8ba54b3847f6
+# EXAMPLES_REPO=https://github.com/gas-killer/example-contracts
+#
+# Constructor wiring for deployed examples. Both default to reading the AVS deployment
+# JSON at AVS_DEPLOYMENT_PATH, which is what the local compose stack produces; set them
+# explicitly when deploying against a testnet with no local deployment JSON.
+# EXAMPLE_AVS_ADDRESS=          # default: addresses.avsServiceManagerWrapper
+# EXAMPLE_SIG_CHECKER_ADDRESS=  # default: addresses.IncredibleSquaringTaskManager
+#
+# NOTE: the signature checker must be a real BLSSignatureChecker (one exposing
+# registryCoordinator()). addresses.blsSigCheck is the BLSSigCheckOperatorStateRetriever,
+# which has no checkSignatures — a target wired to it reverts with an empty 0x during
+# verifyAndUpdate. deploy_example rejects it rather than letting that happen silently.

--- a/example.env
+++ b/example.env
@@ -387,6 +387,11 @@ ARRAY_SUMMATION_FACTORY_ADDRESS=0xF7ded769418Ec1Db4DA3bd2d47ab72ce2296A032
 # scripts/examples/fetch_examples.sh, then deployed by the `deploy_example` bin, which
 # reads the manifest at scripts/examples/examples.toml. See scripts/README.md.
 #
+# Per-example encoding requirement: guardedVault settles under any STATE_ENCODING, but
+# onchainLife only settles under prestate-net (its tracked function is ~16.5M gas, which
+# the struct-log encoders behind legacy/canonical cannot extract). See the STATE_ENCODING
+# block above.
+#
 # Where the checkout and its forge artifacts live. Gitignored.
 # EXAMPLES_DIR=.examples/example-contracts
 # Git revision to build. Pinned to a SHA so a rebuild is reproducible; override with a

--- a/example.env
+++ b/example.env
@@ -387,12 +387,7 @@ ARRAY_SUMMATION_FACTORY_ADDRESS=0xF7ded769418Ec1Db4DA3bd2d47ab72ce2296A032
 # scripts/examples/fetch_examples.sh, then deployed by the `deploy_example` bin, which
 # reads the manifest at scripts/examples/examples.toml. See scripts/README.md.
 #
-# Per-example encoding requirement: guardedVault settles under any STATE_ENCODING, but
-# onchainLife only settles under prestate-net (its tracked function is ~16.5M gas, which
-# the struct-log encoders behind legacy/canonical cannot extract). See the STATE_ENCODING
-# block above.
-#
-# Where the checkout and its forge artifacts live. Gitignored.
+# Where the checkout and its forge artifacts live.
 # EXAMPLES_DIR=.examples/example-contracts
 # Git revision to build. Pinned to a SHA so a rebuild is reproducible; override with a
 # branch name to track upstream.

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -20,14 +20,21 @@ name = "run_scenario"
 path = "run_scenario.rs"
 
 [[bin]]
+name = "deploy_example"
+path = "deploy_example.rs"
+
+[[bin]]
 name = "verify_message_hash_parity"
 path = "verify_message_hash_parity.rs"
 
 [dependencies]
 alloy = { workspace = true }
+alloy-dyn-abi = { workspace = true }
+alloy-json-abi = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 dotenv = { workspace = true }
 gas-analyzer = { workspace = true }
 gas-killer-common = { workspace = true }
@@ -39,3 +46,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -139,6 +139,17 @@ library holds contracts that demonstrate different Gas Killer use cases. The `de
 binary builds them, deploys one wired to the local AVS, records its address where the rest of
 the tooling already looks, and writes a ready-to-run scenario file.
 
+> **Scope: dev and test only. Do not use this to deploy a value-bearing target.**
+>
+> `deploy_example` validates the signature checker by *shape* — that it has code and answers
+> `registryCoordinator()`, which the `BLSSigCheckOperatorStateRetriever` does not. That catches
+> the two documented footguns, but it does not establish that the checker soundly verifies
+> quorum signatures. A permissive or mock checker exposing that getter passes the check, and a
+> target wired to one accepts **unsigned** diffs — total compromise of the thing the AVS exists
+> to guarantee. That trade-off is fine for example contracts on a fork or testnet, which is what
+> this is for. A production target needs the checker verified against the registry coordinator
+> the AVS actually registered against, plus the usual deployment review — not this harness.
+
 One command, assuming the local stack is already up. `guardedVault` is the example to start with —
 it settles under the default encoding, whereas `onchainLife` needs `prestate-net` (see below):
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -163,24 +163,37 @@ cargo run -p scripts --bin run_scenario -- scripts/scenarios/generated/onchainLi
 
 Currently available:
 
-| Example | Status against the local stack |
-|---|---|
-| `guardedVault` | Runs green end to end. An O(N) invariant re-validated on every transition. |
-| `onchainLife` | Deploys and is routable, but its `step(1)` task does **not** render — see below. Conway's Life; heavy compute, tiny flat diff. |
+| Example | Required encoding | What it demonstrates |
+|---|---|---|
+| `guardedVault` | any | An O(N) invariant re-validated on every transition. Runs green end to end. |
+| `onchainLife` | **`prestate-net`** | Conway's Life: heavy compute, tiny flat diff. Deploys and is routable under any encoding, but only settles under `prestate-net` — see below. |
 
-**`onchainLife` currently exceeds the trace-based diff encoder.** The router derives the diff via
-`debug_traceCall`, and one generation of Life is ~16.9M gas. The structLog trace exhausts the
-anvil container and the process is OOM-killed (exit 137), so the task never reaches `ready`:
+**`onchainLife` requires `STATE_ENCODING=prestate-net`.**
+
+`legacy` and `canonical` derive the diff from a struct-log `debug_traceCall`, which costs
+`O(execution steps)` — and one generation of Life is ~16.5M gas. Measured on a stock anvil, that
+trace drives the process from 8 MB to 2.2 GB of RSS in 20s and still has not returned; inside the
+3.82 GiB compose container it is OOM-killed outright (`exit 137`), so the task never reaches
+`ready`:
 
 ```
 ERROR gas_killer_router::sequencer: failed to enrich task, dropping request
   error=Gas analysis failed: debug_trace_call failed: error sending request
 ```
 
-`generations` is already at its floor of 1, so this is a limit of the encoder rather than the
-manifest. The example repo's `docs/APPROACH-A-PRESTATE.md` describes the intended fix — a
-prestate diff extractor that avoids structLogs. The manifest entry is kept so the case stays
-one command to reproduce.
+`generations` is already at its floor of 1, so no manifest setting avoids this — the limit is the
+encoder. `prestate-net` reads the net diff from `prestateTracer`/`callTracer` instead, costing
+`O(changed slots)`: the same call returns in **0s with a 3-slot diff**, and the call tree has no
+target-depth frames, so it takes the net form rather than the canonical fallback.
+
+```bash
+STATE_ENCODING=prestate-net docker compose up -d --force-recreate   # node AND router together
+./scripts/examples/run_example.sh onchainLife
+```
+
+The encoding is consensus-critical — every node and the router must agree, since it changes the
+task digest. See the `STATE_ENCODING` block in `example.env`. Note that under `prestate-net` a
+node whose RPC lacks either tracer fails the task rather than downgrading.
 
 ### Adding an example
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,11 +111,141 @@ An annotated example config lives at `scripts/scenarios/example.toml`.
 | Field | Required | Default | Description |
 |---|---|---|---|
 | `label` | No | `request N` | Human-readable label for output |
+| `submit` | No | `false` | Poll `GET /tasks/{id}` after a `202` and submit the rendered payload with `FUNDED_KEY` (or `PRIVATE_KEY`). Required for `verify` to mean anything when the router runs in ingress mode — see below |
 | `target_address` | Yes | — | Contract address to call. Or `"kubectl"` to resolve it at runtime from the `gas-killer-smoke-target` ConfigMap via `kubectl` (also accepts `"kubectl:<configmap>[/<key>]"`; namespace follows the current kube-context unless `SMOKE_TARGET_NAMESPACE` is set). Or `"local"` to read `addresses.arraySummation` from the local deploy JSON at `AVS_DEPLOYMENT_PATH` (default `config/.nodes/avs_deploy.json`; `"local:<key>"` selects a different deployed contract) |
 | `call_data` | Yes | — | ABI-encoded calldata as a `0x`-prefixed hex string |
 | `from_address` | Yes | — | Sender address, or `"local"` to derive it from the `PRIVATE_KEY` the local stack signs with |
 | `transition_index` | No | `"auto"` | State transition sequence number, or `"auto"` to fetch `stateTransitionCount()` from the contract (requires `http_rpc`) |
 | `value` | No | `"0"` | Wei value as decimal or `0x`-prefixed hex string |
 | `block_height` | No | `0` | Block to use; `0` auto-fetches current block via `http_rpc` |
-| `verify` | No | `false` | Poll `stateTransitionCount()` after a `200` to confirm `verifyAndUpdate` ran |
-| `verify_timeout_secs` | No | `150` | How long to wait for on-chain confirmation |
+| `verify` | No | `false` | Poll `stateTransitionCount()` after a `202` to confirm `verifyAndUpdate` ran |
+| `verify_timeout_secs` | No | `150` | How long to wait for the payload to render and for on-chain confirmation |
+
+### Why `submit` matters
+
+With `INGRESS=true` (the default, see `example.env`) the router **renders** a `verifyAndUpdate`
+transaction rather than broadcasting it: the quorum signs, the executor persists a payload, and
+the *caller* signs and sends it. Nothing reaches the chain until someone does.
+
+So `verify = true` on its own can only ever time out — it polls `stateTransitionCount()` for an
+effect that no one has caused. Pair it with `submit = true`, which waits for the task to reach
+`ready`, then submits `payload.{to, data, value}`. `submit` defaults to `false`, so scenario
+files written before it existed behave exactly as they did.
+
+## Example Contracts
+
+The public [gas-killer/example-contracts](https://github.com/gas-killer/example-contracts)
+library holds contracts that demonstrate different Gas Killer use cases. The `deploy_example`
+binary builds them, deploys one wired to the local AVS, records its address where the rest of
+the tooling already looks, and writes a ready-to-run scenario file.
+
+One command, assuming the local stack is already up:
+
+```bash
+./scripts/examples/run_example.sh onchainLife
+```
+
+Or step by step:
+
+```bash
+# Clone/update the pinned revision, sync submodules recursively, forge build
+./scripts/examples/fetch_examples.sh
+
+# Validate the manifest and ABI encoding without a chain or a running stack
+cargo run -p scripts --bin deploy_example -- --dry-run
+
+# Deploy, assert the target is routable, run its setup calls, emit a scenario
+cargo run -p scripts --bin deploy_example -- --example onchainLife
+
+# Trigger a task, submit the rendered payload, confirm the transition landed
+cargo run -p scripts --bin run_scenario -- scripts/scenarios/generated/onchainLife.toml
+```
+
+Currently available:
+
+| Example | Status against the local stack |
+|---|---|
+| `guardedVault` | Runs green end to end. An O(N) invariant re-validated on every transition. |
+| `onchainLife` | Deploys and is routable, but its `step(1)` task does **not** render — see below. Conway's Life; heavy compute, tiny flat diff. |
+
+**`onchainLife` currently exceeds the trace-based diff encoder.** The router derives the diff via
+`debug_traceCall`, and one generation of Life is ~16.9M gas. The structLog trace exhausts the
+anvil container and the process is OOM-killed (exit 137), so the task never reaches `ready`:
+
+```
+ERROR gas_killer_router::sequencer: failed to enrich task, dropping request
+  error=Gas analysis failed: debug_trace_call failed: error sending request
+```
+
+`generations` is already at its floor of 1, so this is a limit of the encoder rather than the
+manifest. The example repo's `docs/APPROACH-A-PRESTATE.md` describes the intended fix — a
+prestate diff extractor that avoids structLogs. The manifest entry is kept so the case stays
+one command to reproduce.
+
+### Adding an example
+
+Edit `scripts/examples/examples.toml` and add the artifact to `EXPECTED_ARTIFACTS` in
+`fetch_examples.sh`. No Rust changes: constructor argument *types* are read from the Foundry
+artifact's ABI at runtime, and the manifest supplies only values.
+
+```toml
+[[examples]]
+name      = "myExample"                       # key in avs_deploy.json; also --example and the scenario filename
+artifact  = "MyExample.sol:MyExample"
+ctor_args = ["$avs", "$sigChecker", "42"]
+
+  [[examples.setup]]                          # optional; run after deploy
+  sig    = "prepare(uint256)"
+  args   = ["1"]
+  signer = 1                                  # index into the manifest's `signers`
+
+  [[examples.exercise]]                       # one generated scenario request each
+  sig  = "doExpensiveThing(uint32)"
+  args = ["1"]
+```
+
+Placeholders: `$avs`, `$sigChecker`, `$deploy:<key>`, `$signer:<n>`, `$env:VAR`. Array and
+tuple parameters take a TOML list.
+
+To be settleable, a contract must inherit `GasKillerSDK` and pass the AVS service manager plus
+a signature checker to its constructor. `deploy_example` asserts this after deploying — it
+checks the same ERC-165 interface the router gates on, plus `stateTransitionCount()` and
+`getMessageHash()` — so a mis-wired or SDK-mismatched target fails at deploy time instead of
+mid-round.
+
+### Signature checker
+
+`verifyAndUpdate` calls `checkSignatures` on whatever address the constructor received.
+`addresses.blsSigCheck` in the AVS deployment JSON is the `BLSSigCheckOperatorStateRetriever`,
+which has no such function — a target wired to it reverts with an empty `0x` at settlement.
+`deploy_example` defaults `$sigChecker` to `addresses.IncredibleSquaringTaskManager` (which
+does inherit `BLSSignatureChecker`), rejects the retriever by name, and probes for
+`registryCoordinator()` before deploying. Override with `--sig-checker` or
+`EXAMPLE_SIG_CHECKER_ADDRESS`.
+
+### Deploying against a testnet
+
+```bash
+export AVS_DEPLOYMENT_PATH=config/.nodes/sepolia_deploy.json   # keeps local state intact
+cargo run -p scripts --bin deploy_example -- \
+  --example onchainLife \
+  --avs 0x... --sig-checker 0x... \
+  --router-url https://testnet.gaskiller.xyz
+```
+
+The deployment JSON is created if absent. `guardedVault`'s setup calls need several funded
+accounts, so replace the manifest's `signers` list before using it outside a local fork.
+
+### `deploy_example` flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--manifest` | `scripts/examples/examples.toml` | Manifest to read |
+| `--example` | all | Example to deploy, by `name`; repeatable |
+| `--artifacts` | `$EXAMPLES_DIR/out` | Foundry `out/` tree to load artifacts from |
+| `--deploy-json` | `$AVS_DEPLOYMENT_PATH` | Deployment JSON to read wiring from and record into |
+| `--avs` / `--sig-checker` | from env, then the deployment JSON | Constructor wiring |
+| `--router-url` | `$GAS_KILLER_ROUTER_URL` | Written into the generated scenario |
+| `--scenario-dir` | `scripts/scenarios/generated` | Where scenarios are written |
+| `--reuse` | off | Reuse the recorded address instead of deploying again |
+| `--dry-run` | off | Resolve, encode, and emit scenarios without sending transactions |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -139,10 +139,11 @@ library holds contracts that demonstrate different Gas Killer use cases. The `de
 binary builds them, deploys one wired to the local AVS, records its address where the rest of
 the tooling already looks, and writes a ready-to-run scenario file.
 
-One command, assuming the local stack is already up:
+One command, assuming the local stack is already up. `guardedVault` is the example to start with —
+it settles under the default encoding, whereas `onchainLife` needs `prestate-net` (see below):
 
 ```bash
-./scripts/examples/run_example.sh onchainLife
+./scripts/examples/run_example.sh guardedVault
 ```
 
 Or step by step:
@@ -155,10 +156,10 @@ Or step by step:
 cargo run -p scripts --bin deploy_example -- --dry-run
 
 # Deploy, assert the target is routable, run its setup calls, emit a scenario
-cargo run -p scripts --bin deploy_example -- --example onchainLife
+cargo run -p scripts --bin deploy_example -- --example guardedVault
 
 # Trigger a task, submit the rendered payload, confirm the transition landed
-cargo run -p scripts --bin run_scenario -- scripts/scenarios/generated/onchainLife.toml
+cargo run -p scripts --bin run_scenario -- scripts/scenarios/generated/guardedVault.toml
 ```
 
 Currently available:
@@ -241,13 +242,18 @@ does inherit `BLSSignatureChecker`), rejects the retriever by name, and probes f
 ```bash
 export AVS_DEPLOYMENT_PATH=config/.nodes/sepolia_deploy.json   # keeps local state intact
 cargo run -p scripts --bin deploy_example -- \
-  --example onchainLife \
+  --example guardedVault \
   --avs 0x... --sig-checker 0x... \
   --router-url https://testnet.gaskiller.xyz
 ```
 
-The deployment JSON is created if absent. `guardedVault`'s setup calls need several funded
-accounts, so replace the manifest's `signers` list before using it outside a local fork.
+The deployment JSON is created if absent. Both examples carry a constraint off a local fork:
+
+- **`guardedVault`** — `deposit` credits `msg.sender`, so its three depositors need three funded
+  accounts. Replace the manifest's `signers` list, which defaults to anvil's test keys.
+- **`onchainLife`** — needs the whole operator set running `prestate-net` *and* every operator's
+  RPC supporting `prestateTracer`/`callTracer`. That is a fleet-wide decision rather than a
+  per-deploy flag, so it is not something a single `deploy_example` invocation can arrange.
 
 ### `deploy_example` flags
 

--- a/scripts/bindings/mod.rs
+++ b/scripts/bindings/mod.rs
@@ -1,3 +1,10 @@
+//! Shared support code for the `scripts` crate's binaries: `alloy::sol!` contract
+//! bindings generated from the vendored artifacts under `bindings/abis/`, plus
+//! hand-written helpers the binaries have in common.
+
+/// Polling and submission of router-rendered `verifyAndUpdate` payloads.
+pub mod task_payload;
+
 #[allow(
     non_camel_case_types,
     non_snake_case,

--- a/scripts/bindings/task_payload.rs
+++ b/scripts/bindings/task_payload.rs
@@ -1,0 +1,223 @@
+//! Client-side half of the ingress task lifecycle, shared by the script binaries.
+//!
+//! With `INGRESS=true` the router *renders* a `verifyAndUpdate` transaction rather than
+//! broadcasting it: the quorum signs, the executor persists a payload, and the caller is the
+//! one who signs and sends it. So confirming that a task actually settled on-chain takes
+//! three steps, not one — poll `GET /tasks/{id}` until the payload is rendered, submit it,
+//! and only then does the target's `stateTransitionCount()` move.
+//!
+//! A rendered payload is only valid for a window (`valid_until_block`), so the poll and the
+//! submission belong together and are kept in one module.
+
+use alloy::network::{EthereumWallet, TransactionBuilder};
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
+use gas_killer_common::PayloadView;
+use url::Url;
+
+type DynError = Box<dyn std::error::Error + Send + Sync>;
+
+/// How long to wait for a task to reach `ready` before giving up.
+pub const DEFAULT_READY_TIMEOUT_SECS: u64 = 150;
+
+/// How often to re-poll a task's status while waiting for it to become `ready`.
+pub const READY_POLL_INTERVAL_SECS: u64 = 5;
+
+/// Builds the `GET /tasks/{task_id}` URL for a router reachable at `base_url`.
+///
+/// `base_url` may be either the router root (`http://host:8080`) or a submission endpoint
+/// (`http://host:8080/tasks`); the path is replaced either way.
+pub fn task_status_url(base_url: &str, task_id: &str) -> Result<Url, DynError> {
+    let mut url =
+        Url::parse(base_url).map_err(|e| format!("invalid router URL {base_url}: {e}"))?;
+    url.set_path(&format!("/tasks/{task_id}"));
+    Ok(url)
+}
+
+/// Reads the submitter key, preferring `FUNDED_KEY` over `PRIVATE_KEY`.
+///
+/// The local stack runs against an Anvil fork whose dev accounts are funded, so a
+/// hand-edited `.env` carrying a real-but-unfunded `PRIVATE_KEY` should not break local
+/// submission.
+pub fn submitter_key() -> Result<String, DynError> {
+    std::env::var("FUNDED_KEY")
+        .or_else(|_| std::env::var("PRIVATE_KEY"))
+        .map_err(|_| "FUNDED_KEY or PRIVATE_KEY required to submit the payload".into())
+}
+
+/// Polls `GET /tasks/{id}` until the task is `ready` and returns its rendered payload.
+///
+/// A `ready` response carries the transaction request the user submits as-is. A `failed`/`expired`
+/// settlement, or a non-success status (e.g. `409 PAYLOAD_EXPIRED` if the payload went stale before
+/// we submitted), is terminal and surfaces as an error.
+pub async fn wait_for_ready_payload(
+    client: &reqwest::Client,
+    task_status_url: &Url,
+    api_key: Option<&str>,
+    task_id: &str,
+    timeout_secs: u64,
+) -> Result<PayloadView, DynError> {
+    use tokio::time::{Duration, Instant, sleep};
+    let max_wait_time = Duration::from_secs(timeout_secs);
+    let check_interval = Duration::from_secs(READY_POLL_INTERVAL_SECS);
+    let start_time = Instant::now();
+
+    loop {
+        let mut req = client.get(task_status_url.clone());
+        if let Some(api_key) = api_key {
+            req = req.header("Authorization", format!("Bearer {api_key}"));
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to poll task {}: {}", task_id, e))?;
+        let status_code = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse task {} response: {}", task_id, e))?;
+
+        // A non-success status (e.g. 409 PAYLOAD_EXPIRED) carries an error envelope, not a task.
+        if !status_code.is_success() {
+            let code = body
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_str())
+                .unwrap_or("UNKNOWN");
+            return Err(
+                format!("Task {task_id} status query returned {status_code} ({code})").into(),
+            );
+        }
+
+        let task_status = body
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        println!(
+            "task {}: status={}, elapsed={:.1}s",
+            task_id,
+            task_status,
+            start_time.elapsed().as_secs_f64()
+        );
+
+        match task_status.as_str() {
+            "ready" => {
+                let payload_value = body
+                    .get("payload")
+                    .cloned()
+                    .ok_or_else(|| format!("ready task {task_id} carried no payload"))?;
+                let payload: PayloadView = serde_json::from_value(payload_value)
+                    .map_err(|e| format!("failed to parse task {task_id} payload: {e}"))?;
+                println!(
+                    "✅ task {} ready: to={:?} chain_id={} estimated_gas={} valid_until_block={}",
+                    task_id,
+                    payload.to,
+                    payload.chain_id,
+                    payload.estimated_gas,
+                    payload.valid_until_block
+                );
+                return Ok(payload);
+            }
+            "failed" | "expired" => {
+                let error = body
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("<no error recorded>");
+                return Err(
+                    format!("Task {} settled as '{}': {}", task_id, task_status, error).into(),
+                );
+            }
+            _ => {}
+        }
+
+        if start_time.elapsed() >= max_wait_time {
+            return Err(format!(
+                "Task {} did not reach 'ready' within {:.0}s (last status: {})",
+                task_id,
+                max_wait_time.as_secs_f64(),
+                task_status
+            )
+            .into());
+        }
+
+        sleep(check_interval).await;
+    }
+}
+
+/// Signs and submits a rendered payload with a funded key, mirroring what an integrator does, and
+/// asserts the `verifyAndUpdate` transaction lands successfully.
+pub async fn submit_payload(
+    payload: &PayloadView,
+    http_rpc: &str,
+    private_key: &str,
+) -> Result<(), DynError> {
+    let signer: PrivateKeySigner = private_key
+        .parse()
+        .map_err(|_| "invalid FUNDED_KEY/PRIVATE_KEY format")?;
+    let sender = signer.address();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer))
+        .connect_http(http_rpc.parse().map_err(|_| "invalid HTTP_RPC URL")?);
+
+    let tx = TransactionRequest::default()
+        .with_to(payload.to)
+        .with_value(payload.value)
+        .with_input(payload.data.clone());
+
+    println!(
+        "Submitting verifyAndUpdate as {sender} to {:?} ({} bytes calldata)",
+        payload.to,
+        payload.data.len()
+    );
+    let pending = provider
+        .send_transaction(tx)
+        .await
+        .map_err(|e| format!("failed to send verifyAndUpdate: {e}"))?;
+    let receipt = pending
+        .get_receipt()
+        .await
+        .map_err(|e| format!("failed to get verifyAndUpdate receipt: {e}"))?;
+    if !receipt.status() {
+        return Err(format!(
+            "verifyAndUpdate reverted (tx {:?}, block {:?})",
+            receipt.transaction_hash, receipt.block_number
+        )
+        .into());
+    }
+    println!(
+        "✅ verifyAndUpdate landed: tx {:?} in block {:?}",
+        receipt.transaction_hash, receipt.block_number
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_url_from_router_root() {
+        let url = task_status_url("http://localhost:8080", "abc123").unwrap();
+        assert_eq!(url.as_str(), "http://localhost:8080/tasks/abc123");
+    }
+
+    #[test]
+    fn status_url_replaces_an_existing_submission_path() {
+        let url = task_status_url("http://localhost:8080/tasks", "abc123").unwrap();
+        assert_eq!(url.as_str(), "http://localhost:8080/tasks/abc123");
+    }
+
+    #[test]
+    fn status_url_preserves_host_and_scheme() {
+        let url = task_status_url("https://testnet.gaskiller.xyz", "t-1").unwrap();
+        assert_eq!(url.as_str(), "https://testnet.gaskiller.xyz/tasks/t-1");
+    }
+
+    #[test]
+    fn status_url_rejects_a_non_url() {
+        assert!(task_status_url("not a url", "abc").is_err());
+    }
+}

--- a/scripts/deploy_example.rs
+++ b/scripts/deploy_example.rs
@@ -592,7 +592,7 @@ fn toml_string(value: &str) -> String {
 // On-chain steps
 // ---------------------------------------------------------------------------------------
 
-/// Rejects a signature checker that cannot actually verify signatures.
+/// Rejects a signature checker that is *demonstrably* not one.
 ///
 /// `GasKillerSDK.verifyAndUpdate` calls `checkSignatures` on whatever address the constructor
 /// was given. The `BLSSigCheckOperatorStateRetriever` recorded as `blsSigCheck` in the AVS
@@ -600,6 +600,14 @@ fn toml_string(value: &str) -> String {
 /// at settlement time — long after deployment, with nothing pointing at the cause. A real
 /// checker exposes `registryCoordinator()`; the retriever does not, which makes that getter a
 /// cheap discriminator.
+///
+/// This is a **shape** check, not an authenticity one, and the distinction matters: it
+/// establishes "has code and answers `registryCoordinator()`", not "soundly verifies quorum
+/// signatures". A permissive or mock checker that happens to expose that getter passes, and a
+/// target wired to one accepts *unsigned* diffs. Adequate for deploying example contracts to a
+/// fork or testnet, which is all this binary is for — see the scope note in `scripts/README.md`.
+/// Anything value-bearing needs the checker verified against the registry coordinator the AVS
+/// actually registered against, not merely asked whether it has the getter.
 async fn validate_sig_checker(provider: &DynProvider, checker: Address) -> Result<(), DynError> {
     let code = provider
         .get_code_at(checker)

--- a/scripts/deploy_example.rs
+++ b/scripts/deploy_example.rs
@@ -1,0 +1,1653 @@
+//! Deploys contracts from the public `gas-killer/example-contracts` library and points the
+//! AVS at them.
+//!
+//! Unlike `deploy_array_summation`, nothing here is specific to one contract. Constructor
+//! argument *types* are read from the Foundry artifact's ABI at runtime and the *values* come
+//! from a TOML manifest, so adding an example is a manifest edit — no new Rust, no
+//! recompile. Fetch and build the artifacts first with `scripts/examples/fetch_examples.sh`.
+//!
+//! Each example goes through the same sequence:
+//!
+//! 1. Resolve the AVS service manager and the BLS signature checker the target's constructor
+//!    needs, and *validate the checker* — see [`validate_sig_checker`] for why this matters
+//!    more than it looks.
+//! 2. Deploy, by appending ABI-encoded constructor args to the artifact's creation bytecode.
+//! 3. Assert the deployed target is actually routable: it must pass the same ERC-165 gate the
+//!    router applies before submitting `verifyAndUpdate`, and expose the state-tracking and
+//!    digest getters the aggregation path calls. Catching this here turns a confusing
+//!    mid-round router error into one line at deploy time.
+//! 4. Run the manifest's setup calls, which put the contract in a state where its expensive
+//!    function is meaningful (depositors for a vault, and so on).
+//! 5. Record the address under `addresses.<name>` in the AVS deployment JSON and emit a
+//!    ready-to-run scenario file.
+//!
+//! Step 5 is what makes the target reachable by the rest of the tooling: `run_scenario`
+//! resolves `target_address = "local:<name>"` against exactly that JSON, so no other
+//! component needs to learn about the new contract.
+
+use alloy::network::{EthereumWallet, TransactionBuilder};
+use alloy::primitives::{Address, Bytes, FixedBytes, U256, keccak256};
+use alloy::providers::{DynProvider, Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
+use alloy_dyn_abi::{DynSolType, DynSolValue, JsonAbiExt, Specifier};
+use alloy_json_abi::{Function, JsonAbi};
+use clap::Parser;
+use gas_killer_common::bindings::gaskillersdk::GasKillerSDK;
+use gas_killer_common::bindings::{GAS_KILLER_INTERFACE_ID, SCHNORR_GAS_KILLER_INTERFACE_ID};
+use gas_killer_common::{SignatureScheme, signature_scheme};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+type DynError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Key in the AVS deployment JSON holding the service manager the target registers against.
+const AVS_ADDRESS_KEY: &str = "avsServiceManagerWrapper";
+
+/// Key in the AVS deployment JSON holding a contract that really implements
+/// `BLSSignatureChecker.checkSignatures`. The local EigenLayer stack's task manager inherits
+/// `BLSSignatureChecker`, which is why it — and not `blsSigCheck` — is the default.
+const SIG_CHECKER_ADDRESS_KEY: &str = "IncredibleSquaringTaskManager";
+
+/// Key in the AVS deployment JSON holding the `BLSSigCheckOperatorStateRetriever`. It is the
+/// router's off-chain helper for assembling non-signer stakes, *not* a signature checker: it
+/// has no `checkSignatures`, so a target constructed with it reverts with an empty `0x` the
+/// first time a quorum tries to settle. Rejected by name rather than diagnosed later.
+const RETRIEVER_ADDRESS_KEY: &str = "blsSigCheck";
+
+/// Address substituted for an unresolvable `$avs`/`$sigChecker` under `--dry-run`, where the
+/// point is to validate manifest encoding rather than on-chain wiring.
+const DRY_RUN_PLACEHOLDER: Address = Address::repeat_byte(0xee);
+
+#[derive(Parser, Debug)]
+#[command(
+    about = "Deploy example-contracts targets and register them for the local Gas Killer stack"
+)]
+struct Cli {
+    /// Manifest describing the examples, their constructor values, and setup calls.
+    #[arg(long, default_value = "scripts/examples/examples.toml")]
+    manifest: PathBuf,
+
+    /// Example to deploy by `name`; repeatable. Defaults to every example in the manifest.
+    #[arg(long = "example")]
+    examples: Vec<String>,
+
+    /// Directory holding the Foundry `out/` tree built from the example contracts.
+    /// Defaults to `$EXAMPLES_DIR/out`, then `.examples/example-contracts/out`.
+    #[arg(long)]
+    artifacts: Option<PathBuf>,
+
+    /// AVS deployment JSON to read wiring from and record deployed addresses into.
+    /// Defaults to `$AVS_DEPLOYMENT_PATH`, then `config/.nodes/avs_deploy.json`.
+    #[arg(long)]
+    deploy_json: Option<PathBuf>,
+
+    /// AVS service manager address, overriding env and the deployment JSON.
+    #[arg(long)]
+    avs: Option<Address>,
+
+    /// BLS signature checker address, overriding env and the deployment JSON.
+    #[arg(long)]
+    sig_checker: Option<Address>,
+
+    /// Router URL written into the generated scenario files.
+    #[arg(long)]
+    router_url: Option<String>,
+
+    /// Directory the generated scenario files are written to.
+    #[arg(long, default_value = "scripts/scenarios/generated")]
+    scenario_dir: PathBuf,
+
+    /// Reuse the address already recorded for an example instead of deploying a second copy.
+    #[arg(long)]
+    reuse: bool,
+
+    /// Resolve, encode, and emit scenarios without sending any transaction.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+// ---------------------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    /// Private keys available to setup calls. Index 0 is the deployer and the default sender
+    /// for every call; defaults to `["$env:PRIVATE_KEY"]`.
+    #[serde(default)]
+    signers: Vec<String>,
+    #[serde(default)]
+    examples: Vec<ExampleSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExampleSpec {
+    /// Key this contract is recorded under in the deployment JSON, and the name used for
+    /// `--example` and the generated scenario file.
+    name: String,
+    /// Artifact to deploy, as `File.sol:Contract` or just `Contract`.
+    artifact: String,
+    #[serde(default)]
+    ctor_args: Vec<ArgValue>,
+    /// Calls made after deployment to put the contract in a usable state.
+    #[serde(default)]
+    setup: Vec<CallSpec>,
+    /// The tracked functions to drive through the AVS; one scenario request each.
+    #[serde(default)]
+    exercise: Vec<ExerciseSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CallSpec {
+    /// Human-readable signature, e.g. `deposit(uint256)`.
+    sig: String,
+    #[serde(default)]
+    args: Vec<ArgValue>,
+    /// Index into the manifest's `signers`; defaults to the deployer.
+    #[serde(default)]
+    signer: usize,
+    /// Wei to attach, decimal or `0x`-prefixed.
+    #[serde(default)]
+    value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExerciseSpec {
+    /// Label for the generated scenario request; defaults to the example name.
+    #[serde(default)]
+    label: Option<String>,
+    sig: String,
+    #[serde(default)]
+    args: Vec<ArgValue>,
+    /// Whether the generated request polls `stateTransitionCount()` afterwards.
+    #[serde(default = "default_true")]
+    verify: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// A manifest argument value: either a scalar to coerce against the ABI type, or a list
+/// mapping onto an array or tuple parameter.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum ArgValue {
+    Scalar(String),
+    List(Vec<ArgValue>),
+}
+
+// ---------------------------------------------------------------------------------------
+// Placeholder resolution
+// ---------------------------------------------------------------------------------------
+
+/// Everything needed to expand the `$…` placeholders a manifest may reference. Holds plain
+/// data so resolution is testable without a chain or a filesystem.
+#[derive(Debug, Default)]
+struct Resolver {
+    avs: Option<Address>,
+    sig_checker: Option<Address>,
+    /// `addresses` from the AVS deployment JSON.
+    deploy_addresses: BTreeMap<String, String>,
+    signers: Vec<Address>,
+}
+
+impl Resolver {
+    /// Expands a single scalar. Values not starting with `$` pass through untouched.
+    ///
+    /// - `$avs` / `$sigChecker` — the resolved constructor wiring
+    /// - `$deploy:<key>` — any key under `addresses` in the deployment JSON
+    /// - `$signer:<n>` — the address of the nth manifest signer
+    /// - `$env:VAR` — an environment variable
+    fn resolve(&self, raw: &str) -> Result<String, DynError> {
+        let Some(rest) = raw.strip_prefix('$') else {
+            return Ok(raw.to_string());
+        };
+
+        if let Some(key) = rest.strip_prefix("deploy:") {
+            return self.deploy_addresses.get(key).cloned().ok_or_else(|| {
+                format!("$deploy:{key} not found under `addresses` in the deployment JSON").into()
+            });
+        }
+        if let Some(idx) = rest.strip_prefix("signer:") {
+            let idx: usize = idx
+                .parse()
+                .map_err(|_| format!("$signer:{idx} is not a signer index"))?;
+            return self
+                .signers
+                .get(idx)
+                .map(|a| format!("{a:?}"))
+                .ok_or_else(|| {
+                    format!(
+                        "$signer:{idx} is out of range; the manifest declares {} signer(s)",
+                        self.signers.len()
+                    )
+                    .into()
+                });
+        }
+        if let Some(var) = rest.strip_prefix("env:") {
+            return std::env::var(var)
+                .map_err(|_| format!("$env:{var} is not set in the environment").into());
+        }
+
+        match rest {
+            "avs" => self
+                .avs
+                .map(|a| format!("{a:?}"))
+                .ok_or_else(|| avs_unresolved_message(AVS_ADDRESS_KEY, "--avs", "EXAMPLE_AVS_ADDRESS").into()),
+            "sigChecker" => self.sig_checker.map(|a| format!("{a:?}")).ok_or_else(|| {
+                avs_unresolved_message(
+                    SIG_CHECKER_ADDRESS_KEY,
+                    "--sig-checker",
+                    "EXAMPLE_SIG_CHECKER_ADDRESS",
+                )
+                .into()
+            }),
+            other => Err(format!(
+                "unknown placeholder `${other}`; supported: $avs, $sigChecker, $deploy:<key>, $signer:<n>, $env:VAR"
+            )
+            .into()),
+        }
+    }
+}
+
+fn avs_unresolved_message(json_key: &str, flag: &str, env_var: &str) -> String {
+    format!(
+        "could not resolve the address for `{json_key}`: pass {flag}, set {env_var}, or point \
+         --deploy-json at a deployment JSON that contains it"
+    )
+}
+
+/// Recursively expands placeholders inside a manifest argument.
+fn resolve_arg(resolver: &Resolver, arg: &ArgValue) -> Result<ArgValue, DynError> {
+    match arg {
+        ArgValue::Scalar(s) => Ok(ArgValue::Scalar(resolver.resolve(s)?)),
+        ArgValue::List(items) => Ok(ArgValue::List(
+            items
+                .iter()
+                .map(|i| resolve_arg(resolver, i))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------------------
+// ABI coercion
+// ---------------------------------------------------------------------------------------
+
+/// Turns a manifest value into a `DynSolValue` of the type the ABI declares.
+///
+/// Array, fixed-array, and tuple parameters recurse into a TOML list; anything else is
+/// coerced from its string form, which is also how a bracketed array literal is accepted.
+fn coerce_arg(ty: &DynSolType, arg: &ArgValue) -> Result<DynSolValue, DynError> {
+    match (ty, arg) {
+        (DynSolType::Array(inner), ArgValue::List(items)) => Ok(DynSolValue::Array(
+            items
+                .iter()
+                .map(|i| coerce_arg(inner, i))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        (DynSolType::FixedArray(inner, len), ArgValue::List(items)) => {
+            if items.len() != *len {
+                return Err(format!(
+                    "expected {len} values for {ty}, manifest supplied {}",
+                    items.len()
+                )
+                .into());
+            }
+            Ok(DynSolValue::FixedArray(
+                items
+                    .iter()
+                    .map(|i| coerce_arg(inner, i))
+                    .collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        (DynSolType::Tuple(types), ArgValue::List(items)) => {
+            if items.len() != types.len() {
+                return Err(format!(
+                    "expected {} values for {ty}, manifest supplied {}",
+                    types.len(),
+                    items.len()
+                )
+                .into());
+            }
+            Ok(DynSolValue::Tuple(
+                types
+                    .iter()
+                    .zip(items)
+                    .map(|(t, i)| coerce_arg(t, i))
+                    .collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        (_, ArgValue::Scalar(s)) => ty
+            .coerce_str(s)
+            .map_err(|e| format!("`{s}` is not a valid {ty}: {e}").into()),
+        (_, ArgValue::List(_)) => {
+            Err(format!("{ty} takes a single value, manifest supplied a list").into())
+        }
+    }
+}
+
+/// Coerces a positional argument list against the ABI types it will be encoded as.
+fn coerce_args(types: &[DynSolType], args: &[ArgValue]) -> Result<Vec<DynSolValue>, DynError> {
+    if types.len() != args.len() {
+        return Err(format!(
+            "expected {} argument(s), manifest supplied {}",
+            types.len(),
+            args.len()
+        )
+        .into());
+    }
+    types
+        .iter()
+        .zip(args)
+        .map(|(t, a)| coerce_arg(t, a))
+        .collect()
+}
+
+/// Parses a human-readable signature (`step(uint32)`) and ABI-encodes a call to it.
+fn encode_call(sig: &str, args: &[ArgValue]) -> Result<Bytes, DynError> {
+    let func = parse_signature(sig)?;
+    let types = resolve_param_types(&func.inputs)?;
+    let values = coerce_args(&types, args).map_err(|e| format!("encoding call to `{sig}`: {e}"))?;
+    Ok(func
+        .abi_encode_input(&values)
+        .map_err(|e| format!("failed to ABI-encode `{sig}`: {e}"))?
+        .into())
+}
+
+/// Parses a signature, tolerating a leading `function ` keyword.
+fn parse_signature(sig: &str) -> Result<Function, DynError> {
+    let trimmed = sig.trim();
+    let body = trimmed.strip_prefix("function ").unwrap_or(trimmed);
+    Function::parse(body)
+        .map_err(|e| format!("`{sig}` is not a valid function signature: {e}").into())
+}
+
+/// Resolves ABI parameter declarations into the dynamic types used for encoding.
+fn resolve_param_types<P: Specifier<DynSolType>>(
+    params: &[P],
+) -> Result<Vec<DynSolType>, DynError> {
+    params
+        .iter()
+        .map(|p| {
+            p.resolve()
+                .map_err(|e| -> DynError { format!("unsupported ABI parameter type: {e}").into() })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------------------
+// Forge artifacts
+// ---------------------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ForgeArtifact {
+    abi: JsonAbi,
+    bytecode: ForgeBytecode,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgeBytecode {
+    object: String,
+}
+
+/// Maps an `artifact` manifest entry onto its path in a Foundry `out/` tree.
+///
+/// `File.sol:Contract` selects both explicitly; a bare `Contract` assumes the conventional
+/// `Contract.sol/Contract.json`.
+fn artifact_path(artifacts_dir: &Path, artifact: &str) -> PathBuf {
+    match artifact.split_once(':') {
+        Some((file, contract)) => artifacts_dir.join(file).join(format!("{contract}.json")),
+        None => artifacts_dir
+            .join(format!("{artifact}.sol"))
+            .join(format!("{artifact}.json")),
+    }
+}
+
+/// Reads an artifact and returns its ABI plus creation bytecode.
+///
+/// An artifact whose `bytecode.object` is empty is interface-only (the shape the service
+/// vendors for `GasKillerSDK`) and cannot be deployed.
+fn load_artifact(path: &Path) -> Result<(JsonAbi, Bytes), DynError> {
+    let raw = fs::read_to_string(path).map_err(|e| {
+        format!(
+            "failed to read artifact {}: {e} — run scripts/examples/fetch_examples.sh first",
+            path.display()
+        )
+    })?;
+    let artifact: ForgeArtifact = serde_json::from_str(&raw)
+        .map_err(|e| format!("failed to parse artifact {}: {e}", path.display()))?;
+
+    let hex_body = artifact.bytecode.object.trim_start_matches("0x");
+    if hex_body.is_empty() {
+        return Err(format!(
+            "artifact {} carries no creation bytecode; it is ABI-only and cannot be deployed",
+            path.display()
+        )
+        .into());
+    }
+    let bytecode = alloy::hex::decode(hex_body)
+        .map_err(|e| format!("artifact {} has invalid bytecode: {e}", path.display()))?;
+
+    Ok((artifact.abi, bytecode.into()))
+}
+
+/// Builds the creation transaction input: creation bytecode with ABI-encoded constructor
+/// arguments appended.
+fn build_init_code(abi: &JsonAbi, bytecode: &Bytes, args: &[ArgValue]) -> Result<Bytes, DynError> {
+    let mut init_code = bytecode.to_vec();
+
+    match &abi.constructor {
+        Some(ctor) => {
+            let types = resolve_param_types(&ctor.inputs)?;
+            let values = coerce_args(&types, args)
+                .map_err(|e| format!("encoding constructor arguments: {e}"))?;
+            let encoded = ctor
+                .abi_encode_input(&values)
+                .map_err(|e| format!("failed to ABI-encode constructor arguments: {e}"))?;
+            init_code.extend_from_slice(&encoded);
+        }
+        None if args.is_empty() => {}
+        None => {
+            return Err(format!(
+                "artifact has no constructor but the manifest supplies {} argument(s)",
+                args.len()
+            )
+            .into());
+        }
+    }
+
+    Ok(init_code.into())
+}
+
+// ---------------------------------------------------------------------------------------
+// Deployment JSON
+// ---------------------------------------------------------------------------------------
+
+/// Reads `addresses` out of an AVS deployment JSON, tolerating a missing file so a testnet
+/// run can start from nothing.
+fn read_deploy_addresses(path: &Path) -> Result<BTreeMap<String, String>, DynError> {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return Ok(BTreeMap::new());
+    };
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("failed to parse deployment JSON {}: {e}", path.display()))?;
+
+    let Some(addresses) = parsed.get("addresses").and_then(|a| a.as_object()) else {
+        return Ok(BTreeMap::new());
+    };
+    Ok(addresses
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+        .collect())
+}
+
+/// Merges `addresses.<key> = <address>` into the deployment JSON, preserving every other key
+/// and creating the file if it does not exist yet.
+fn record_deployed_address(path: &Path, key: &str, address: Address) -> Result<(), DynError> {
+    let mut deployment: serde_json::Value = match fs::read_to_string(path) {
+        Ok(raw) => serde_json::from_str(&raw)
+            .map_err(|e| format!("failed to parse deployment JSON {}: {e}", path.display()))?,
+        Err(_) => serde_json::json!({}),
+    };
+
+    if !deployment["addresses"].is_object() {
+        deployment["addresses"] = serde_json::json!({});
+    }
+    deployment["addresses"][key] = serde_json::json!(format!("{address:?}"));
+
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "failed to create deployment JSON directory {}: {e}",
+                parent.display()
+            )
+        })?;
+    }
+    let serialized = serde_json::to_string_pretty(&deployment)
+        .map_err(|e| format!("failed to serialize deployment JSON: {e}"))?;
+    fs::write(path, serialized)
+        .map_err(|e| format!("failed to write deployment JSON {}: {e}", path.display()))?;
+
+    println!(
+        "📝 recorded addresses.{key} = {address:?} in {}",
+        path.display()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------------
+// Scenario emission
+// ---------------------------------------------------------------------------------------
+
+/// One generated scenario request.
+struct ScenarioRequest {
+    label: String,
+    call_data: Bytes,
+    verify: bool,
+}
+
+/// Renders a `run_scenario` config that drives the deployed target.
+///
+/// The target is referenced by the `local:<key>` sentinel rather than a literal address, so
+/// the file stays correct across redeploys. `api_key` is omitted because `run_scenario`
+/// already falls back to `GAS_KILLER_API_KEY`.
+fn render_scenario(name: &str, router_url: &str, requests: &[ScenarioRequest]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Generated by `cargo run -p scripts --bin deploy_example -- --example {name}`.\n\
+         # Overwritten on every deploy — edit scripts/examples/examples.toml instead.\n\
+         #\n\
+         # Run with:\n\
+         #   cargo run -p scripts --bin run_scenario -- scripts/scenarios/generated/{name}.toml\n\n"
+    ));
+    out.push_str(&format!("router_url = {}\n", toml_string(router_url)));
+    out.push_str("http_rpc   = \"$HTTP_RPC\"\n\n");
+    out.push_str("[[scenarios]]\n");
+    out.push_str(&format!("name = {}\n", toml_string(name)));
+    out.push_str("mode = \"serial\"\n");
+
+    for request in requests {
+        out.push_str("\n  [[scenarios.requests]]\n");
+        out.push_str(&format!(
+            "  label          = {}\n",
+            toml_string(&request.label)
+        ));
+        out.push_str(&format!(
+            "  target_address = {}\n",
+            toml_string(&format!("local:{name}"))
+        ));
+        out.push_str(&format!(
+            "  call_data      = {}\n",
+            toml_string(&format!("0x{}", alloy::hex::encode(&request.call_data)))
+        ));
+        out.push_str("  from_address   = \"local\"\n");
+        // The router renders a payload rather than broadcasting it, so a scenario that wants
+        // to observe an on-chain effect has to submit that payload itself.
+        out.push_str("  submit         = true\n");
+        out.push_str(&format!("  verify         = {}\n", request.verify));
+    }
+
+    out
+}
+
+/// Quotes a value as a TOML basic string.
+fn toml_string(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
+    format!("\"{escaped}\"")
+}
+
+// ---------------------------------------------------------------------------------------
+// On-chain steps
+// ---------------------------------------------------------------------------------------
+
+/// Rejects a signature checker that cannot actually verify signatures.
+///
+/// `GasKillerSDK.verifyAndUpdate` calls `checkSignatures` on whatever address the constructor
+/// was given. The `BLSSigCheckOperatorStateRetriever` recorded as `blsSigCheck` in the AVS
+/// deployment JSON has no such function, so a target wired to it reverts with an empty `0x`
+/// at settlement time — long after deployment, with nothing pointing at the cause. A real
+/// checker exposes `registryCoordinator()`; the retriever does not, which makes that getter a
+/// cheap discriminator.
+async fn validate_sig_checker(provider: &DynProvider, checker: Address) -> Result<(), DynError> {
+    let code = provider
+        .get_code_at(checker)
+        .await
+        .map_err(|e| format!("failed to read code at signature checker {checker:?}: {e}"))?;
+    if code.is_empty() {
+        return Err(format!("signature checker {checker:?} has no code deployed").into());
+    }
+
+    let selector = &keccak256("registryCoordinator()")[..4];
+    let probe = TransactionRequest::default()
+        .with_to(checker)
+        .with_input(Bytes::copy_from_slice(selector));
+
+    match provider.call(probe).await {
+        Ok(ret) if ret.len() >= 32 => Ok(()),
+        _ => Err(format!(
+            "{checker:?} does not expose registryCoordinator(), so it is not a BLSSignatureChecker \
+             — a target wired to it reverts with an empty 0x during verifyAndUpdate. Did you pass \
+             the `{RETRIEVER_ADDRESS_KEY}` operator-state retriever? Set \
+             EXAMPLE_SIG_CHECKER_ADDRESS to a real checker."
+        )
+        .into()),
+    }
+}
+
+/// Confirms the freshly deployed target is one the router will actually settle against.
+///
+/// The ERC-165 check is the same gate `router::executor` applies before submitting
+/// `verifyAndUpdate`, and it is the one most likely to fail on a contract built against a
+/// different `solidity-sdk` revision than the service expects — the interface ID changes
+/// whenever `IGasKillerSDK` does.
+async fn assert_routable(
+    provider: &DynProvider,
+    target: Address,
+    exercise_selector: Option<FixedBytes<4>>,
+) -> Result<(), DynError> {
+    let (interface_id, scheme) = match signature_scheme() {
+        SignatureScheme::Bls => (GAS_KILLER_INTERFACE_ID, "bls"),
+        SignatureScheme::Schnorr => (SCHNORR_GAS_KILLER_INTERFACE_ID, "schnorr"),
+    };
+    let sdk = GasKillerSDK::new(target, provider);
+
+    let supported = sdk
+        .supportsInterface(interface_id)
+        .call()
+        .await
+        .map_err(|e| format!("supportsInterface({interface_id}) call failed on {target:?}: {e}"))?;
+    if !supported {
+        return Err(format!(
+            "{target:?} does not report support for the {scheme} interface {interface_id}, so the \
+             router will refuse to settle against it. The contract must inherit the \
+             {} base contract, and its solidity-sdk revision must match the one this service \
+             was built against.",
+            match scheme {
+                "schnorr" => "SchnorrGasKillerSDK",
+                _ => "GasKillerSDK",
+            }
+        )
+        .into());
+    }
+
+    let count = sdk
+        .stateTransitionCount()
+        .call()
+        .await
+        .map_err(|e| format!("stateTransitionCount() call failed on {target:?}: {e}"))?;
+
+    // The digest the quorum signs is computed off-chain and must match this getter byte for
+    // byte; probing it now proves the ABI is the shape the aggregation path assumes.
+    if let Some(selector) = exercise_selector {
+        sdk.getMessageHash(count, selector, Bytes::new())
+            .call()
+            .await
+            .map_err(|e| format!("getMessageHash() call failed on {target:?}: {e}"))?;
+    }
+
+    println!(
+        "✅ {target:?} is routable: supportsInterface({interface_id}) = true, stateTransitionCount() = {count}"
+    );
+    Ok(())
+}
+
+/// Sends a manifest setup call and requires it to succeed.
+async fn run_setup_call(
+    provider: &DynProvider,
+    target: Address,
+    call: &CallSpec,
+    resolver: &Resolver,
+) -> Result<(), DynError> {
+    let args = call
+        .setup_args(resolver)
+        .map_err(|e| format!("setup call `{}`: {e}", call.sig))?;
+    let data = encode_call(&call.sig, &args)?;
+    let value = match &call.value {
+        Some(raw) => parse_wei(raw)?,
+        None => U256::ZERO,
+    };
+
+    let tx = TransactionRequest::default()
+        .with_to(target)
+        .with_value(value)
+        .with_input(data);
+
+    let receipt = provider
+        .send_transaction(tx)
+        .await
+        .map_err(|e| format!("setup call `{}` failed to send: {e}", call.sig))?
+        .get_receipt()
+        .await
+        .map_err(|e| format!("setup call `{}` receipt failed: {e}", call.sig))?;
+    if !receipt.status() {
+        return Err(format!(
+            "setup call `{}` reverted (tx {:?})",
+            call.sig, receipt.transaction_hash
+        )
+        .into());
+    }
+    println!("   ↳ {} (signer {})", call.sig, call.signer);
+    Ok(())
+}
+
+impl CallSpec {
+    fn setup_args(&self, resolver: &Resolver) -> Result<Vec<ArgValue>, DynError> {
+        self.args.iter().map(|a| resolve_arg(resolver, a)).collect()
+    }
+}
+
+/// Parses a wei amount given in decimal or `0x`-prefixed hex.
+fn parse_wei(raw: &str) -> Result<U256, DynError> {
+    let trimmed = raw.trim();
+    let parsed = match trimmed.strip_prefix("0x") {
+        Some(hex_body) => U256::from_str_radix(hex_body, 16),
+        None => U256::from_str_radix(trimmed, 10),
+    };
+    parsed.map_err(|e| format!("`{raw}` is not a valid wei amount: {e}").into())
+}
+
+// ---------------------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<(), DynError> {
+    dotenv::dotenv().ok();
+    let cli = Cli::parse();
+
+    let manifest_raw = fs::read_to_string(&cli.manifest)
+        .map_err(|e| format!("failed to read manifest {}: {e}", cli.manifest.display()))?;
+    let manifest: Manifest = toml::from_str(&manifest_raw)
+        .map_err(|e| format!("failed to parse manifest {}: {e}", cli.manifest.display()))?;
+
+    let selected = select_examples(&manifest, &cli.examples)?;
+    let artifacts_dir = resolve_artifacts_dir(cli.artifacts.clone());
+    let deploy_json = resolve_deploy_json(cli.deploy_json.clone());
+    let deploy_addresses = read_deploy_addresses(&deploy_json)?;
+
+    // Signer keys are resolved before anything else: their addresses are placeholder inputs,
+    // and index 0 is the deployer.
+    let signer_keys = resolve_signer_keys(&manifest.signers)?;
+    let signers: Vec<PrivateKeySigner> = signer_keys
+        .iter()
+        .enumerate()
+        .map(|(i, key)| {
+            key.trim()
+                .parse::<PrivateKeySigner>()
+                .map_err(|_| -> DynError {
+                    format!("signers[{i}] is not a valid private key").into()
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let avs = resolve_wiring_address(
+        cli.avs,
+        "EXAMPLE_AVS_ADDRESS",
+        AVS_ADDRESS_KEY,
+        &deploy_addresses,
+    )?;
+    let sig_checker = resolve_wiring_address(
+        cli.sig_checker,
+        "EXAMPLE_SIG_CHECKER_ADDRESS",
+        SIG_CHECKER_ADDRESS_KEY,
+        &deploy_addresses,
+    )?;
+    reject_retriever_as_checker(sig_checker, &deploy_addresses)?;
+
+    let mut resolver = Resolver {
+        avs,
+        sig_checker,
+        deploy_addresses: deploy_addresses.clone(),
+        signers: signers.iter().map(|s| s.address()).collect(),
+    };
+
+    if cli.dry_run {
+        println!("🧪 dry run: resolving and encoding only, no transactions will be sent");
+        // A dry run validates the manifest against the artifacts, which does not require real
+        // wiring — substitute a sentinel so a machine with no deployment JSON can still check
+        // that every argument encodes.
+        if resolver.avs.is_none() || resolver.sig_checker.is_none() {
+            println!(
+                "⚠️  AVS wiring unresolved; substituting {DRY_RUN_PLACEHOLDER:?} so encoding can \
+                 still be validated"
+            );
+            resolver.avs = resolver.avs.or(Some(DRY_RUN_PLACEHOLDER));
+            resolver.sig_checker = resolver.sig_checker.or(Some(DRY_RUN_PLACEHOLDER));
+        }
+    }
+    let resolver = resolver;
+
+    let router_url = cli
+        .router_url
+        .clone()
+        .or_else(|| std::env::var("GAS_KILLER_ROUTER_URL").ok())
+        .unwrap_or_else(|| "http://localhost:8080".to_string());
+
+    // One wallet-backed provider per signer, so a setup call can be sent as whichever account
+    // the manifest names. Index 0 is the deployer. Left empty by a dry run, which must work
+    // without an RPC endpoint at all.
+    let signer_providers = if cli.dry_run {
+        Vec::new()
+    } else {
+        let http_rpc: url::Url = std::env::var("HTTP_RPC")
+            .map_err(|_| "HTTP_RPC environment variable is required to deploy")?
+            .parse()
+            .map_err(|_| "invalid HTTP_RPC URL")?;
+        if signers.is_empty() {
+            return Err("the manifest must declare at least one signer".into());
+        }
+        println!("🔑 deployer: {:?}", signers[0].address());
+        signers
+            .iter()
+            .map(|signer| {
+                ProviderBuilder::new()
+                    .wallet(EthereumWallet::from(signer.clone()))
+                    .connect_http(http_rpc.clone())
+                    .erased()
+            })
+            .collect()
+    };
+
+    if let (Some(provider), Some(checker)) = (signer_providers.first(), sig_checker) {
+        validate_sig_checker(provider, checker).await?;
+        println!("🔐 signature checker: {checker:?}");
+    }
+
+    for example in selected {
+        println!("\n═══ {} ═══", example.name);
+        deploy_one(
+            example,
+            &resolver,
+            &signer_providers,
+            &artifacts_dir,
+            &deploy_json,
+            &cli,
+            &router_url,
+        )
+        .await
+        .map_err(|e| format!("example `{}`: {e}", example.name))?;
+    }
+
+    println!("\n🎉 done");
+    Ok(())
+}
+
+/// Deploys one example, wires it up, and emits its scenario.
+///
+/// `signer_providers` is one wallet-backed provider per manifest signer, empty for a dry run.
+async fn deploy_one(
+    example: &ExampleSpec,
+    resolver: &Resolver,
+    signer_providers: &[DynProvider],
+    artifacts_dir: &Path,
+    deploy_json: &Path,
+    cli: &Cli,
+    router_url: &str,
+) -> Result<(), DynError> {
+    let path = artifact_path(artifacts_dir, &example.artifact);
+    let (abi, bytecode) = load_artifact(&path)?;
+    println!("📦 artifact: {}", path.display());
+
+    let ctor_args = example
+        .ctor_args
+        .iter()
+        .map(|a| resolve_arg(resolver, a))
+        .collect::<Result<Vec<_>, _>>()?;
+    let init_code = build_init_code(&abi, &bytecode, &ctor_args)?;
+    println!(
+        "🧱 init code: {} bytes ({} bytes of constructor arguments)",
+        init_code.len(),
+        init_code.len() - bytecode.len()
+    );
+
+    // Encode the exercise calldata before deploying: a manifest typo should fail before a
+    // transaction is spent, not after.
+    let requests = example
+        .exercise
+        .iter()
+        .map(|ex| {
+            let args = ex
+                .args
+                .iter()
+                .map(|a| resolve_arg(resolver, a))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ScenarioRequest {
+                label: ex.label.clone().unwrap_or_else(|| example.name.clone()),
+                call_data: encode_call(&ex.sig, &args)?,
+                verify: ex.verify,
+            })
+        })
+        .collect::<Result<Vec<ScenarioRequest>, DynError>>()?;
+
+    let exercise_selector = match example.exercise.first() {
+        Some(ex) => Some(parse_signature(&ex.sig)?.selector()),
+        None => None,
+    };
+
+    let scenario_path = cli.scenario_dir.join(format!("{}.toml", example.name));
+
+    let Some(provider) = signer_providers.first() else {
+        for request in &requests {
+            println!(
+                "   ↳ {} → 0x{}",
+                request.label,
+                alloy::hex::encode(&request.call_data)
+            );
+        }
+        write_scenario(
+            &scenario_path,
+            &render_scenario(&example.name, router_url, &requests),
+        )?;
+        return Ok(());
+    };
+
+    let target = match reusable_address(cli, resolver, &example.name, provider).await? {
+        Some(existing) => {
+            println!("♻️  reusing {existing:?} from addresses.{}", example.name);
+            existing
+        }
+        None => {
+            let receipt = provider
+                .send_transaction(TransactionRequest::default().with_deploy_code(init_code))
+                .await
+                .map_err(|e| format!("failed to send deployment transaction: {e}"))?
+                .get_receipt()
+                .await
+                .map_err(|e| format!("deployment transaction was not mined: {e}"))?;
+            if !receipt.status() {
+                return Err(format!(
+                    "deployment reverted (tx {:?}) — check the constructor arguments",
+                    receipt.transaction_hash
+                )
+                .into());
+            }
+            let address = receipt
+                .contract_address
+                .ok_or("deployment receipt carried no contract address")?;
+            println!(
+                "🚀 deployed at {address:?} (tx {:?})",
+                receipt.transaction_hash
+            );
+            address
+        }
+    };
+
+    assert_routable(provider, target, exercise_selector).await?;
+
+    if !example.setup.is_empty() {
+        println!("⚙️  running {} setup call(s)", example.setup.len());
+        for call in &example.setup {
+            let call_provider = signer_providers.get(call.signer).ok_or_else(|| {
+                format!(
+                    "setup call `{}` wants signer {} but the manifest declares {}",
+                    call.sig,
+                    call.signer,
+                    signer_providers.len()
+                )
+            })?;
+            run_setup_call(call_provider, target, call, resolver).await?;
+        }
+    }
+
+    record_deployed_address(deploy_json, &example.name, target)?;
+    write_scenario(
+        &scenario_path,
+        &render_scenario(&example.name, router_url, &requests),
+    )?;
+
+    Ok(())
+}
+
+/// Returns the already-recorded address when `--reuse` is set and it still has code.
+async fn reusable_address(
+    cli: &Cli,
+    resolver: &Resolver,
+    name: &str,
+    provider: &DynProvider,
+) -> Result<Option<Address>, DynError> {
+    if !cli.reuse {
+        return Ok(None);
+    }
+    let Some(recorded) = resolver.deploy_addresses.get(name) else {
+        return Ok(None);
+    };
+    let address: Address = recorded
+        .parse()
+        .map_err(|_| format!("addresses.{name} is not a valid address: {recorded}"))?;
+    let code = provider
+        .get_code_at(address)
+        .await
+        .map_err(|e| format!("failed to read code at {address:?}: {e}"))?;
+    Ok((!code.is_empty()).then_some(address))
+}
+
+fn write_scenario(path: &Path, contents: &str) -> Result<(), DynError> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    fs::write(path, contents)
+        .map_err(|e| format!("failed to write scenario {}: {e}", path.display()))?;
+    println!("📄 wrote {}", path.display());
+    Ok(())
+}
+
+/// Filters the manifest down to the requested examples, preserving manifest order.
+fn select_examples<'a>(
+    manifest: &'a Manifest,
+    requested: &[String],
+) -> Result<Vec<&'a ExampleSpec>, DynError> {
+    if manifest.examples.is_empty() {
+        return Err("the manifest declares no examples".into());
+    }
+    if requested.is_empty() {
+        return Ok(manifest.examples.iter().collect());
+    }
+    for name in requested {
+        if !manifest.examples.iter().any(|e| &e.name == name) {
+            let known: Vec<&str> = manifest.examples.iter().map(|e| e.name.as_str()).collect();
+            return Err(format!(
+                "no example named `{name}`; manifest has: {}",
+                known.join(", ")
+            )
+            .into());
+        }
+    }
+    Ok(manifest
+        .examples
+        .iter()
+        .filter(|e| requested.contains(&e.name))
+        .collect())
+}
+
+/// Expands `$env:VAR` in the manifest's signer list, defaulting to the deployer key.
+fn resolve_signer_keys(declared: &[String]) -> Result<Vec<String>, DynError> {
+    let declared: Vec<String> = if declared.is_empty() {
+        vec!["$env:PRIVATE_KEY".to_string()]
+    } else {
+        declared.to_vec()
+    };
+    // Only `$env:` is meaningful here — the other placeholders resolve to addresses.
+    let env_only = Resolver::default();
+    declared.iter().map(|k| env_only.resolve(k)).collect()
+}
+
+/// Resolves a constructor wiring address by flag, then env, then the deployment JSON.
+fn resolve_wiring_address(
+    flag: Option<Address>,
+    env_var: &str,
+    json_key: &str,
+    deploy_addresses: &BTreeMap<String, String>,
+) -> Result<Option<Address>, DynError> {
+    if let Some(address) = flag {
+        return Ok(Some(address));
+    }
+    if let Some(raw) = std::env::var(env_var).ok().filter(|v| !v.trim().is_empty()) {
+        return Ok(Some(raw.trim().parse().map_err(|_| {
+            format!("{env_var} is not a valid address: {raw}")
+        })?));
+    }
+    match deploy_addresses.get(json_key) {
+        Some(raw) => Ok(Some(raw.parse().map_err(|_| {
+            format!("addresses.{json_key} is not a valid address: {raw}")
+        })?)),
+        None => Ok(None),
+    }
+}
+
+/// Fails fast when the resolved checker is the operator-state retriever, which cannot verify
+/// signatures. See [`validate_sig_checker`].
+fn reject_retriever_as_checker(
+    sig_checker: Option<Address>,
+    deploy_addresses: &BTreeMap<String, String>,
+) -> Result<(), DynError> {
+    let (Some(checker), Some(retriever)) =
+        (sig_checker, deploy_addresses.get(RETRIEVER_ADDRESS_KEY))
+    else {
+        return Ok(());
+    };
+    let Ok(retriever) = retriever.parse::<Address>() else {
+        return Ok(());
+    };
+    if checker == retriever {
+        return Err(format!(
+            "the resolved signature checker {checker:?} is `addresses.{RETRIEVER_ADDRESS_KEY}`, the \
+             BLSSigCheckOperatorStateRetriever. It has no checkSignatures, so verifyAndUpdate would \
+             revert with an empty 0x. Point EXAMPLE_SIG_CHECKER_ADDRESS at a real BLSSignatureChecker."
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn resolve_artifacts_dir(flag: Option<PathBuf>) -> PathBuf {
+    flag.or_else(|| {
+        std::env::var("EXAMPLES_DIR")
+            .ok()
+            .filter(|d| !d.trim().is_empty())
+            .map(|d| PathBuf::from(d).join("out"))
+    })
+    .unwrap_or_else(|| PathBuf::from(".examples/example-contracts/out"))
+}
+
+fn resolve_deploy_json(flag: Option<PathBuf>) -> PathBuf {
+    flag.or_else(|| {
+        std::env::var("AVS_DEPLOYMENT_PATH")
+            .ok()
+            .filter(|p| !p.trim().is_empty())
+            .map(PathBuf::from)
+    })
+    .unwrap_or_else(|| PathBuf::from("config/.nodes/avs_deploy.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ADDR_A: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    const ADDR_B: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+    fn resolver() -> Resolver {
+        Resolver {
+            avs: Some(ADDR_A.parse().unwrap()),
+            sig_checker: Some(ADDR_B.parse().unwrap()),
+            deploy_addresses: BTreeMap::from([(
+                "registryCoordinator".to_string(),
+                ADDR_A.to_string(),
+            )]),
+            signers: vec![ADDR_A.parse().unwrap(), ADDR_B.parse().unwrap()],
+        }
+    }
+
+    // ---- manifest parsing ----
+
+    #[test]
+    fn manifest_parses_scalar_and_list_arguments() {
+        let manifest: Manifest = toml::from_str(
+            r#"
+            signers = ["$env:PRIVATE_KEY", "0xabc"]
+
+            [[examples]]
+            name = "guardedVault"
+            artifact = "GuardedVault.sol:GuardedVault"
+            ctor_args = ["$avs", "$sigChecker", "5000"]
+
+              [[examples.setup]]
+              sig = "deposit(uint256)"
+              args = ["1000"]
+              signer = 1
+
+              [[examples.exercise]]
+              label = "settle_two"
+              sig = "settle(address[],int256[])"
+              args = [["$signer:0", "$signer:1"], ["100", "-100"]]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(manifest.signers.len(), 2);
+        let example = &manifest.examples[0];
+        assert_eq!(example.name, "guardedVault");
+        assert_eq!(example.ctor_args.len(), 3);
+        assert_eq!(example.setup[0].signer, 1);
+        // verify defaults to true so a generated scenario asserts an on-chain effect.
+        assert!(example.exercise[0].verify);
+        assert!(matches!(example.exercise[0].args[0], ArgValue::List(ref v) if v.len() == 2));
+    }
+
+    #[test]
+    fn manifest_rejects_an_unknown_field() {
+        let err = toml::from_str::<Manifest>(
+            r#"
+            [[examples]]
+            name = "x"
+            artifact = "X"
+            constructor_args = ["1"]
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("constructor_args"), "{err}");
+    }
+
+    // ---- placeholder resolution ----
+
+    #[test]
+    fn resolves_every_placeholder_form() {
+        let r = resolver();
+        assert_eq!(
+            r.resolve("$avs").unwrap(),
+            format!("{:?}", ADDR_A.parse::<Address>().unwrap())
+        );
+        assert_eq!(
+            r.resolve("$sigChecker").unwrap(),
+            format!("{:?}", ADDR_B.parse::<Address>().unwrap())
+        );
+        assert_eq!(r.resolve("$deploy:registryCoordinator").unwrap(), ADDR_A);
+        assert_eq!(
+            r.resolve("$signer:1").unwrap(),
+            format!("{:?}", ADDR_B.parse::<Address>().unwrap())
+        );
+    }
+
+    #[test]
+    fn passes_through_a_literal_value() {
+        assert_eq!(resolver().resolve("5000").unwrap(), "5000");
+        assert_eq!(resolver().resolve(ADDR_A).unwrap(), ADDR_A);
+    }
+
+    #[test]
+    fn rejects_unknown_and_out_of_range_placeholders() {
+        let r = resolver();
+        assert!(
+            r.resolve("$nope")
+                .unwrap_err()
+                .to_string()
+                .contains("unknown placeholder")
+        );
+        assert!(
+            r.resolve("$signer:9")
+                .unwrap_err()
+                .to_string()
+                .contains("out of range")
+        );
+        assert!(
+            r.resolve("$deploy:missing")
+                .unwrap_err()
+                .to_string()
+                .contains("not found")
+        );
+    }
+
+    #[test]
+    fn unresolved_wiring_names_the_ways_to_supply_it() {
+        let r = Resolver::default();
+        let err = r.resolve("$avs").unwrap_err().to_string();
+        assert!(err.contains("--avs"), "{err}");
+        assert!(err.contains("EXAMPLE_AVS_ADDRESS"), "{err}");
+    }
+
+    #[test]
+    fn resolves_placeholders_inside_nested_lists() {
+        let arg = ArgValue::List(vec![ArgValue::List(vec![ArgValue::Scalar(
+            "$signer:0".to_string(),
+        )])]);
+        let resolved = resolve_arg(&resolver(), &arg).unwrap();
+        let ArgValue::List(outer) = resolved else {
+            panic!("expected a list");
+        };
+        let ArgValue::List(inner) = &outer[0] else {
+            panic!("expected a nested list");
+        };
+        assert!(matches!(&inner[0], ArgValue::Scalar(s) if s.starts_with("0x")));
+    }
+
+    // ---- ABI coercion ----
+
+    #[test]
+    fn coerces_a_fixed_array_constructor_argument() {
+        // OnchainLife's seed parameter: a uint256[16] board.
+        let ty = DynSolType::FixedArray(Box::new(DynSolType::Uint(256)), 16);
+        let mut items = vec![ArgValue::Scalar("0".to_string()); 16];
+        items[0] = ArgValue::Scalar("2381976568446569244317409228317215686658".to_string());
+
+        let value = coerce_arg(&ty, &ArgValue::List(items)).unwrap();
+        let DynSolValue::FixedArray(words) = value else {
+            panic!("expected a fixed array");
+        };
+        assert_eq!(words.len(), 16);
+        assert_eq!(
+            words[0].as_uint().unwrap().0,
+            U256::from_str_radix("2381976568446569244317409228317215686658", 10).unwrap()
+        );
+    }
+
+    #[test]
+    fn fixed_array_length_mismatch_is_an_error() {
+        let ty = DynSolType::FixedArray(Box::new(DynSolType::Uint(256)), 16);
+        let err = coerce_arg(&ty, &ArgValue::List(vec![ArgValue::Scalar("0".into())]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("expected 16 values"), "{err}");
+    }
+
+    #[test]
+    fn coerces_signed_and_address_arrays() {
+        let deltas = coerce_arg(
+            &DynSolType::Array(Box::new(DynSolType::Int(256))),
+            &ArgValue::List(vec![
+                ArgValue::Scalar("100".into()),
+                ArgValue::Scalar("-100".into()),
+            ]),
+        )
+        .unwrap();
+        assert!(matches!(deltas, DynSolValue::Array(ref v) if v.len() == 2));
+
+        let users = coerce_arg(
+            &DynSolType::Array(Box::new(DynSolType::Address)),
+            &ArgValue::List(vec![
+                ArgValue::Scalar(ADDR_A.into()),
+                ArgValue::Scalar(ADDR_B.into()),
+            ]),
+        )
+        .unwrap();
+        assert!(matches!(users, DynSolValue::Array(ref v) if v.len() == 2));
+    }
+
+    #[test]
+    fn arity_mismatch_is_an_error() {
+        let err = coerce_args(
+            &[DynSolType::Address, DynSolType::Uint(256)],
+            &[ArgValue::Scalar(ADDR_A.into())],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("expected 2 argument(s)"), "{err}");
+    }
+
+    #[test]
+    fn a_bad_scalar_names_the_expected_type() {
+        let err = coerce_arg(&DynSolType::Address, &ArgValue::Scalar("nope".into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+    }
+
+    // ---- calldata encoding ----
+
+    #[test]
+    fn encodes_a_call_with_the_right_selector() {
+        let data = encode_call("step(uint32)", &[ArgValue::Scalar("16".into())]).unwrap();
+        // selector + one 32-byte word
+        assert_eq!(data.len(), 36);
+        assert_eq!(
+            &data[..4],
+            &keccak256("step(uint32)")[..4],
+            "selector must match the signature"
+        );
+        assert_eq!(U256::from_be_slice(&data[4..36]), U256::from(16));
+    }
+
+    #[test]
+    fn encodes_dynamic_array_arguments() {
+        let data = encode_call(
+            "settle(address[],int256[])",
+            &[
+                ArgValue::List(vec![ArgValue::Scalar(ADDR_A.into())]),
+                ArgValue::List(vec![ArgValue::Scalar("0".into())]),
+            ],
+        )
+        .unwrap();
+        assert_eq!(&data[..4], &keccak256("settle(address[],int256[])")[..4]);
+        // two head offsets + two (length, element) pairs
+        assert_eq!(data.len(), 4 + 32 * 6);
+    }
+
+    #[test]
+    fn tolerates_a_function_keyword_prefix() {
+        let bare = encode_call("step(uint32)", &[ArgValue::Scalar("1".into())]).unwrap();
+        let prefixed =
+            encode_call("function step(uint32)", &[ArgValue::Scalar("1".into())]).unwrap();
+        assert_eq!(bare, prefixed);
+    }
+
+    #[test]
+    fn rejects_a_malformed_signature() {
+        let err = encode_call("step(", &[]).unwrap_err().to_string();
+        assert!(err.contains("not a valid function signature"), "{err}");
+    }
+
+    // ---- artifact handling ----
+
+    #[test]
+    fn artifact_paths_handle_both_spellings() {
+        let dir = Path::new("out");
+        assert_eq!(
+            artifact_path(dir, "OnchainLife.sol:OnchainLife"),
+            Path::new("out/OnchainLife.sol/OnchainLife.json")
+        );
+        assert_eq!(
+            artifact_path(dir, "OnchainLife"),
+            Path::new("out/OnchainLife.sol/OnchainLife.json")
+        );
+    }
+
+    #[test]
+    fn init_code_is_bytecode_plus_encoded_arguments() {
+        let abi: JsonAbi = serde_json::from_str(
+            r#"[{"type":"constructor","inputs":[
+                 {"name":"a","type":"address"},
+                 {"name":"n","type":"uint256"}
+               ],"stateMutability":"nonpayable"}]"#,
+        )
+        .unwrap();
+        let bytecode = Bytes::from(vec![0x60, 0x80]);
+
+        let init_code = build_init_code(
+            &abi,
+            &bytecode,
+            &[
+                ArgValue::Scalar(ADDR_A.into()),
+                ArgValue::Scalar("5000".into()),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(&init_code[..2], &[0x60, 0x80]);
+        assert_eq!(init_code.len(), 2 + 64);
+        assert_eq!(U256::from_be_slice(&init_code[34..66]), U256::from(5000));
+    }
+
+    #[test]
+    fn init_code_rejects_arguments_for_a_constructorless_artifact() {
+        let abi: JsonAbi = serde_json::from_str("[]").unwrap();
+        let err = build_init_code(
+            &abi,
+            &Bytes::from(vec![0x00]),
+            &[ArgValue::Scalar("1".into())],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("no constructor"), "{err}");
+    }
+
+    // ---- deployment JSON merge ----
+
+    #[test]
+    fn recording_an_address_preserves_unrelated_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("avs_deploy.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"{"lastUpdate":{"block_number":"7"},"addresses":{"arraySummation":"0x1234"}}"#,
+        )
+        .unwrap();
+
+        let deployed: Address = ADDR_B.parse().unwrap();
+        record_deployed_address(&path, "onchainLife", deployed).unwrap();
+
+        let written: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(written["lastUpdate"]["block_number"], "7");
+        assert_eq!(written["addresses"]["arraySummation"], "0x1234");
+        assert_eq!(written["addresses"]["onchainLife"], format!("{deployed:?}"));
+    }
+
+    #[test]
+    fn recording_an_address_creates_a_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fresh.json");
+        let deployed: Address = ADDR_A.parse().unwrap();
+
+        record_deployed_address(&path, "guardedVault", deployed).unwrap();
+
+        let addresses = read_deploy_addresses(&path).unwrap();
+        assert_eq!(addresses["guardedVault"], format!("{deployed:?}"));
+    }
+
+    #[test]
+    fn reading_addresses_tolerates_a_missing_file() {
+        let addresses = read_deploy_addresses(Path::new("/nonexistent/avs_deploy.json")).unwrap();
+        assert!(addresses.is_empty());
+    }
+
+    // ---- scenario emission ----
+
+    #[test]
+    fn scenario_targets_the_local_sentinel_and_enables_submit() {
+        let rendered = render_scenario(
+            "onchainLife",
+            "http://localhost:8080",
+            &[ScenarioRequest {
+                label: "life_step_1".to_string(),
+                call_data: Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+                verify: true,
+            }],
+        );
+
+        assert!(rendered.contains(r#"target_address = "local:onchainLife""#));
+        assert!(rendered.contains(r#"from_address   = "local""#));
+        assert!(rendered.contains(r#"call_data      = "0xdeadbeef""#));
+        assert!(rendered.contains("submit         = true"));
+        assert!(rendered.contains("verify         = true"));
+        assert!(rendered.contains(r#"http_rpc   = "$HTTP_RPC""#));
+        // api_key is intentionally absent: run_scenario falls back to GAS_KILLER_API_KEY.
+        assert!(!rendered.contains("api_key"));
+    }
+
+    #[test]
+    fn generated_scenario_round_trips_through_the_toml_parser() {
+        let rendered = render_scenario(
+            "guardedVault",
+            "https://testnet.gaskiller.xyz",
+            &[
+                ScenarioRequest {
+                    label: "settle_two".to_string(),
+                    call_data: Bytes::from(vec![0x01, 0x02, 0x03, 0x04]),
+                    verify: true,
+                },
+                ScenarioRequest {
+                    label: "settle_again".to_string(),
+                    call_data: Bytes::from(vec![0x05, 0x06, 0x07, 0x08]),
+                    verify: false,
+                },
+            ],
+        );
+
+        let parsed: toml::Value = toml::from_str(&rendered).unwrap();
+        assert_eq!(
+            parsed["router_url"].as_str(),
+            Some("https://testnet.gaskiller.xyz")
+        );
+        let requests = parsed["scenarios"][0]["requests"].as_array().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[1]["verify"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn toml_strings_escape_quotes_and_backslashes() {
+        assert_eq!(toml_string(r#"a"b\c"#), r#""a\"b\\c""#);
+    }
+
+    // ---- selection and wiring resolution ----
+
+    #[test]
+    fn selecting_examples_filters_and_reports_unknown_names() {
+        let manifest: Manifest = toml::from_str(
+            r#"
+            [[examples]]
+            name = "a"
+            artifact = "A"
+
+            [[examples]]
+            name = "b"
+            artifact = "B"
+            "#,
+        )
+        .unwrap();
+
+        // No selection means everything, in manifest order.
+        let all = select_examples(&manifest, &[]).unwrap();
+        assert_eq!(
+            all.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+
+        let one = select_examples(&manifest, &["b".to_string()]).unwrap();
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].name, "b");
+
+        let err = select_examples(&manifest, &["c".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no example named `c`"), "{err}");
+        assert!(err.contains("a, b"), "{err}");
+    }
+
+    #[test]
+    fn flag_beats_env_and_json_for_wiring() {
+        let json = BTreeMap::from([(AVS_ADDRESS_KEY.to_string(), ADDR_B.to_string())]);
+        let flag: Address = ADDR_A.parse().unwrap();
+        let resolved = resolve_wiring_address(
+            Some(flag),
+            "EXAMPLE_AVS_ADDRESS_UNSET_IN_TEST",
+            AVS_ADDRESS_KEY,
+            &json,
+        )
+        .unwrap();
+        assert_eq!(resolved, Some(flag));
+    }
+
+    #[test]
+    fn wiring_falls_back_to_the_deployment_json() {
+        let json = BTreeMap::from([(AVS_ADDRESS_KEY.to_string(), ADDR_B.to_string())]);
+        let resolved = resolve_wiring_address(
+            None,
+            "EXAMPLE_AVS_ADDRESS_UNSET_IN_TEST",
+            AVS_ADDRESS_KEY,
+            &json,
+        )
+        .unwrap();
+        assert_eq!(resolved, Some(ADDR_B.parse().unwrap()));
+    }
+
+    #[test]
+    fn missing_wiring_resolves_to_none_rather_than_erroring() {
+        let resolved = resolve_wiring_address(
+            None,
+            "EXAMPLE_AVS_ADDRESS_UNSET_IN_TEST",
+            AVS_ADDRESS_KEY,
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn the_operator_state_retriever_is_refused_as_a_checker() {
+        let json = BTreeMap::from([(RETRIEVER_ADDRESS_KEY.to_string(), ADDR_A.to_string())]);
+        let err = reject_retriever_as_checker(Some(ADDR_A.parse().unwrap()), &json)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("checkSignatures"), "{err}");
+
+        // A different checker is fine.
+        reject_retriever_as_checker(Some(ADDR_B.parse().unwrap()), &json).unwrap();
+    }
+
+    // ---- misc ----
+
+    #[test]
+    fn signer_list_defaults_to_the_deployer_key() {
+        // SAFETY: single-threaded test setting a variable only this test reads.
+        unsafe { std::env::set_var("PRIVATE_KEY", "0xdeadbeef") };
+        assert_eq!(resolve_signer_keys(&[]).unwrap(), vec!["0xdeadbeef"]);
+    }
+
+    #[test]
+    fn wei_parses_decimal_and_hex() {
+        assert_eq!(parse_wei("1000").unwrap(), U256::from(1000));
+        assert_eq!(parse_wei("0x10").unwrap(), U256::from(16));
+        assert!(parse_wei("twelve").is_err());
+    }
+
+    #[test]
+    fn artifacts_dir_defaults_under_the_examples_checkout() {
+        assert_eq!(
+            resolve_artifacts_dir(Some(PathBuf::from("custom/out"))),
+            PathBuf::from("custom/out")
+        );
+    }
+}

--- a/scripts/examples/examples.toml
+++ b/scripts/examples/examples.toml
@@ -1,0 +1,109 @@
+# Manifest for the `deploy_example` binary — the contracts from
+# gas-killer/example-contracts, how to construct them, and how to exercise them.
+#
+#   ./scripts/examples/fetch_examples.sh
+#   cargo run -p scripts --bin deploy_example -- --dry-run
+#   cargo run -p scripts --bin deploy_example -- --example onchainLife
+#   cargo run -p scripts --bin run_scenario -- scripts/scenarios/generated/onchainLife.toml
+#
+# Argument *types* come from each artifact's ABI, so only values live here. A value is a
+# string; an array or tuple parameter takes a list. Placeholders:
+#
+#   $avs           the AVS service manager (addresses.avsServiceManagerWrapper, or --avs)
+#   $sigChecker    a real BLSSignatureChecker (addresses.IncredibleSquaringTaskManager, or
+#                  --sig-checker). NOT addresses.blsSigCheck — see example.env.
+#   $deploy:<key>  any key under `addresses` in the AVS deployment JSON
+#   $signer:<n>    the address of signers[n] below
+#   $env:VAR       an environment variable
+#
+# Adding an example is an edit here plus an entry in EXPECTED_ARTIFACTS in
+# fetch_examples.sh. No Rust changes.
+
+# Index 0 is the deployer and the default sender for every setup call. The remaining entries
+# are Anvil's well-known unlocked test accounts, used only to create distinct depositors for
+# guardedVault below. They are public keys for a local fork — a testnet run must replace this
+# list with funded keys (or drop the multi-depositor setup).
+signers = [
+  "$env:PRIVATE_KEY",
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d", # anvil #1
+  "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a", # anvil #2
+  "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6", # anvil #3
+]
+
+# ── OnchainLife ──────────────────────────────────────────────────────────────────────────
+# Conway's Game of Life on a 64x64 toroidal board, stepped entirely on-chain. One generation
+# costs roughly 16.9M gas and two exceed a 30M block, but the resulting diff is at most 16
+# changed words plus the generation counter — the same size no matter how many generations the
+# operator stepped. The cost-collapse case.
+[[examples]]
+name      = "onchainLife"
+artifact  = "OnchainLife.sol:OnchainLife"
+# uint256[16] seed: the board, four 64-bit rows per word. Word 0 carries a standard glider at
+# cells (1,0) (2,1) (0,2) (1,2) (2,2), i.e. the sum of 1 << (y * 64 + x).
+ctor_args = [
+  "$avs",
+  "$sigChecker",
+  [
+    "2381976568446569244317409228317215686658",
+    "0", "0", "0", "0", "0", "0", "0",
+    "0", "0", "0", "0", "0", "0", "0", "0",
+  ],
+]
+
+  # WARNING: this exercise does not currently complete against the local compose stack.
+  #
+  # The router derives the diff by calling `debug_traceCall`, and one generation of Life is
+  # ~16.9M gas. The resulting structLog trace exhausted the anvil container (3.82 GiB) and the
+  # process was OOM-killed (exit 137), so the task never rendered a payload:
+  #
+  #   ERROR gas_killer_router::sequencer: failed to enrich task, dropping request
+  #     error=Gas analysis failed: debug_trace_call failed: error sending request
+  #
+  # `generations` is the only parameter and 1 is already its floor, so there is no cheaper
+  # setting — the limit is the trace-based encoder, not the manifest. The example repo
+  # describes the intended fix in docs/APPROACH-A-PRESTATE.md (a prestate diff extractor that
+  # avoids structLogs entirely). Left in place so the case stays one command to reproduce.
+  #
+  # `guardedVault` below is the example that currently runs green end to end.
+  [[examples.exercise]]
+  label = "life_step_1"
+  sig   = "step(uint32)"
+  args  = ["1"]
+
+# ── GuardedVault ─────────────────────────────────────────────────────────────────────────
+# A vault whose every state transition re-validates an O(N) global invariant. Operators
+# simulate `settle`, run `checkInvariant()` against the post-state, and only sign a diff that
+# passes — so the quorum signature doubles as an attestation that the transition preserved the
+# invariant, and `verifyAndUpdate` never re-runs the O(N) check itself.
+[[examples]]
+name      = "guardedVault"
+artifact  = "GuardedVault.sol:GuardedVault"
+# maxConcentrationBps: no depositor may hold more than 50% of total shares.
+ctor_args = ["$avs", "$sigChecker", "5000"]
+
+  # `settle` reverts with NotDepositor for an address that never deposited, and `deposit`
+  # credits msg.sender — so each depositor has to come from a different signer.
+  #
+  # Three depositors, not two: the concentration cap is checked against the post-state, and
+  # with only two equal depositors at a 50% cap every non-zero delta would breach it. At three
+  # the cap is 1500 of 3000 shares, leaving room for the transfer below.
+  [[examples.setup]]
+  sig    = "deposit(uint256)"
+  args   = ["1000"]
+  signer = 1
+
+  [[examples.setup]]
+  sig    = "deposit(uint256)"
+  args   = ["1000"]
+  signer = 2
+
+  [[examples.setup]]
+  sig    = "deposit(uint256)"
+  args   = ["1000"]
+  signer = 3
+
+  # Deltas must sum to zero or `settle` reverts with NonConservingSettle.
+  [[examples.exercise]]
+  label = "vault_settle_transfer"
+  sig   = "settle(address[],int256[])"
+  args  = [["$signer:1", "$signer:2"], ["100", "-100"]]

--- a/scripts/examples/examples.toml
+++ b/scripts/examples/examples.toml
@@ -32,9 +32,9 @@ signers = [
 
 # ── OnchainLife ──────────────────────────────────────────────────────────────────────────
 # Conway's Game of Life on a 64x64 toroidal board, stepped entirely on-chain. One generation
-# costs roughly 16.9M gas and two exceed a 30M block, but the resulting diff is at most 16
-# changed words plus the generation counter — the same size no matter how many generations the
-# operator stepped. The cost-collapse case.
+# costs ~16.5M gas (measured: 16,552,726) and two exceed a 30M block, but the resulting diff is
+# at most 16 changed words plus the generation counter — the same size no matter how many
+# generations the operator stepped. The cost-collapse case.
 [[examples]]
 name      = "onchainLife"
 artifact  = "OnchainLife.sol:OnchainLife"
@@ -50,21 +50,24 @@ ctor_args = [
   ],
 ]
 
-  # WARNING: this exercise does not currently complete against the local compose stack.
+  # REQUIRES STATE_ENCODING=prestate-net. Under the default `legacy` (and under `canonical`)
+  # this exercise cannot complete.
   #
-  # The router derives the diff by calling `debug_traceCall`, and one generation of Life is
-  # ~16.9M gas. The resulting structLog trace exhausted the anvil container (3.82 GiB) and the
-  # process was OOM-killed (exit 137), so the task never rendered a payload:
+  # Those encodings derive the diff from a struct-log `debug_traceCall`, which costs
+  # O(execution steps) — and one generation of Life is ~16.5M gas. Measured on a stock anvil,
+  # that trace drives the process from 8 MB to 2.2 GB of RSS in 20s and still has not returned;
+  # inside the 3.82 GiB compose container it is OOM-killed outright (exit 137), so the task
+  # never renders a payload:
   #
   #   ERROR gas_killer_router::sequencer: failed to enrich task, dropping request
   #     error=Gas analysis failed: debug_trace_call failed: error sending request
   #
-  # `generations` is the only parameter and 1 is already its floor, so there is no cheaper
-  # setting — the limit is the trace-based encoder, not the manifest. The example repo
-  # describes the intended fix in docs/APPROACH-A-PRESTATE.md (a prestate diff extractor that
-  # avoids structLogs entirely). Left in place so the case stays one command to reproduce.
+  # `generations` is already at its floor of 1, so no manifest setting avoids this — the limit
+  # is the encoder. `prestate-net` reads the net diff from prestateTracer/callTracer instead,
+  # costing O(changed slots): the same call returns in 0s with a 3-slot diff, and the call tree
+  # has no target-depth frames, so it takes the net form rather than the canonical fallback.
   #
-  # `guardedVault` below is the example that currently runs green end to end.
+  # `guardedVault` below runs green end to end under any of the three encodings.
   [[examples.exercise]]
   label = "life_step_1"
   sig   = "step(uint32)"

--- a/scripts/examples/fetch_examples.sh
+++ b/scripts/examples/fetch_examples.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Fetches and builds the public gas-killer/example-contracts library so the `deploy_example`
+# binary has Foundry artifacts to deploy from.
+#
+# Idempotent: clones on the first run, then fetches and re-checks-out the pinned revision on
+# every later run. The checkout is gitignored — it is a build input, not part of this repo.
+#
+# EXAMPLES_REF pins a commit rather than a branch so a rebuild is reproducible. Override it
+# with a branch name to track upstream:
+#
+#   EXAMPLES_REF=hudsonhrh/gas-killer-foundry-examples ./scripts/examples/fetch_examples.sh
+#
+# The example contracts resolve the Gas Killer SDK, EigenLayer, and OpenZeppelin through
+# nested submodules, so the recursive clone pulls a few hundred MB on a cold run.
+#
+# Requires: git, and Foundry (`forge`) on PATH.
+
+set -euo pipefail
+
+EXAMPLES_REPO="${EXAMPLES_REPO:-https://github.com/gas-killer/example-contracts}"
+EXAMPLES_REF="${EXAMPLES_REF:-f9aa0a6020ec7b3e28db47999ece8ba54b3847f6}"
+EXAMPLES_DIR="${EXAMPLES_DIR:-.examples/example-contracts}"
+
+# Contracts the manifest expects to exist once the build finishes.
+EXPECTED_ARTIFACTS=(
+  "OnchainLife.sol/OnchainLife.json"
+  "GuardedVault.sol/GuardedVault.json"
+)
+
+if ! command -v forge >/dev/null 2>&1; then
+  echo "❌ forge not found on PATH. Install Foundry: https://getfoundry.sh" >&2
+  exit 1
+fi
+
+if [ ! -d "$EXAMPLES_DIR/.git" ]; then
+  echo "📥 cloning $EXAMPLES_REPO into $EXAMPLES_DIR"
+  mkdir -p "$(dirname "$EXAMPLES_DIR")"
+  git clone --recurse-submodules "$EXAMPLES_REPO" "$EXAMPLES_DIR"
+else
+  echo "📥 updating existing checkout at $EXAMPLES_DIR"
+fi
+
+echo "🔖 checking out $EXAMPLES_REF"
+git -C "$EXAMPLES_DIR" fetch --tags origin
+# A pinned SHA is not necessarily reachable by a branch name, so fetch it directly. Tolerated
+# if it fails: the ref may already be local, or may be a branch the fetch above resolved.
+git -C "$EXAMPLES_DIR" fetch origin "$EXAMPLES_REF" 2>/dev/null || true
+git -C "$EXAMPLES_DIR" checkout --detach "$EXAMPLES_REF" 2>/dev/null \
+  || git -C "$EXAMPLES_DIR" checkout --detach "origin/$EXAMPLES_REF"
+
+# The SDK remappings resolve through the submodule's own lib/ tree, so this must be recursive
+# or the build fails on unresolved EigenLayer and OpenZeppelin imports.
+echo "🔗 syncing submodules (recursive)"
+git -C "$EXAMPLES_DIR" submodule update --init --recursive
+
+echo "🔨 building with forge"
+(cd "$EXAMPLES_DIR" && forge build)
+
+missing=0
+for artifact in "${EXPECTED_ARTIFACTS[@]}"; do
+  if [ ! -f "$EXAMPLES_DIR/out/$artifact" ]; then
+    echo "❌ expected artifact missing: $EXAMPLES_DIR/out/$artifact" >&2
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  echo "The manifest at scripts/examples/examples.toml may be out of date with the checkout." >&2
+  exit 1
+fi
+
+resolved="$(git -C "$EXAMPLES_DIR" rev-parse HEAD)"
+echo
+echo "✅ example contracts built at $resolved"
+echo "   artifacts: $EXAMPLES_DIR/out"
+echo
+echo "Next:"
+echo "   cargo run -p scripts --bin deploy_example -- --dry-run"
+echo "   cargo run -p scripts --bin deploy_example -- --example onchainLife"

--- a/scripts/examples/run_example.sh
+++ b/scripts/examples/run_example.sh
@@ -35,6 +35,18 @@ if ! curl -fsS --max-time 5 "$ROUTER_URL/healthz" >/dev/null 2>&1; then
 fi
 echo "✅ router healthy at $ROUTER_URL"
 
+# onchainLife's tracked function is ~16.5M gas. Only the prestate-net encoding, which reads a
+# net diff sized by changed slots, can extract it; the struct-log encoders behind legacy and
+# canonical exhaust the node first. Warn rather than block — the running stack's encoding is
+# what actually matters and this only sees the local environment.
+if [ "$EXAMPLE" = "onchainLife" ] && [ "${STATE_ENCODING:-legacy}" != "prestate-net" ]; then
+  echo "⚠️  STATE_ENCODING is '${STATE_ENCODING:-legacy}', but onchainLife only settles under 'prestate-net'." >&2
+  echo "   Expect the task to never reach 'ready' (the struct-log trace exhausts the node)." >&2
+  echo "   Recreate the stack with the encoding set on the nodes AND the router:" >&2
+  echo "     STATE_ENCODING=prestate-net docker compose up -d --force-recreate" >&2
+  echo >&2
+fi
+
 if [ "${SKIP_FETCH:-0}" != "1" ]; then
   "$REPO_ROOT/scripts/examples/fetch_examples.sh"
 else

--- a/scripts/examples/run_example.sh
+++ b/scripts/examples/run_example.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# End-to-end harness for one example contract: fetch and build it, deploy it wired to the
+# local AVS, then drive a task through the router and confirm the state transition landed.
+#
+#   ./scripts/examples/run_example.sh onchainLife
+#   ./scripts/examples/run_example.sh guardedVault
+#
+# Expects the local stack to already be running (`./scripts/run_e2e_test.sh --keep-up`, or
+# `docker compose up -d`). Set SKIP_FETCH=1 to reuse an existing artifact build.
+#
+# Requires: git, forge, cargo, and an authenticated router (GAS_KILLER_API_KEY) if ADMIN_KEY
+# minting is enabled on the deployment.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+EXAMPLE="${1:-}"
+if [ -z "$EXAMPLE" ]; then
+  echo "Usage: $0 <example-name>" >&2
+  echo >&2
+  echo "Examples declared in scripts/examples/examples.toml:" >&2
+  grep -E '^name\s*=' scripts/examples/examples.toml | sed 's/name *= *//; s/"//g; s/^/  /' >&2
+  exit 1
+fi
+
+ROUTER_URL="${GAS_KILLER_ROUTER_URL:-http://localhost:8080}"
+if ! curl -fsS --max-time 5 "$ROUTER_URL/healthz" >/dev/null 2>&1; then
+  echo "❌ router not reachable at $ROUTER_URL/healthz" >&2
+  echo "   Start the local stack first:  ./scripts/run_e2e_test.sh --keep-up" >&2
+  echo "   (or point GAS_KILLER_ROUTER_URL at a running router)" >&2
+  exit 1
+fi
+echo "✅ router healthy at $ROUTER_URL"
+
+if [ "${SKIP_FETCH:-0}" != "1" ]; then
+  "$REPO_ROOT/scripts/examples/fetch_examples.sh"
+else
+  echo "⏭️  SKIP_FETCH=1, reusing the existing artifact build"
+fi
+
+echo
+echo "═══ deploying $EXAMPLE ═══"
+cargo run -q -p scripts --bin deploy_example -- --example "$EXAMPLE"
+
+SCENARIO="scripts/scenarios/generated/$EXAMPLE.toml"
+if [ ! -f "$SCENARIO" ]; then
+  echo "❌ $SCENARIO was not generated; does the example declare an [[examples.exercise]]?" >&2
+  exit 1
+fi
+
+echo
+echo "═══ running $SCENARIO ═══"
+cargo run -q -p scripts --bin run_scenario -- "$SCENARIO"

--- a/scripts/run_scenario.rs
+++ b/scripts/run_scenario.rs
@@ -1,6 +1,9 @@
 use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::signers::local::PrivateKeySigner;
+use bindings::task_payload::{
+    submit_payload, submitter_key, task_status_url, wait_for_ready_payload,
+};
 use gas_killer_common::ReadOnlyProvider;
 use gas_killer_common::bindings::gaskillersdk::GasKillerSDK;
 use reqwest::Client;
@@ -118,10 +121,19 @@ struct RequestConfig {
     /// Set to 0 to auto-fetch the current block from `http_rpc`.
     #[serde(default)]
     block_height: u64,
+    /// When true, poll `GET /tasks/{id}` after a 202 and submit the rendered payload.
+    ///
+    /// With `INGRESS=true` the router renders a `verifyAndUpdate` transaction rather than
+    /// broadcasting it, so nothing reaches the chain until a caller signs and sends that
+    /// payload. `verify` can therefore only ever time out unless this is set (or the router
+    /// runs in auto-execute mode, where something else broadcasts).
+    #[serde(default)]
+    submit: bool,
     /// When true, poll stateTransitionCount() after a 202 to confirm verifyAndUpdate ran.
     #[serde(default)]
     verify: bool,
-    /// How long to wait for on-chain confirmation (seconds, default: 150).
+    /// How long to wait, in seconds, for the payload to render and for the on-chain effect to
+    /// appear. Covers both waits when `submit = true` (default: 150).
     #[serde(default = "default_verify_timeout")]
     verify_timeout_secs: u64,
 }
@@ -232,12 +244,56 @@ async fn verify_on_chain(
     }
 }
 
+// ── Endpoints ─────────────────────────────────────────────────────────────────
+
+/// Where and how to reach the router and the chain, for the lifetime of a run.
+///
+/// Held behind `Arc`s so parallel-mode requests, which are spawned onto their own tasks and so
+/// must own everything they touch, can clone it cheaply.
+#[derive(Clone)]
+struct Endpoints {
+    client: Arc<Client>,
+    router_url: Arc<String>,
+    api_key: Arc<Option<String>>,
+    /// `None` when no request needs an RPC endpoint.
+    http_rpc: Arc<Option<String>>,
+}
+
+impl Endpoints {
+    fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref().filter(|k| !k.is_empty())
+    }
+
+    /// Waits for the router to render the task's payload, then signs and submits it.
+    ///
+    /// This is the step that actually puts `verifyAndUpdate` on-chain in ingress mode; the
+    /// router only prepares the transaction. Uses `FUNDED_KEY` in preference to `PRIVATE_KEY`.
+    async fn submit_rendered_payload(
+        &self,
+        task_id: &str,
+        ready_timeout_secs: u64,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let http_rpc = self
+            .http_rpc
+            .as_deref()
+            .ok_or("`http_rpc` is required when `submit = true`")?;
+        let status_url = task_status_url(&self.router_url, task_id)?;
+        let payload = wait_for_ready_payload(
+            &self.client,
+            &status_url,
+            self.api_key(),
+            task_id,
+            ready_timeout_secs,
+        )
+        .await?;
+        submit_payload(&payload, http_rpc, &submitter_key()?).await
+    }
+}
+
 // ── Core execution ────────────────────────────────────────────────────────────
 
 async fn send_request(
-    client: &Client,
-    router_url: &str,
-    api_key: Option<&str>,
+    endpoints: &Endpoints,
     cfg: &RequestConfig,
     current_block: u64,
     provider: Option<&ReadOnlyProvider>,
@@ -334,12 +390,10 @@ async fn send_request(
         },
     };
 
-    let url = format!("{}/tasks", router_url.trim_end_matches('/'));
+    let url = format!("{}/tasks", endpoints.router_url.trim_end_matches('/'));
     let start = Instant::now();
-    let mut req = client.post(&url).json(&payload);
-    if let Some(key) = api_key
-        && !key.is_empty()
-    {
+    let mut req = endpoints.client.post(&url).json(&payload);
+    if let Some(key) = endpoints.api_key() {
         req = req.header("Authorization", format!("Bearer {key}"));
     }
     let resp = req.send().await;
@@ -348,8 +402,8 @@ async fn send_request(
     // The router acknowledges an accepted submission with `202 Accepted` and a
     // `{ task_id, status }` body; any other status carries an error envelope, surfaced verbatim
     // in the report.
-    let (status, api_success, message) = match resp {
-        Err(e) => (0u16, false, format!("connection error: {e}")),
+    let (status, api_success, message, task_id) = match resp {
+        Err(e) => (0u16, false, format!("connection error: {e}"), None),
         Ok(r) => {
             let status = r.status().as_u16();
             match r.text().await {
@@ -359,6 +413,7 @@ async fn send_request(
                             status,
                             true,
                             format!("{} (task {})", body.status, body.task_id),
+                            Some(body.task_id),
                         ),
                         Err(e) => {
                             let trimmed = body_text.trim();
@@ -367,7 +422,7 @@ async fn send_request(
                             } else {
                                 format!("{trimmed} (unparseable 202: {e})")
                             };
-                            (status, false, msg)
+                            (status, false, msg, None)
                         }
                     }
                 }
@@ -378,12 +433,42 @@ async fn send_request(
                     } else {
                         trimmed.to_string()
                     };
-                    (status, false, msg)
+                    (status, false, msg, None)
                 }
-                Err(e) => (status, false, format!("failed to read response body: {e}")),
+                Err(e) => (
+                    status,
+                    false,
+                    format!("failed to read response body: {e}"),
+                    None,
+                ),
             }
         }
     };
+
+    // Land the rendered payload before checking for its effect. Ordering matters: the verify
+    // poll below watches for a state transition that only this submission can cause.
+    if cfg.submit && api_success && status == 202 {
+        let outcome = match task_id.as_deref() {
+            Some(id) => {
+                println!("       Waiting for the rendered payload, then submitting...");
+                endpoints
+                    .submit_rendered_payload(id, cfg.verify_timeout_secs)
+                    .await
+                    .map_err(|e| format!("submit failed: {e}"))
+            }
+            None => Err("`submit = true` but the 202 carried no task_id".to_string()),
+        };
+        if let Err(e) = outcome {
+            return RequestResult {
+                label,
+                status,
+                api_success,
+                message,
+                elapsed,
+                on_chain: Some(OnChainResult::Error(e)),
+            };
+        }
+    }
 
     // Verify on-chain only if the API accepted the request
     let on_chain = if cfg.verify && api_success && status == 202 {
@@ -451,9 +536,7 @@ fn print_result(result: &RequestResult, index: usize, total: usize) {
 }
 
 async fn run_scenario(
-    client: Arc<Client>,
-    router_url: Arc<String>,
-    api_key: Arc<Option<String>>,
+    endpoints: &Endpoints,
     scenario: &Scenario,
     current_block: u64,
     provider: Option<Arc<ReadOnlyProvider>>,
@@ -473,16 +556,8 @@ async fn run_scenario(
         Mode::Serial => {
             let mut results = Vec::with_capacity(total);
             for (i, req_cfg) in scenario.requests.iter().enumerate() {
-                let result = send_request(
-                    &client,
-                    &router_url,
-                    api_key.as_deref(),
-                    req_cfg,
-                    current_block,
-                    provider.as_deref(),
-                    i,
-                )
-                .await;
+                let result =
+                    send_request(endpoints, req_cfg, current_block, provider.as_deref(), i).await;
                 print_result(&result, i, total);
                 results.push(result);
                 if i + 1 < total && scenario.delay_between_ms > 0 {
@@ -497,22 +572,12 @@ async fn run_scenario(
                 .iter()
                 .enumerate()
                 .map(|(i, req_cfg)| {
-                    let client = client.clone();
-                    let router_url = router_url.clone();
-                    let api_key = api_key.clone();
+                    let endpoints = endpoints.clone();
                     let req_cfg = req_cfg.clone();
                     let provider = provider.clone();
                     tokio::spawn(async move {
-                        send_request(
-                            &client,
-                            &router_url,
-                            api_key.as_deref(),
-                            &req_cfg,
-                            current_block,
-                            provider.as_deref(),
-                            i,
-                        )
-                        .await
+                        send_request(&endpoints, &req_cfg, current_block, provider.as_deref(), i)
+                            .await
                     })
                 })
                 .collect();
@@ -841,17 +906,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     }
 
+    // `submit` needs the RPC to send the rendered payload, the same way `verify` needs it to
+    // read the target's transition count.
     let needs_rpc = config
         .scenarios
         .iter()
         .flat_map(|s| s.requests.iter())
-        .any(|r| r.block_height == 0 || r.verify);
+        .any(|r| r.block_height == 0 || r.verify || r.submit);
 
     let provider: Option<Arc<ReadOnlyProvider>> = if needs_rpc {
-        let rpc = config
-            .http_rpc
-            .as_deref()
-            .ok_or("`http_rpc` is required when block_height = 0 or verify = true")?;
+        let rpc = config.http_rpc.as_deref().ok_or(
+            "`http_rpc` is required when block_height = 0, verify = true, or submit = true",
+        )?;
         Some(Arc::new(
             ProviderBuilder::new().connect_http(Url::parse(rpc)?),
         ))
@@ -876,19 +942,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if config.ingress_timeout_secs > 0 {
         client_builder = client_builder.timeout(Duration::from_secs(config.ingress_timeout_secs));
     }
-    let client = Arc::new(client_builder.build()?);
-    let router_url = Arc::new(config.router_url.clone());
-
     // The config field takes precedence; fall back to the environment so CI/automation can inject
     // a key without editing the scenario file.
-    let api_key = Arc::new(
-        config
-            .api_key
-            .clone()
-            .filter(|k| !k.is_empty())
-            .or_else(|| std::env::var("GAS_KILLER_API_KEY").ok())
-            .filter(|k| !k.is_empty()),
-    );
+    let api_key = config
+        .api_key
+        .clone()
+        .filter(|k| !k.is_empty())
+        .or_else(|| std::env::var("GAS_KILLER_API_KEY").ok())
+        .filter(|k| !k.is_empty());
 
     println!("Router: {}", config.router_url);
     println!(
@@ -900,18 +961,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     );
 
+    let endpoints = Endpoints {
+        client: Arc::new(client_builder.build()?),
+        router_url: Arc::new(config.router_url.clone()),
+        api_key: Arc::new(api_key),
+        http_rpc: Arc::new(config.http_rpc.clone()),
+    };
+
     let mut all_results: Vec<RequestResult> = Vec::new();
 
     for scenario in &config.scenarios {
-        let results = run_scenario(
-            client.clone(),
-            router_url.clone(),
-            api_key.clone(),
-            scenario,
-            current_block,
-            provider.clone(),
-        )
-        .await;
+        let results = run_scenario(&endpoints, scenario, current_block, provider.clone()).await;
         print_scenario_summary(&results);
         all_results.extend(results);
     }
@@ -942,6 +1002,51 @@ mod tests {
             parse_local_sentinel("local").as_deref(),
             Some("arraySummation")
         );
+    }
+
+    /// Existing scenario files predate `submit` and must keep their current behaviour: the
+    /// runner posts the task and never sends a transaction of its own.
+    #[test]
+    fn submit_defaults_to_false_when_absent() {
+        let config: Config = toml::from_str(
+            r#"
+            [[scenarios]]
+            name = "smoke"
+
+              [[scenarios.requests]]
+              target_address = "local"
+              call_data      = "0xdeadbeef"
+              from_address   = "local"
+            "#,
+        )
+        .unwrap();
+
+        let request = &config.scenarios[0].requests[0];
+        assert!(!request.submit);
+        assert!(!request.verify);
+        assert_eq!(request.verify_timeout_secs, 150);
+    }
+
+    #[test]
+    fn submit_is_read_from_the_config() {
+        let config: Config = toml::from_str(
+            r#"
+            [[scenarios]]
+            name = "generated"
+
+              [[scenarios.requests]]
+              target_address = "local:onchainLife"
+              call_data      = "0xdeadbeef"
+              from_address   = "local"
+              submit         = true
+              verify         = true
+            "#,
+        )
+        .unwrap();
+
+        let request = &config.scenarios[0].requests[0];
+        assert!(request.submit);
+        assert!(request.verify);
     }
 
     #[test]

--- a/scripts/send_request.rs
+++ b/scripts/send_request.rs
@@ -1,12 +1,12 @@
-use alloy::network::{EthereumWallet, TransactionBuilder};
 use alloy::primitives::{Address, U256, hex};
 use alloy::providers::{Provider, ProviderBuilder};
-use alloy::rpc::types::TransactionRequest;
-use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolCall;
 use bindings::arraysummation::ArraySummation::sumCall;
 use bindings::reentrantcheckpoint::ReentrantCheckpoint::advanceCall;
-use gas_killer_common::PayloadView;
+use bindings::task_payload::{
+    DEFAULT_READY_TIMEOUT_SECS, submit_payload, submitter_key, task_status_url,
+    wait_for_ready_payload,
+};
 use gas_killer_router::ingress::{GasKillerTaskRequest, GasKillerTaskRequestBody};
 use serde_json::json;
 use std::env;
@@ -212,8 +212,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 .map(str::to_string)
         })
         .ok_or("Accepted response did not carry a task_id")?;
-    let mut task_status_url = Url::parse(&url)?;
-    task_status_url.set_path(&format!("/tasks/{task_id}"));
+    let status_url = task_status_url(&url, &task_id)?;
     let api_key = env::var("GAS_KILLER_API_KEY")
         .ok()
         .filter(|k| !k.is_empty());
@@ -221,14 +220,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Poll until the task is `ready`, extract the rendered payload, submit it with a funded key,
     // then confirm the on-chain effect by checking `currentSum` moved.
     let http_rpc = env::var("HTTP_RPC")?;
-    // Prefer FUNDED_KEY (the Anvil dev account funded on the fork) so a hand-edited `.env` with a
-    // real-but-unfunded PRIVATE_KEY doesn't accidentally break local submission.
-    let submit_key = env::var("FUNDED_KEY")
-        .or_else(|_| env::var("PRIVATE_KEY"))
-        .map_err(|_| "FUNDED_KEY or PRIVATE_KEY required to submit the payload")?;
+    let submit_key = submitter_key()?;
 
-    let payload =
-        wait_for_ready_payload(&client, &task_status_url, api_key.as_deref(), &task_id).await?;
+    let payload = wait_for_ready_payload(
+        &client,
+        &status_url,
+        api_key.as_deref(),
+        &task_id,
+        DEFAULT_READY_TIMEOUT_SECS,
+    )
+    .await?;
 
     submit_payload(&payload, &http_rpc, &submit_key).await?;
 
@@ -245,153 +246,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!(
         "✅ SUCCESS: target progress changed {} → {} after the user-submitted verifyAndUpdate (task {})",
         initial_sum, final_sum, task_id
-    );
-    Ok(())
-}
-
-/// Polls `GET /tasks/{id}` until the task is `ready` and returns its rendered payload.
-///
-/// A `ready` response carries the transaction request the user submits as-is. A `failed`/`expired`
-/// settlement, or a non-success status (e.g. `409 PAYLOAD_EXPIRED` if the payload went stale before
-/// we submitted), is terminal and surfaces as an error.
-async fn wait_for_ready_payload(
-    client: &reqwest::Client,
-    task_status_url: &Url,
-    api_key: Option<&str>,
-    task_id: &str,
-) -> Result<PayloadView, Box<dyn std::error::Error + Send + Sync>> {
-    use tokio::time::{Duration, Instant, sleep};
-    let max_wait_time = Duration::from_secs(150);
-    let check_interval = Duration::from_secs(5);
-    let start_time = Instant::now();
-
-    loop {
-        let mut req = client.get(task_status_url.clone());
-        if let Some(api_key) = api_key {
-            req = req.header("Authorization", format!("Bearer {api_key}"));
-        }
-        let resp = req
-            .send()
-            .await
-            .map_err(|e| format!("Failed to poll task {}: {}", task_id, e))?;
-        let status_code = resp.status();
-        let body: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse task {} response: {}", task_id, e))?;
-
-        // A non-success status (e.g. 409 PAYLOAD_EXPIRED) carries an error envelope, not a task.
-        if !status_code.is_success() {
-            let code = body
-                .get("error")
-                .and_then(|e| e.get("code"))
-                .and_then(|c| c.as_str())
-                .unwrap_or("UNKNOWN");
-            return Err(
-                format!("Task {task_id} status query returned {status_code} ({code})").into(),
-            );
-        }
-
-        let task_status = body
-            .get("status")
-            .and_then(|s| s.as_str())
-            .unwrap_or("unknown")
-            .to_string();
-
-        println!(
-            "task {}: status={}, elapsed={:.1}s",
-            task_id,
-            task_status,
-            start_time.elapsed().as_secs_f64()
-        );
-
-        match task_status.as_str() {
-            "ready" => {
-                let payload_value = body
-                    .get("payload")
-                    .cloned()
-                    .ok_or_else(|| format!("ready task {task_id} carried no payload"))?;
-                let payload: PayloadView = serde_json::from_value(payload_value)
-                    .map_err(|e| format!("failed to parse task {task_id} payload: {e}"))?;
-                println!(
-                    "✅ task {} ready: to={:?} chain_id={} estimated_gas={} valid_until_block={}",
-                    task_id,
-                    payload.to,
-                    payload.chain_id,
-                    payload.estimated_gas,
-                    payload.valid_until_block
-                );
-                return Ok(payload);
-            }
-            "failed" | "expired" => {
-                let error = body
-                    .get("error")
-                    .and_then(|e| e.as_str())
-                    .unwrap_or("<no error recorded>");
-                return Err(
-                    format!("Task {} settled as '{}': {}", task_id, task_status, error).into(),
-                );
-            }
-            _ => {}
-        }
-
-        if start_time.elapsed() >= max_wait_time {
-            return Err(format!(
-                "Task {} did not reach 'ready' within {:.0}s (last status: {})",
-                task_id,
-                max_wait_time.as_secs_f64(),
-                task_status
-            )
-            .into());
-        }
-
-        sleep(check_interval).await;
-    }
-}
-
-/// Signs and submits a rendered payload with a funded key, mirroring what an integrator does, and
-/// asserts the `verifyAndUpdate` transaction lands successfully.
-async fn submit_payload(
-    payload: &PayloadView,
-    http_rpc: &str,
-    private_key: &str,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let signer: PrivateKeySigner = private_key
-        .parse()
-        .map_err(|_| "invalid FUNDED_KEY/PRIVATE_KEY format")?;
-    let sender = signer.address();
-    let provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(signer))
-        .connect_http(http_rpc.parse().map_err(|_| "invalid HTTP_RPC URL")?);
-
-    let tx = TransactionRequest::default()
-        .with_to(payload.to)
-        .with_value(payload.value)
-        .with_input(payload.data.clone());
-
-    println!(
-        "Submitting verifyAndUpdate as {sender} to {:?} ({} bytes calldata)",
-        payload.to,
-        payload.data.len()
-    );
-    let pending = provider
-        .send_transaction(tx)
-        .await
-        .map_err(|e| format!("failed to send verifyAndUpdate: {e}"))?;
-    let receipt = pending
-        .get_receipt()
-        .await
-        .map_err(|e| format!("failed to get verifyAndUpdate receipt: {e}"))?;
-    if !receipt.status() {
-        return Err(format!(
-            "verifyAndUpdate reverted (tx {:?}, block {:?})",
-            receipt.transaction_hash, receipt.block_number
-        )
-        .into());
-    }
-    println!(
-        "✅ verifyAndUpdate landed: tx {:?} in block {:?}",
-        receipt.transaction_hash, receipt.block_number
     );
     Ok(())
 }


### PR DESCRIPTION
## Why

`gas-killer/example-contracts` is meant to be a public library showing off Gas Killer use cases, but there was no way to get one of those contracts onto a chain and pointed at by the AVS without writing Rust. `deploy_array_summation` is hardcoded to a single target deployed through a pre-existing factory, and `scripts/bindings/` needs a compiled-in `sol!` module plus a vendored artifact per contract.

This adds a harness that fetches and builds the example contracts, deploys one wired to the AVS, records its address where the existing tooling already looks, and emits a runnable scenario — with no new Rust needed for the next example someone adds.

## What

- **`scripts/deploy_example.rs`** — manifest-driven deployer. Constructor argument *types* come from the Foundry artifact's ABI at runtime (`alloy-dyn-abi`) and *values* from TOML, so adding an example is a manifest edit. Deploys by appending encoded args to the creation bytecode, runs post-deploy assertions, executes setup calls as any declared signer, records `addresses.<name>`, and writes a scenario file.
- **`scripts/examples/`** — `fetch_examples.sh` (clone + recursive submodules + `forge build` at a pinned SHA), `examples.toml` (both examples), `run_example.sh` (fetch → deploy → run scenario).
- **`submit` in `run_scenario`** — see below. Defaults to `false`, so every existing scenario file behaves exactly as before.
- **`scripts/bindings/task_payload.rs`** — the poll/submit helpers, previously private to `send_request`, now shared by both bins.

Nothing existing changes behaviour: `deploy_array_summation`, `run_e2e_test.sh`, and the `array-summation`/`reentrant` CI matrix are untouched.

### The `submit` gap

With `INGRESS=true` the router *renders* a `verifyAndUpdate` transaction rather than broadcasting it, so nothing reaches the chain until the caller signs and sends it. `run_scenario` posted the task and then polled `stateTransitionCount()` — which no one was going to move, so `verify = true` could only ever time out. `submit = true` closes that loop.

### Why not reuse the examples repo's own forge scripts

`script/DeployBase.sol`'s `_resolveChecker()` deploys a **`MockBLSSignatureChecker`** when `SIG_CHECKER_ADDRESS` is unset, and `_avs()` defaults to `address(0xA75)` — against the real AVS that yields a target which accepts unsigned diffs. Separately, wiring a target to `addresses.blsSigCheck` (the `BLSSigCheckOperatorStateRetriever`) makes `verifyAndUpdate` revert with an empty `0x`. The deployer resolves the checker by an explicit precedence, rejects the retriever by name, and probes for `registryCoordinator()` before spending gas.

## Verified against a live local stack

`guardedVault` runs green end to end on an anvil Sepolia fork:

```
🚀 deployed at 0x32b9698f… (tx 0x5c6fd5a2…)
✅ supportsInterface(0x93de4531) = true, stateTransitionCount() = 0
⚙️  3 setup call(s): deposit(uint256) × signers 1, 2, 3
✅ task ready: estimated_gas=288363 valid_until_block=11425518
✅ verifyAndUpdate landed: tx 0xd22449bf… in block 11425470
stateTransitionCount: 1 (initial: 0)
━━━  Overall: 1/1 passed
```

On-chain post-state confirms a real, invariant-preserving transition: `totalShares` still 3000 (conservation held), shares 1000/1000/1000 → **1100/900/1000**, `isHealthy() = true`. The `Settled(uint256)` LOG1 event was replayed byte-exact by the diff under the default `STATE_ENCODING=legacy`.

Also green: `cargo fmt`, `clippy --all-targets --all-features -D warnings`, `cargo test` (291 tests, 41 new).

## `onchainLife` requires the `prestate-net` encoding

`onchainLife` deploys and passes the routability gate under any encoding, but only **settles** under `STATE_ENCODING=prestate-net`.

`legacy` and `canonical` derive the diff from a struct-log `debug_traceCall`, costing `O(execution steps)`, and one generation of Life is ~16.5M gas (measured: 16,552,726). On a stock anvil that trace drives the process from 8 MB to 2.2 GB of RSS in 20s and still has not returned; inside the 3.82 GiB compose container it is OOM-killed outright (`exit 137`), so the task never reaches `ready`:

```
ERROR gas_killer_router::sequencer: failed to enrich task, dropping request
  error=Gas analysis failed: debug_trace_call failed: error sending request
```

`generations` is already at its floor of 1, so no manifest setting avoids this — the limit is the encoder. Under `prestate-net` the same call returns in **0s with a 3-slot diff**, and `callTracer` shows no target-depth frames, so it takes the net form rather than the canonical fallback.

That encoding landed in #348 (merged, `51a61f2`), so it is available on `main` and this branch is rebased onto it. Note the value is fail-closed by design: `parse_state_encoding` panics on anything unrecognized rather than falling back, so a typo cannot put an operator into a running-but-digest-divergent state.

**Verified end to end** on a rebuilt local stack with all four binaries on `prestate-net`: `generation()` 0 → 1, `stateTransitionCount()` 0 → 1, `boardHash()` changed, the `GenerationStepped` LOG2 event replayed by the diff, and anvil memory flat at ~30 MiB throughout (see the verification comment below). `run_example.sh` warns when `onchainLife` is run under any other encoding, and the manifest entry is kept so the case stays one command:

```bash
STATE_ENCODING=prestate-net docker compose up -d --force-recreate
./scripts/examples/run_example.sh onchainLife
```

<sub>An earlier version of this description claimed gas-analyzer#163 needed "no public API change / zero code changes" on the service side. That came from #163's own body, which is stale: a commit inside that PR (`60ab3f44`) deliberately turned the implicit fast path into the opt-in `StateEncoding::PrestateNet` variant and removed the graceful fallback. Corrected above.</sub>

## Follow-up

`router/Cargo.toml` and `scripts/Cargo.toml` both declare `gas-analyzer` but never use it; `common` is the only real consumer. Unrelated cleanup.


