### PR TITLE
feat: adopt the prestate-net state encoding from gas-analyzer

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,6 +30,10 @@ jobs:
         #   - the aggregate-Schnorr path under the CANONICAL encoding settling a task that
         #     makes a re-entrant external call mid-transition — a green run proves
         #     re-entrancy settles safely end-to-end.
+        #   - the BLS path under the PRESTATE-NET encoding, which signs the target's net
+        #     storage diff read from prestateTracer/callTracer rather than a struct-log
+        #     trace. `ArraySummation.sum` makes no external call at target depth, so this
+        #     leg exercises the net form itself rather than its canonical fallback.
         include:
           - signature_scheme: bls
             state_encoding: legacy
@@ -40,6 +44,9 @@ jobs:
           - signature_scheme: schnorr
             state_encoding: canonical
             e2e_example: reentrant
+          - signature_scheme: bls
+            state_encoding: prestate-net
+            e2e_example: array-summation
 
     steps:
       - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,7 +4015,7 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 [[package]]
 name = "gas-analyzer-core"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#24051bce1251b890f0f2f4f0141026bfb52aca59"
+source = "git+https://github.com/gas-killer/gas-analyzer#964eb229cabb7c3d933b58ab2bf4f82c9be027cd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-estimator"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#24051bce1251b890f0f2f4f0141026bfb52aca59"
+source = "git+https://github.com/gas-killer/gas-analyzer#964eb229cabb7c3d933b58ab2bf4f82c9be027cd"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-evmsketch"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#24051bce1251b890f0f2f4f0141026bfb52aca59"
+source = "git+https://github.com/gas-killer/gas-analyzer#964eb229cabb7c3d933b58ab2bf4f82c9be027cd"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "gas-analyzer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/gas-killer/gas-analyzer#24051bce1251b890f0f2f4f0141026bfb52aca59"
+source = "git+https://github.com/gas-killer/gas-analyzer#964eb229cabb7c3d933b58ab2bf4f82c9be027cd"
 dependencies = [
  "alloy",
  "alloy-eips",

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -397,15 +397,27 @@ fn parse_signature_scheme(value: Option<&str>) -> SignatureScheme {
 }
 
 /// Reads the storage-update encoding from `STATE_ENCODING` (case-insensitive
-/// `legacy` | `canonical`), defaulting to [`StateEncoding::Legacy`].
+/// `legacy` | `canonical` | `prestate-net`), defaulting to [`StateEncoding::Legacy`].
 ///
 /// `canonical` emits canonical state slices before every external call and a
 /// final re-assertion slice, so a re-entrant call into a Gas Killer target
 /// observes the storage native execution would have had (see
-/// `gas_analyzer::compute_state_updates_canonical`). **Node and router must run
-/// the same value** — the encoding changes `storage_updates`, hence the task
-/// digest — so this is read from one env var threaded to both binaries.
-/// Panics on an unrecognized value rather than silently diverging digests.
+/// `gas_analyzer::compute_state_updates_canonical`).
+///
+/// `prestate-net` signs the target's *net* storage diff — one slot-sorted store per
+/// changed slot plus its logs — read from the `prestateTracer`/`callTracer` pair
+/// instead of a struct-log trace. It costs `O(changed slots)` rather than
+/// `O(execution steps)`, which is what makes heavy-compute tracked functions
+/// extractable at all: their struct-log trace is large enough to time out or exhaust
+/// the node. Calls the net form cannot represent (an external `CALL`, `CREATE`, or
+/// `SELFDESTRUCT` at target depth) fall back to the *canonical* encoder, and a node
+/// whose RPC lacks either tracer fails the task rather than quietly downgrading —
+/// see [`gas_analyzer::StateEncoding::PrestateNet`].
+///
+/// **Node and router must run the same value** — the encoding changes
+/// `storage_updates`, hence the task digest — so this is read from one env var
+/// threaded to both binaries. Panics on an unrecognized value rather than silently
+/// diverging digests.
 pub fn state_encoding() -> gas_analyzer::StateEncoding {
     parse_state_encoding(env::var("STATE_ENCODING").ok().as_deref())
 }
@@ -413,11 +425,18 @@ pub fn state_encoding() -> gas_analyzer::StateEncoding {
 /// Parses the `STATE_ENCODING` value (case-insensitive, trimmed). `None` / empty →
 /// `Legacy`. Panics on an unrecognized value rather than silently diverging the
 /// node's and router's digests.
+///
+/// Each encoding has exactly one accepted spelling. Alternates would let two
+/// operators believe they are configured identically while signing different bytes,
+/// which is the failure this panic exists to prevent.
 fn parse_state_encoding(raw: Option<&str>) -> gas_analyzer::StateEncoding {
     match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
         None | Some("") | Some("legacy") => gas_analyzer::StateEncoding::Legacy,
         Some("canonical") => gas_analyzer::StateEncoding::Canonical,
-        Some(other) => panic!("STATE_ENCODING must be 'legacy' or 'canonical', got '{other}'"),
+        Some("prestate-net") => gas_analyzer::StateEncoding::PrestateNet,
+        Some(other) => {
+            panic!("STATE_ENCODING must be 'legacy', 'canonical', or 'prestate-net', got '{other}'")
+        }
     }
 }
 
@@ -765,12 +784,29 @@ mod tests {
             parse_state_encoding(Some("Canonical")),
             StateEncoding::Canonical
         );
+        assert_eq!(
+            parse_state_encoding(Some("prestate-net")),
+            StateEncoding::PrestateNet
+        );
+        assert_eq!(
+            parse_state_encoding(Some(" Prestate-Net ")),
+            StateEncoding::PrestateNet
+        );
     }
 
     #[test]
     #[should_panic(expected = "STATE_ENCODING must be")]
     fn state_encoding_rejects_unknown() {
         let _ = parse_state_encoding(Some("bogus"));
+    }
+
+    /// Each encoding has one spelling. A near-miss must panic rather than resolve, so an
+    /// operator who mistypes the value cannot end up signing a different representation
+    /// from the rest of the fleet.
+    #[test]
+    #[should_panic(expected = "STATE_ENCODING must be")]
+    fn state_encoding_rejects_a_near_miss_spelling() {
+        let _ = parse_state_encoding(Some("prestate_net"));
     }
 
     #[test]

--- a/example.env
+++ b/example.env
@@ -143,10 +143,12 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 # retry attempt. Schnorr mode only.
 # P2P_SCHNORR_MESSAGES_PER_SECOND=64
 
-# STATE_ENCODING: legacy (default) or canonical. How the off-chain executor lays
-# out a task's storage mutations in the update program applied on-chain. Must be
-# identical on every node AND the router — it changes `storage_updates`, hence the
-# task digest, so a mismatch makes every signature fail to verify.
+# STATE_ENCODING: legacy (default), canonical, or prestate-net. How the off-chain
+# executor lays out a task's storage mutations in the update program applied
+# on-chain. Must be identical on every node AND the router — it changes
+# `storage_updates`, hence the task digest, so a mismatch makes every signature fail
+# to verify. Roll changes out atomically; a rolling update that transiently mixes
+# encodings fails quorum until it converges.
 #   legacy    — raw depth-1 SSTOREs in trace order; nested writes replay natively
 #               inside their emitted CALL. No guarantee about the storage an
 #               external (re-entrant) call observes mid-program.
@@ -156,6 +158,25 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 #               plus a final slice re-asserting the canonical end state. Same
 #               on-chain primitives (StateChangeHandlerLib), no contract change.
 #               Enable for targets whose tasks make re-entrant external calls.
+#   prestate-net — the target's NET storage diff: one slot-sorted store per changed
+#               slot, plus its logs, read from the prestateTracer/callTracer pair
+#               rather than a struct-log trace. Costs O(changed slots) instead of
+#               O(execution steps), which is what makes heavy-compute tracked
+#               functions extractable at all — their struct-log trace is large enough
+#               to time out or exhaust the node. Repeated writes to one slot collapse
+#               to a single store and a slot written back to its original value
+#               produces none, so it is deliberately byte-different from the other
+#               two for the same call. Calls it cannot represent (an external CALL,
+#               CREATE, or SELFDESTRUCT at target depth) fall back to the CANONICAL
+#               encoder, not legacy.
+#
+#               REQUIRES every node's and the router's RPC to support debug_traceCall
+#               with prestateTracer (diffMode) and callTracer (withLog). A node whose
+#               RPC lacks either FAILS THE TASK rather than quietly downgrading —
+#               silently switching representation would sign a digest no other
+#               operator can match, turning a node-config difference into a consensus
+#               split. Anvil supports both; hosted providers often gate prestateTracer
+#               to paid tiers, so confirm before enabling off a local fork.
 # STATE_ENCODING=legacy
 
 # =============================================================================

--- a/example.env
+++ b/example.env
@@ -177,6 +177,23 @@ FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
 #               operator can match, turning a node-config difference into a consensus
 #               split. Anvil supports both; hosted providers often gate prestateTracer
 #               to paid tiers, so confirm before enabling off a local fork.
+#
+#               Tracer support is necessary but NOT sufficient on a mixed fleet: the
+#               clients must also agree on tracer OUTPUT. Log ordering is taken from
+#               callTracer's global `index` when every log carries one and from
+#               `position` otherwise, and `index` is not universally populated (geth
+#               populates `position`). Two operators on different clients can both
+#               support the tracers and still order logs differently — same end state,
+#               different bytes, forked digest. Until gas-analyzer#178 settles on one
+#               source and fails closed when it is absent, treat prestate-net as
+#               proven only on a single-client fleet (the all-anvil local stack), not
+#               a heterogeneous geth/reth/hosted deployment.
+#
+#               Observability: the extraction path is recorded as an `extraction`
+#               field (prestate_net | struct_log) on the evmsketch.encode tracing
+#               span, so a fleet split across representations is detectable. It is a
+#               span field rather than an event, so it needs span logging enabled to
+#               surface — it will not appear at plain RUST_LOG=info.
 # STATE_ENCODING=legacy
 
 # =============================================================================

--- a/helm/gas-killer/templates/node-deployment.yaml
+++ b/helm/gas-killer/templates/node-deployment.yaml
@@ -255,6 +255,10 @@ spec:
             # Quorum signature scheme (bls | schnorr); must match the router's.
             - name: SIGNATURE_SCHEME
               value: {{ default "bls" $root.Values.global.signatureScheme | quote }}
+            # Storage-update encoding (legacy | canonical | prestate-net); must match
+            # the router's — it changes the task digest.
+            - name: STATE_ENCODING
+              value: {{ default "legacy" $root.Values.global.stateEncoding | quote }}
           ports:
             - name: node
               containerPort: {{ $nodePort }}

--- a/helm/gas-killer/templates/router-deployment.yaml
+++ b/helm/gas-killer/templates/router-deployment.yaml
@@ -360,6 +360,10 @@ spec:
             # Quorum signature scheme (bls | schnorr); must match the nodes'.
             - name: SIGNATURE_SCHEME
               value: {{ default "bls" .Values.global.signatureScheme | quote }}
+            # Storage-update encoding (legacy | canonical | prestate-net); must match
+            # the nodes' — it changes the task digest.
+            - name: STATE_ENCODING
+              value: {{ default "legacy" .Values.global.stateEncoding | quote }}
             - name: PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -38,6 +38,13 @@ global:
   # debug_traceCall with prestateTracer (diffMode) and callTracer (withLog), and fails
   # the task rather than downgrading if they are missing. Hosted providers often gate
   # prestateTracer to paid tiers — confirm before enabling.
+  #
+  # Support alone is not enough on a mixed fleet: the clients must also agree on
+  # tracer OUTPUT. callTracer log ordering depends on whether the client populates the
+  # global `index` (geth populates `position` instead), so two operators on different
+  # clients can order logs differently and fork the digest while both "supporting" the
+  # tracers. Until gas-analyzer#178 settles on one source, only enable this on a
+  # single-client fleet. See the STATE_ENCODING block in example.env.
   stateEncoding: "legacy"
 
   # Number of operator nodes to deploy

--- a/helm/gas-killer/values.yaml
+++ b/helm/gas-killer/values.yaml
@@ -26,6 +26,20 @@ global:
   # this "bls" for TESTNET/secretManager deployments (which restore only BLS keys).
   signatureScheme: "bls"
 
+  # Storage-update encoding: "legacy" (default), "canonical", or "prestate-net".
+  # Selects the signed representation of a task's storage mutations, so like
+  # signatureScheme every binary in the deployment must agree — it changes the task
+  # digest, and a rolling update that transiently mixes encodings fails quorum until
+  # it converges. Prefer recreating nodes and router together when changing it.
+  #
+  # "prestate-net" reads the target's net diff from prestateTracer/callTracer instead
+  # of a struct-log trace, which is what makes heavy-compute tracked functions
+  # extractable; it REQUIRES every node's and the router's RPC to support
+  # debug_traceCall with prestateTracer (diffMode) and callTracer (withLog), and fails
+  # the task rather than downgrading if they are missing. Hosted providers often gate
+  # prestateTracer to paid tiers — confirm before enabling.
+  stateEncoding: "legacy"
+
   # Number of operator nodes to deploy
   nodeCount: 3
 


### PR DESCRIPTION
## Why

`onchainLife` — the Conway's Life example from #347 — deploys and passes the router's routability gate, but its task never renders. One generation is ~16.9M gas, and the struct-log extractor's `debug_traceCall` produced a trace large enough to **OOM-kill the anvil container** (`exit 137`, `oomkilled=true`):

```
ERROR gas_killer_router::sequencer: failed to enrich task, dropping request
  error=Gas analysis failed: debug_trace_call failed: error sending request
```

gas-killer/gas-analyzer#163 + #165 have merged and address exactly this: a net-diff extraction read from `prestateTracer` + `callTracer` costing `O(changed slots)` instead of `O(execution steps)`.

## Heads-up: #163's description is stale

Its body says "no public API change… the service picks this up on a dependency bump with zero code changes." That was true early on the branch and was **deliberately reversed before merge** by `60ab3f44` ("make the prestate net diff an explicit StateEncoding rather than an implicit fast path"); the body was never updated. The merged design:

- `StateEncoding::PrestateNet` is a **third, opt-in variant**, not an automatic fast path.
- Under `Legacy`/`Canonical` the prestate branch is never entered — same single `debug_traceCall`, same bytes. **The bump alone is behaviour-neutral.**
- A tracer failure under `PrestateNet` is a **hard error, never a quiet downgrade**. An operator whose node lacks the tracers would otherwise sign a digest no one else can match, turning a node-config difference into a consensus split.
- The service's `parse_state_encoding` **panics** on unrecognized values, so it had to learn the variant before the option was reachable at all.

(I repeated the stale claim in #347's description; that needs correcting too.)

## What this does

Adds the capability, leaves the default alone.

| | Eligible call | Ineligible call | Node lacks tracers |
|---|---|---|---|
| `legacy` (default) | struct-log, depth-1 SSTOREs | same | n/a |
| `canonical` | struct-log, checkpointed | same | n/a |
| `prestate-net` **(new)** | net form: one slot-sorted store per changed slot + logs | falls back to **canonical**, not legacy | **hard error** |

- **`Cargo.lock`** — `cargo update -p gas-analyzer-evmsketch`, `24051bce → 964eb229`. Exactly the four sibling-package `source =` lines and nothing else; `Cargo.toml` untouched, matching the established playbook (`d6782385`, `bc387a0` — a `rev =` pin has never been used here). 22 commits / 12 files ride along: #163 and #165 (library) plus #179/#180 (CI lint matrix, toolchain pin). No new dependencies, no declared MSRV, unchanged signatures and error type.
- **`common/src/config.rs`** — the `prestate-net` arm, updated docs, and tests. One accepted spelling per encoding: alternates would let two operators believe they are configured identically while signing different bytes, so `prestate_net` is rejected rather than resolved.
- **`example.env`** — a third bullet covering the net form, the canonical fallback, and the tracer requirement.
- **Helm** — `global.stateEncoding` (default `"legacy"`) threaded into the node and router deployments. It was previously unset chart-side, so clusters silently got legacy with no way to opt in. Render-verified for both default and override.
- **e2e matrix** — a fourth leg. `ArraySummation.sum` makes no external call at target depth, so it exercises the net form itself rather than its canonical fallback.

Deliberately **not** changed: `Cargo.toml`, `common/src/validator.rs` (its single call site passes `self.state_encoding` straight through), `docker-compose.yml` and `scripts/run_e2e_test.sh` (both already thread the value).

## Consensus note

`StateEncoding` selects the *signed representation*, not just how it is obtained — the encoded updates are hashed into the task digest. It must be uniform fleet-wide and rolled out atomically; a rolling update that transiently mixes encodings fails quorum until it converges. `legacy → prestate-net` changes digests for essentially every call, which is exactly why the default stays `legacy` here.

Enabling it anywhere beyond a local fork also requires every node's **and** the router's RPC to support `debug_traceCall` with `prestateTracer` (diffMode) and `callTracer` (withLog). Anvil supports both; hosted providers often gate `prestateTracer` to paid tiers.

## Testing

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, `cargo check`, `cargo test` all green (253 tests). Helm templates rendered for both the default and the override.

**Draft** until the new `prestate-net` e2e leg goes green — the encoding's live behaviour is unproven until then. Local end-to-end verification was blocked by a full disk / wedged Docker on my machine, so CI is the first real exercise of the path.

## Follow-ups

- Correct #347's description and, once this lands, rebase it and rewrite its "Known limitation" section: `onchainLife` works under `STATE_ENCODING=prestate-net`, not automatically.
- `router/Cargo.toml` and `scripts/Cargo.toml` both declare `gas-analyzer` but never use it; `common` is the only real consumer. Unrelated cleanup.
